### PR TITLE
manage returning errors instead throwing them

### DIFF
--- a/packages/http/src/mionHttp.ts
+++ b/packages/http/src/mionHttp.ts
@@ -19,7 +19,7 @@ import {DEFAULT_HTTP_OPTIONS} from './constants';
 import type {HttpOptions, HttpRawServerContext} from './types';
 import type {IncomingMessage, RequestListener, Server as HttpServer, ServerResponse} from 'http';
 import type {Server as HttpsServer} from 'https';
-import type {Obj, Headers, RawRequest, PublicError, RouterOptions, SharedDataFactory} from '@mionkit/router';
+import type {Obj, Headers, RawRequest, RouterOptions, SharedDataFactory} from '@mionkit/router';
 import {error} from 'console';
 
 type Logger = typeof console | undefined;

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -207,13 +207,13 @@ const invalidRoutes = {
 export const myInvalidApi = registerRoutes(invalidRoutes); // throws an error
 ```
 
-## `Handling errors`
+## `Handling Errors`
 
-All errors thrown within Routes/Hooks will be catch and handled, as there is no concept of logger within the router errors are not automatically logged.
+All errors thrown within Routes/Hooks will be catch and handled. As there is no concept of logger within the router errors are not automatically logged instead they are added to the `context.request.internalErrors` to be managed by the application logger.
 
-For every error thrown within the Routes/Hook Two types of errors are generated, Public errors are returned in the `response.publicErrors` & and private error stored in the `context.request.internalErrors` to be managed by any logger hook or similar. The public errors should only contains generic message and a status code, the private errors contains also stack trace and the rest of properties of any js Error.
+For every error thrown within the Routes/Hook Two types of errors are generated: Public errors stored in the `response.publicErrors` & and private error stored in the `context.request.internalErrors` to be managed by the application logger. The public errors should only contain a generic message and a status code as this information is sent back to the client, while private errors contains the stack trace and the rest of properties of any js Error.
 
-Throwing a `RouteError` generates a public error otherwise a generic public 500 error is generated.
+If `RouterOptions.autoGenerateErrorId` is set to true an error id will be automatically generated and both public and private error will share the same id so errors can be traced properly.
 
 ```ts
 // examples/error-handling.routes.ts
@@ -240,7 +240,7 @@ export const getPet = (app, ctx, id: string): Promise<Pet> => {
      * Full RouteError containing dbError message and stacktrace will be added
      * to ctx.request.internalErrors, so it can be logged or managed after
      */
-    throw new RouteError({statusCode, publicMessage, originalError: dbError as Error});
+    return new RouteError({statusCode, publicMessage, originalError: dbError as Error});
   }
 };
 

--- a/packages/router/src/errors.ts
+++ b/packages/router/src/errors.ts
@@ -8,7 +8,39 @@
 import {randomUUID} from 'crypto';
 import {getRouterOptions} from './router';
 import {statusCodeToReasonPhrase} from './status-codes';
-import {Obj, RouteErrorParams} from './types';
+import {Obj} from './types';
+
+// #######  Errors #######
+
+// TODO: the interface for Public Errors is a bit confusing, maybe this should be called PublicError, review the way params are passed etc.
+/** Any error triggered by hooks or routes must follow this interface, returned errors in the body also follows this interface */
+export type RouteErrorParams = {
+    /** id of the error. */
+    id?: number | string;
+    /** response status code */
+    statusCode: Readonly<number>;
+    /** the message that will be returned in the response */
+    publicMessage: Readonly<string>;
+    /**
+     * the error message, it is private and wont be returned in the response.
+     * If not defined, it is assigned from originalError.message or publicMessage.
+     */
+    message?: Readonly<string>;
+    /** options data related to the error, ie validation data */
+    publicData?: Readonly<unknown>;
+    /** original error used to create the RouteError */
+    originalError?: Readonly<Error>;
+    /** name of the error, if not defined it is assigned from status code */
+    name?: Readonly<string>;
+};
+
+export type PublicError = {
+    id?: number | string;
+    name: Readonly<string>;
+    statusCode: Readonly<number>;
+    message: Readonly<string>;
+    errorData?: Readonly<unknown>;
+};
 
 export class RouteError extends Error {
     /** id of the error, if RouterOptions.autoGenerateErrorId is set to true and id with timestamp+uuid will be generated */

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -51,18 +51,6 @@ let routerOptions: RouterOptions = {
 
 // ############# PUBLIC METHODS #############
 
-export const registerRoutes = <R extends Routes>(routes: R): PublicMethods<R> => {
-    if (!app) throw new Error('Router has not been initialized yet');
-    recursiveFlatRoutes(routes);
-    // we only want to get information about the routes when creating api spec
-    if (routerOptions.getPublicRoutesData || process.env.GENERATE_ROUTER_SPEC === 'true') {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const {getPublicRoutes} = require('./publicMethods');
-        return getPublicRoutes(routes) as PublicMethods<R>;
-    }
-
-    return {} as PublicMethods<R>;
-};
 export const getRouteExecutionPath = (path: string) => flatRouter.get(path);
 export const getRouteEntries = () => flatRouter.entries();
 export const geRoutesSize = () => flatRouter.size;
@@ -113,6 +101,19 @@ export const initRouter = async <App extends Obj, SharedData, RawContext extends
     app = application;
     sharedDataFactory = sharedDataFactoryFunction;
     setRouterOptions(routerOpts);
+};
+
+export const registerRoutes = <R extends Routes>(routes: R): PublicMethods<R> => {
+    if (!app) throw new Error('Router has not been initialized yet');
+    recursiveFlatRoutes(routes);
+    // we only want to get information about the routes when creating api spec
+    if (routerOptions.getPublicRoutesData || process.env.GENERATE_ROUTER_SPEC === 'true') {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const {getPublicRoutes} = require('./publicMethods');
+        return getPublicRoutes(routes) as PublicMethods<R>;
+    }
+
+    return {} as PublicMethods<R>;
 };
 
 export const getRoutePathFromPointer = (route: Route, pointer: string[]) => getRoutePath(route, join(...pointer));

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -6,7 +6,7 @@
  * ######## */
 
 import {ReflectionOptions, FunctionReflection, SerializedTypes} from '@mionkit/runtype';
-import {RouteError} from './errors';
+import {PublicError, RouteError} from './errors';
 
 // #######  Routes #######
 
@@ -190,38 +190,6 @@ export type Headers = {[key: string]: string | boolean | number};
 /** Function used to create the shared data object on each route call  */
 export type SharedDataFactory<SharedData> = () => SharedData;
 
-// #######  Errors #######
-
-// TODO: the interface for Public Errors is a bit confusing, maybe this should be called PublicError, review the way params are passed etc.
-/** Any error triggered by hooks or routes must follow this interface, returned errors in the body also follows this interface */
-export type RouteErrorParams = {
-    /** id of the error. */
-    id?: number | string;
-    /** response status code */
-    statusCode: Readonly<number>;
-    /** the message that will be returned in the response */
-    publicMessage: Readonly<string>;
-    /**
-     * the error message, it is private and wont be returned in the response.
-     * If not defined, it is assigned from originalError.message or publicMessage.
-     */
-    message?: Readonly<string>;
-    /** options data related to the error, ie validation data */
-    publicData?: Readonly<unknown>;
-    /** original error used to create the RouteError */
-    originalError?: Readonly<Error>;
-    /** name of the error, if not defined it is assigned from status code */
-    name?: Readonly<string>;
-};
-
-export type PublicError = {
-    id?: number | string;
-    name: Readonly<string>;
-    statusCode: Readonly<number>;
-    message: Readonly<string>;
-    errorData?: Readonly<unknown>;
-};
-
 // ####### Public Facing Types #######
 
 //TODO: some hooks could have no public params and not return any data so they should not be in the public spec
@@ -238,6 +206,7 @@ export type PublicMethods<Type extends Routes> = {
         : never;
 };
 
+/** Handler type in the client's side */
 export type PublicHandler<H extends Handler> = H extends (app: any, ctx: Context<any, any>, ...rest: infer Req) => infer Resp
     ? (...rest: Req) => Promise<Awaited<Resp>>
     : never;


### PR DESCRIPTION
Partial work on  #36.

Thi PR adds support for returning errors instead throwing them. but returned errors are still generic.

To add typesafe errors The error code and name should be at least generic.

Maybe we could create a new `ApplicationError<StatusCode, Name>` and infer the status code and name from the types when creating the error using reflection. 

Also if we add the error to the return type, then on the  client we will need to create a type map to remove the errors from the return type and throw them so they are handled by the client in the cath method.

Server:
```ts
export const addTwo= (value:any): number | ApplicationError<400, 'Not A Number'> => {
    if (isNan(value)) {
        throw new ApplicationError<400, 'Not A Number'>('value is not a number');
    }
    return value + 2;
};
``` 

Client:
```ts
type AddTwo = typeof addTwo;
type Success = AnythinButErrors<AddTwo>; // type = number
type Fail = OnlyErrors<AddTwo>; // type = ApplicationError<400, 'Not A Number'>

   response
   .then((sum: Success) => {
        // ... do anything
    })
   .catch((err: Fail) => {
        // ... do anything
   });
``` 


This las thing of types Promise error is unknown in typescript, so maybe is a good selling point for the client.

**All this is quite a bit of rewort so maybe prioritise for later.**