### PR TITLE
#19 mion client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -13174,6 +13174,7 @@
         "@mionkit/runtype": "^0.4.2"
       },
       "devDependencies": {
+        "@mionkit/http": "^0.4.2",
         "@mionkit/router": "^0.4.2"
       }
     },
@@ -14394,6 +14395,7 @@
       "requires": {
         "@deepkit/type": "^1.0.1-alpha.97",
         "@mionkit/core": "^0.4.2",
+        "@mionkit/http": "^0.4.2",
         "@mionkit/router": "^0.4.2",
         "@mionkit/runtype": "^0.4.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13206,6 +13206,7 @@
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
+        "@mionkit/core": "^0.4.2",
         "@mionkit/router": "^0.4.2"
       }
     },
@@ -13237,7 +13238,8 @@
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@deepkit/type": "^1.0.1-alpha.97"
+        "@deepkit/type": "1.0.1-alpha.97",
+        "@mionkit/core": "0.4.2"
       }
     },
     "packages/serverless": {
@@ -14430,6 +14432,7 @@
     "@mionkit/common": {
       "version": "file:packages/common",
       "requires": {
+        "@mionkit/core": "^0.4.2",
         "@mionkit/router": "^0.4.2"
       }
     },
@@ -14453,7 +14456,8 @@
     "@mionkit/runtype": {
       "version": "file:packages/runtype",
       "requires": {
-        "@deepkit/type": "^1.0.1-alpha.97"
+        "@deepkit/type": "1.0.1-alpha.97",
+        "@mionkit/core": "0.4.2"
       }
     },
     "@mionkit/serverless": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "workspaces": [
         "packages/core",
+        "packages/common",
         "packages/runtype",
         "packages/router",
         "packages/http",
@@ -1749,6 +1750,10 @@
     },
     "node_modules/@mionkit/codegen": {
       "resolved": "packages/codegen",
+      "link": true
+    },
+    "node_modules/@mionkit/common": {
+      "resolved": "packages/common",
       "link": true
     },
     "node_modules/@mionkit/core": {
@@ -13196,6 +13201,14 @@
         "module-from-string": "^3.3.0"
       }
     },
+    "packages/common": {
+      "name": "@mionkit/common",
+      "version": "0.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "@mionkit/router": "^0.4.2"
+      }
+    },
     "packages/core": {
       "name": "@mionkit/core",
       "version": "0.4.2",
@@ -14412,6 +14425,12 @@
         "module-from-string": "^3.3.0",
         "prettier": "^2.7.1",
         "ts-morph": "^17.0.1"
+      }
+    },
+    "@mionkit/common": {
+      "version": "file:packages/common",
+      "requires": {
+        "@mionkit/router": "^0.4.2"
       }
     },
     "@mionkit/core": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "https://github.com/MionKit/issues"
   },
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.0.0"
   },
   "devDependencies": {
     "@deepkit/core": "^1.0.1-alpha.97",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "workspaces": [
     "packages/core",
+    "packages/common",
     "packages/runtype",
     "packages/router",
     "packages/http",

--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -5,5 +5,8 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-export * from './src/client';
 export * from './src/types';
+export * from './src/constants';
+export * from './src/reflection';
+export * from './src/request';
+export * from './src/client';

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -62,6 +62,7 @@
   },
   "gitHead": "2efdcd77c572e64f2b9621b4921ffd2f5e83bc0a",
   "devDependencies": {
+    "@mionkit/http": "^0.4.2",
     "@mionkit/router": "^0.4.2"
   }
 }

--- a/packages/client/src/client.spec.ts
+++ b/packages/client/src/client.spec.ts
@@ -7,7 +7,7 @@
 
 import {RemoteMethods, Routes, registerRoutes} from '@mionkit/router';
 import {initMionClient} from './client';
-import {HookRequest, RemoteCallResponse, RouteRequest} from './types';
+import {HookRequest, RouteRequest} from './types';
 import {initHttpRouter, startHttpServer} from '@mionkit/http';
 import {Server} from 'http';
 
@@ -94,13 +94,13 @@ describe('client', () => {
         expect((methods as any).abcd(1, 'a')).toEqual(expectedUntyped);
     });
 
-    it.skip('fetch a route', async () => {
+    it('fetch a route', async () => {
         // TODO: implement the get public method info route in the router
         const {client, methods} = initMionClient<MyApi>({baseURL: 'http://localhost:3000'});
 
         const response = await methods.sayHello(someUser).call(methods.auth('token'));
 
-        expect(response).toBeDefined();
+        expect(response).toEqual(`Hello John Doe`);
     });
 
     it('fail if a remote call fails', () => {});

--- a/packages/client/src/client.spec.ts
+++ b/packages/client/src/client.spec.ts
@@ -5,33 +5,103 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {ClientMethods} from '..';
-import {initClient} from './client';
-import {RemoteMethods, Routes, initRouter, registerRoutes} from '@mionkit/router';
+import {RemoteMethods, Routes, registerRoutes} from '@mionkit/router';
+import {initMionClient} from './client';
+import {HookRequest, RemoteCallResponse, RouteRequest} from './types';
+import {initHttpRouter, startHttpServer} from '@mionkit/http';
+import {Server} from 'http';
 
 // TODO: test & write client
-describe('client should', () => {
+describe('client', () => {
     type User = {name: string; surname: string};
 
     const routes = {
-        auth: {hook: (ctx, token: string): User => ({name: 'John', surname: 'Doe'})},
+        auth: {
+            headerName: 'Authorization',
+            canReturnData: true,
+            headerHook: (ctx, token: string): User => ({name: 'John', surname: 'Doe'}),
+        },
         sayHello: {route: (ctx, user: User): string => `Hello ${user.name} ${user.surname}`},
+        utils: {
+            sumTwo: (ctx, a: number): number => a + 2,
+        },
         log: {hook: (ctx): void => console.log('ending')},
     } satisfies Routes;
 
-    type MyRoutes = typeof routes;
-    type MyApi = RemoteMethods<MyRoutes>;
-    type Auth = MyApi['auth']['_handler'];
-    type SayHello = MyApi['sayHello']['_handler'];
+    const someUser = {name: 'John', surname: 'Doe'};
+    let myApi: RemoteMethods<typeof routes>;
+    type MyApi = typeof myApi;
 
-    type CLientAPi = ClientMethods<MyApi>;
-    type ClientAuth = CLientAPi['auth'];
-    type ClientSayHello = CLientAPi['sayHello'];
-    type Next = ReturnType<ClientSayHello>;
+    const port = 8076;
+    let server: Server;
+    beforeAll(async () => {
+        initHttpRouter({sharedDataFactory: () => {}, port});
+        myApi = registerRoutes(routes);
+        server = await startHttpServer();
+    });
 
-    it('proxy should capture calls', () => {});
+    afterAll(
+        async () =>
+            new Promise<void>((resolve, reject) => {
+                server.close((err) => {
+                    if (err) reject();
+                    else resolve();
+                });
+            })
+    );
 
-    it('make a remote call', () => {});
+    it('proxy to trap remote methods calls and return MethodRequest data', () => {
+        const {client, methods} = initMionClient<MyApi>({baseURL: 'http://localhost:3000'});
+
+        const expectedAuth: HookRequest<any> = {
+            pointer: ['auth'],
+            id: 'auth',
+            isResolved: false,
+            params: ['token'],
+            persist: expect.any(Function),
+        };
+
+        const expectedSayHello: RouteRequest<any> = {
+            pointer: ['sayHello'],
+            id: 'sayHello',
+            isResolved: false,
+            params: [someUser],
+            call: expect.any(Function),
+        };
+
+        const expectedSumTwo: HookRequest<any> = {
+            pointer: ['utils', 'sumTwo'],
+            id: 'utils-sumTwo',
+            isResolved: false,
+            params: [2],
+            persist: expect.any(Function),
+        };
+
+        expect(methods.auth('token')).toEqual(expect.objectContaining(expectedAuth));
+        expect(methods.sayHello(someUser)).toEqual(expect.objectContaining(expectedSayHello));
+        expect(methods.utils.sumTwo(2)).toEqual(expect.objectContaining(expectedSumTwo));
+
+        // is a proxy so actually could trap any call even if does not exists in methods and is not strongly typed
+        // note bellow code should not be used when using the client
+        const expectedUntyped: RouteRequest<any> & HookRequest<any> = {
+            pointer: ['abcd'],
+            id: 'abcd',
+            isResolved: false,
+            params: [1, 'a'],
+            call: expect.any(Function),
+            persist: expect.any(Function),
+        };
+        expect((methods as any).abcd(1, 'a')).toEqual(expectedUntyped);
+    });
+
+    it.skip('fetch a route', async () => {
+        // TODO: implement the get public method info route in the router
+        const {client, methods} = initMionClient<MyApi>({baseURL: 'http://localhost:3000'});
+
+        const response = await methods.sayHello(someUser).call(methods.auth('token'));
+
+        expect(response).toBeDefined();
+    });
 
     it('fail if a remote call fails', () => {});
 });

--- a/packages/client/src/client.spec.ts
+++ b/packages/client/src/client.spec.ts
@@ -94,7 +94,8 @@ describe('client', () => {
         expect((methods as any).abcd(1, 'a')).toEqual(expectedUntyped);
     });
 
-    it('fetch a route', async () => {
+    // TODO: jest upgrade required to include nadive node fetch types without using jsdom
+    it.skip('fetch a route', async () => {
         // TODO: implement the get public method info route in the router
         const {client, methods} = initMionClient<MyApi>({baseURL: 'http://localhost:3000'});
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -16,8 +16,8 @@ import {
     RouteRequest,
     RemoteCallResponse,
 } from './types';
-import {RemoteHandlers, RemoteMethod, RemoteMethods, RemoteResponse} from '@mionkit/router';
-import {getRouterItemId} from '@mionkit/core';
+import {RemoteMethods} from '@mionkit/router';
+import {PublicError, getRouterItemId} from '@mionkit/core';
 import {MionRequest} from './request';
 
 export function initMionClient<RM extends RemoteMethods<any>>(
@@ -61,8 +61,11 @@ class MethodProxy {
                 persist: (storage = this.clientOptions.storage) => {
                     // todo persist values to storage
                 },
-                call: (...hooks: HookRequest<any>[]): Promise<RemoteCallResponse<any, HookRequest<any>[]>> => {
-                    return this.client.callRoute(methodRequestProxy, ...hooks);
+                call: async (...hooks: HookRequest<any>[]): Promise<any | PublicError> => {
+                    return this.client.callRoute(methodRequestProxy, ...hooks).then((resp) => {
+                        if (resp.hasErrors) throw resp;
+                        return resp.routeResponse;
+                    });
                 },
             } as RouteRequest<any> & HookRequest<any>;
             return methodRequestProxy;

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -12,6 +12,11 @@ export const DEFAULT_PREFILL_OPTIONS: ClientOptions = {
     baseURL: '',
     storage: 'localStorage',
 
+    fetchOptions: {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+    },
+
     /** Prefix for all routes, i.e: api/v1.
      * path separator is added between the prefix and the route */
     prefix: '',

--- a/packages/client/src/reflection.ts
+++ b/packages/client/src/reflection.ts
@@ -1,0 +1,64 @@
+/* ########
+ * 2023 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {RemoteMethod, ResolvedResponse} from '@mionkit/router';
+import {FunctionReflection} from '@mionkit/runtype';
+import {PublicError, StatusCodes} from '@mionkit/core';
+
+export function serializeParameters(params: any[], method: RemoteMethod, reflection?: FunctionReflection): any[] | PublicError {
+    if (!reflection) return params;
+    if (params.length && method.enableSerialization) {
+        try {
+            params = reflection.serializeParams(params);
+        } catch (e: any | Error) {
+            return new PublicError({
+                statusCode: StatusCodes.BAD_REQUEST,
+                name: 'Serialization Error',
+                message: `Invalid params '${method.id}', can not serialize: ${e.message} `,
+                errorData: e?.errors,
+            });
+        }
+    }
+    return params;
+}
+
+export function validateParameters(params: any[], method: RemoteMethod, reflection?: FunctionReflection): any[] | PublicError {
+    if (!reflection) return params;
+    if (method.enableValidation) {
+        const validationResponse = reflection.validateParams(params);
+        if (validationResponse.hasErrors) {
+            return new PublicError({
+                statusCode: StatusCodes.BAD_REQUEST,
+                name: 'Validation Error',
+                message: `Invalid params in '${method.id}', validation failed.`,
+                errorData: validationResponse,
+            });
+        }
+    }
+    return params;
+}
+
+export function deSerializeReturn(
+    remoteHandlerResponse: ResolvedResponse<any>,
+    method: RemoteMethod,
+    reflection?: FunctionReflection
+): ResolvedResponse<any> | PublicError {
+    if (!reflection || !method.enableSerialization) return remoteHandlerResponse;
+    const result = remoteHandlerResponse[0];
+    if (!result) return remoteHandlerResponse;
+    try {
+        const serialized = reflection.deserializeReturn(result);
+        return [serialized, remoteHandlerResponse[1]];
+    } catch (e: any) {
+        return new PublicError({
+            statusCode: StatusCodes.BAD_REQUEST,
+            name: 'Serialization Error',
+            message: `Invalid response '${method.id}', can not serialize: ${e.message}`,
+            errorData: e?.errors,
+        });
+    }
+}

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -1,0 +1,279 @@
+/* ########
+ * 2023 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {RemoteMethod, ResolvedPublicResponses, ResolvedResponse} from '@mionkit/router';
+import {
+    ClientOptions,
+    HookRequest,
+    MethodRequest,
+    ReflectionById,
+    RemoteCallResponse,
+    RemoteMethodsById,
+    RequestBody,
+    RouteRequest,
+} from './types';
+import {FunctionReflection, SerializedTypes, getDeserializedFunctionType, getFunctionReflectionMethods} from '@mionkit/runtype';
+import {
+    GET_PUBLIC_METHODS_ID,
+    PublicError,
+    StatusCodes,
+    getRoutePath,
+    isPublicError,
+    getRouterItemId,
+    deserializeIfIsPublicError,
+} from '@mionkit/core';
+import {STORAGE_KEY} from './constants';
+import {deSerializeReturn, serializeParameters, validateParameters} from './reflection';
+
+export class MionRequest<RR extends RouteRequest<any>, RHList extends HookRequest<any>[]> {
+    requestBody: RequestBody = {};
+    routeId = '';
+    path = '';
+    constructor(
+        private route: RR,
+        private hooks: RHList,
+        private options: ClientOptions,
+        private remoteMethodsById: RemoteMethodsById,
+        private reflectionById: ReflectionById
+    ) {
+        this.routeId = route.id;
+        this.path = getRoutePath(route.pointer, this.options);
+        this.addRequestParams(route);
+        hooks.forEach((hook) => this.addRequestParams(hook));
+    }
+
+    addRequestParams(methodRequest: MethodRequest<any>) {
+        if (methodRequest.isResolved) throw new Error(`Request ${methodRequest.id} is already resolved`);
+        if (this.requestBody[methodRequest.id]) throw new Error(`Params for ${methodRequest.id} already exists in the request`);
+        this.requestBody[methodRequest.id] = methodRequest.params;
+    }
+
+    async runRoute(skipChecks = false): Promise<RemoteCallResponse<any, any>> {
+        const remoteMethodIds = Object.keys(this.requestBody);
+        const missingMethods = remoteMethodIds.filter((id) => !this.remoteMethodsById.has(id));
+        if (!skipChecks) await this.fetchRemoteMethodsInfo(missingMethods);
+        const missingPersistedIds = this.addMissingPersistedHookParams();
+
+        const remoteCallResponse: RemoteCallResponse<any, any> = {
+            routeResponse: null,
+            hooksResponses: [],
+            persistedHooksResponses: {},
+            otherResponses: {},
+            hasRouteError: false,
+            hasHookErrors: false,
+            hasOtherErrors: false,
+            hasPersistedErrors: false,
+            hasErrors: false,
+        };
+
+        if (!skipChecks) {
+            this.validateAndSerialize(remoteCallResponse);
+            if (remoteCallResponse.hasErrors) return remoteCallResponse;
+        }
+
+        try {
+            const url = new URL(this.path, this.options.baseURL);
+            const fetchOptions: RequestInit = {
+                ...this.options.fetchOptions,
+                headers: {
+                    ...this.options.fetchOptions.headers,
+                    // TODO: set headers from hook headers
+                },
+                body: JSON.stringify(this.requestBody),
+            };
+            const response = await fetch(url, fetchOptions);
+            let respObj = await response.json();
+            if (!skipChecks) respObj = this.deserializeResponseBody(respObj as ResolvedPublicResponses);
+            this.assignResponses(remoteCallResponse, respObj, response.headers, missingPersistedIds);
+        } catch (error: any) {
+            remoteCallResponse.otherResponses['request-error'] = new PublicError({
+                statusCode: StatusCodes.BAD_REQUEST,
+                name: 'Request Error',
+                message: error?.message || 'Unknown error',
+            });
+            remoteCallResponse.hasErrors = true;
+        }
+
+        return remoteCallResponse;
+    }
+
+    validateAndSerialize(remoteCallResponse: RemoteCallResponse<any, any>): void {
+        this.validateRequestBody(remoteCallResponse);
+        this.serializeRequestBody(remoteCallResponse);
+        remoteCallResponse.hasRouteError = isPublicError(remoteCallResponse.routeResponse);
+        remoteCallResponse.hasHookErrors = remoteCallResponse.hooksResponses.some((hookResp) => isPublicError(hookResp));
+        remoteCallResponse.hasErrors = remoteCallResponse.hasRouteError || remoteCallResponse.hasHookErrors;
+    }
+
+    assignResponses(
+        remoteCallResponse: RemoteCallResponse<any, any>,
+        respBody: ResolvedPublicResponses,
+        headers: Headers,
+        missingPersistedIds: string[]
+    ) {
+        const processedIds: string[] = [];
+        // assign route
+        remoteCallResponse.routeResponse = deserializeIfIsPublicError(respBody[this.routeId]);
+        remoteCallResponse.hasRouteError = isPublicError(remoteCallResponse.routeResponse);
+        this.route.isResolved = true;
+        this.route.return = remoteCallResponse.routeResponse;
+        processedIds.push(this.routeId);
+
+        // assign hooks
+        this.hooks.forEach((hook) => {
+            const remoteMethod = this.remoteMethodsById.get(hook.id);
+            const inHeader = remoteMethod?.inHeader;
+            const headerName = remoteMethod?.headerName || '';
+            // header hooks can return errors in body.
+            const value = inHeader ? headers.get(headerName) || respBody[headerName] : respBody[hook.id];
+            hook.return = deserializeIfIsPublicError(value);
+            remoteCallResponse.hooksResponses.push(hook.return);
+            remoteCallResponse.hasHookErrors = remoteCallResponse.hasHookErrors || isPublicError(hook.return);
+            hook.isResolved = true;
+            processedIds.push(hook.id);
+        });
+        // assign others
+        missingPersistedIds.forEach((id) => {
+            if (respBody[id]) {
+                const respValue = deserializeIfIsPublicError(respBody[id]);
+                remoteCallResponse.persistedHooksResponses[id] = respValue;
+                remoteCallResponse.hasPersistedErrors = remoteCallResponse.hasPersistedErrors || isPublicError(respValue);
+                processedIds.push(id);
+            }
+        });
+
+        const extraResponseIds = Object.keys(respBody).filter((x) => !processedIds.includes(x));
+        extraResponseIds.forEach((id) => {
+            const respValue = deserializeIfIsPublicError(respBody[id]);
+            remoteCallResponse.otherResponses[id] = respValue;
+            remoteCallResponse.hasOtherErrors = remoteCallResponse.hasOtherErrors || isPublicError(respValue);
+        });
+        remoteCallResponse.hasErrors =
+            remoteCallResponse.hasRouteError ||
+            remoteCallResponse.hasHookErrors ||
+            remoteCallResponse.hasOtherErrors ||
+            remoteCallResponse.hasPersistedErrors;
+    }
+
+    addMissingPersistedHookParams(): string[] {
+        const remoteRoute = this.remoteMethodsById.get(this.routeId);
+        if (!remoteRoute) throw new Error(`Remote route ${this.routeId} not found.`);
+        const hookPointerIds = remoteRoute.executionPathIds.filter((id) => !!id && this.routeId !== id);
+
+        const missingPersistedIds: string[] = [];
+
+        hookPointerIds.forEach((id) => {
+            const currentParams = this.requestBody[id];
+            if (currentParams) return;
+            const storageKey = this.getLocalStorageKey(id);
+            const persistedParams = localStorage.getItem(storageKey);
+            if (!persistedParams) return;
+            try {
+                const params = JSON.parse(persistedParams);
+                this.requestBody[id] = params;
+            } catch (e) {
+                localStorage.removeItem(storageKey);
+            } finally {
+                missingPersistedIds.push(id);
+            }
+        });
+
+        return missingPersistedIds;
+    }
+
+    serializeRequestBody(response: RemoteCallResponse<any, any>): void {
+        if (!this.options.enableSerialization) return;
+        Object.entries(this.requestBody).forEach(([key, params]) => {
+            const remoteMethod = this.remoteMethodsById.get(key);
+            if (!remoteMethod) throw new Error(`Metadata for remote method ${key} not found.`);
+            const serialized = serializeParameters(params, remoteMethod, this.reflectionById.get(remoteMethod.id));
+            response[key] = serialized;
+        });
+    }
+
+    validateRequestBody(response: RemoteCallResponse<any, any>): void {
+        if (!this.options.enableValidation) return;
+        Object.entries(this.requestBody).forEach(([key, params]) => {
+            const remoteMethod = this.remoteMethodsById.get(key);
+            if (!remoteMethod) throw new Error(`Metadata for remote method ${key} not found.`);
+            response[key] = validateParameters(params, remoteMethod, this.reflectionById.get(remoteMethod.id));
+        });
+    }
+
+    deserializeResponseBody(responseBody: ResolvedPublicResponses): ResolvedPublicResponses {
+        const deSerializedBody = responseBody;
+        Object.entries(deSerializedBody).forEach(([key, remoteHandlerResponse]) => {
+            const remoteMethod = this.remoteMethodsById.get(key);
+            if (!remoteMethod) throw new Error(`Metadata for remote method ${key} not found.`);
+            const deSerialized = deSerializeReturn(remoteHandlerResponse, remoteMethod, this.reflectionById.get(remoteMethod.id));
+            deSerializedBody[key] = deSerialized;
+        });
+        return deSerializedBody;
+    }
+
+    async fetchRemoteMethodsInfo(paths: string[]) {
+        this.restoreRemoteMethodsFromLocalStorage(paths);
+        const missingAfterLocal = paths.filter((path) => !this.remoteMethodsById.has(path));
+        if (!missingAfterLocal.length) return;
+        const body: RequestBody = {
+            [GET_PUBLIC_METHODS_ID]: [missingAfterLocal],
+        };
+        try {
+            const url = new URL(GET_PUBLIC_METHODS_ID, this.options.baseURL);
+            const response = await fetch(url, {
+                method: 'PUT',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(body),
+            });
+            const respObj = await response.json();
+            const resp = respObj[GET_PUBLIC_METHODS_ID] as ResolvedResponse<{[key: string]: RemoteMethod}>;
+            // TODO: convert Public error into a class that extends error and throw as an error
+            if (isPublicError(resp)) throw new PublicError(resp);
+            if (!resp) throw new Error('No remote methods found in response');
+
+            Object.entries(resp).forEach(([path, remoteMethod]: [string, RemoteMethod]) => {
+                this.setRemoteMethodMetadata(path, remoteMethod);
+            });
+        } catch (error: any) {
+            throw new Error(`Error fetching validation and serialization metadata: ${error?.message}`);
+        }
+    }
+
+    restoreRemoteMethodsFromLocalStorage(paths: string[]) {
+        return paths.map((path) => {
+            const storageKey = this.getLocalStorageKey(path);
+            const remoteMethodJson = localStorage.getItem(storageKey);
+            if (!remoteMethodJson) return;
+            try {
+                const remoteMethod = JSON.parse(remoteMethodJson);
+                this.setRemoteMethodMetadata(path, remoteMethod, false);
+            } catch (e) {
+                localStorage.removeItem(storageKey);
+                return;
+            }
+        });
+    }
+
+    getLocalStorageKey(id: string) {
+        return `${STORAGE_KEY}:remote-methods:${id}`;
+    }
+
+    setRemoteMethodMetadata(id: string, method: RemoteMethod, store = true) {
+        const methodWithPathIds = {
+            ...method,
+            executionPathIds: method.executionPathPointers?.map((pointer) => getRouterItemId(pointer)) || [],
+        };
+        this.remoteMethodsById.set(id, methodWithPathIds);
+        this.reflectionById.set(id, this.getFunctionReflection(method.handlerSerializedType));
+        if (store) localStorage.setItem(this.getLocalStorageKey(id), JSON.stringify(method));
+    }
+
+    getFunctionReflection(serializedTypes: SerializedTypes): FunctionReflection {
+        const type = getDeserializedFunctionType(serializedTypes);
+        return getFunctionReflectionMethods(type, this.options.reflectionOptions, 0);
+    }
+}

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -120,7 +120,7 @@ export interface MethodRequest<RM extends RemoteMethod> {
  * Note routePointer is using as differentiating key from hookPointer in HookInfo, so types can't overlap.
  */
 export interface RouteRequest<RR extends RemoteRoute> extends MethodRequest<RR> {
-    call: <RHList extends HookRequest<any>[]>(...hooks: RHList) => Promise<RemoteCallResponse<RR, RHList>>;
+    call: <RHList extends HookRequest<any>[]>(...hooks: RHList) => ReturnType<RR['_handler']>;
 }
 
 /** structure returned from the proxy, containing info of the remote hook to execute

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -9,9 +9,12 @@ import {PublicError, RouteError} from '@mionkit/core';
 import {JsonParser, RemoteHeaderHook, RemoteHook, RemoteMethod, RemoteMethods, RemoteRoute} from '@mionkit/router';
 import {FunctionReflection, ReflectionOptions} from '@mionkit/runtype';
 
+export type StorageType = 'localStorage' | 'sessionStorage';
+
 export type ClientOptions = {
     baseURL: string;
-    storage: 'localStorage' | 'sessionStorage' | 'none';
+    storage: StorageType;
+    fetchOptions: RequestInit;
 
     // ############# ROUTER OPTIONS (should match router options) #############
 
@@ -37,8 +40,6 @@ export type InitOptions = Partial<ClientOptions> & {
     baseURL: string;
 };
 
-// ####### Public Route Types #######
-
 export type RequestBody = {
     [key: string]: any[];
 };
@@ -47,12 +48,98 @@ export type PublicMethodReflection = {
     reflection: FunctionReflection;
 };
 
-type ClientFetch<Parent, RH extends RemoteMethod> = Parent & {
-    fetch: () => ReturnType<RH['_handler']>;
+export type RemoteMethodWithExecutionPathIds = RemoteMethod & {
+    executionPathIds: string[];
 };
 
-export type ClientMethods<Type extends RemoteMethods<any>> = {
-    [Property in keyof Type]: Type[Property] extends RemoteRoute | RemoteHook | RemoteHeaderHook
-        ? (...params: Parameters<Type[Property]['_handler']>) => ClientFetch<ClientMethods<Type>, Type[Property]>
+export type RemoteMethodsById = Map<string, RemoteMethodWithExecutionPathIds>;
+
+export type ReflectionById = Map<string, FunctionReflection>;
+
+// export type MethodRequestListAsObject<RList extends MethodRequest<any>[]> = {
+//     [Property in keyof RList as `${RList[Property & number]['id']}`]: RList[Property];
+// };
+
+export type HooksResponse<RHList extends HookRequest<any>[]> = {[P in keyof RHList]: Awaited<Required<RHList[P]>['return']>};
+export type RouteResponse<RR extends RouteRequest<any> | RemoteRoute> = RR extends RemoteRoute
+    ? Awaited<ReturnType<RR['_handler']>>
+    : RR extends RouteRequest<any>
+    ? RR['return']
+    : never;
+
+export type RemoteCallResponse<RR extends RouteRequest<any> | RemoteRoute, RHList extends HookRequest<any>[]> = {
+    routeResponse: RouteResponse<RR>;
+    hooksResponses: HooksResponse<RHList>;
+    persistedHooksResponses: {[key: string]: PublicError | unknown};
+    otherResponses: {[key: string]: PublicError | unknown};
+    hasRouteError: boolean;
+    hasHookErrors: boolean;
+    hasOtherErrors: boolean;
+    hasPersistedErrors: boolean;
+    hasErrors: boolean;
+};
+
+export type SuccessOnlyReturn<RM extends RouteRequest<any> | HookRequest<any>> = Exclude<
+    Required<RM>['return'],
+    PublicError | RouteError
+>;
+export type SuccessOnlyHooksResp<RHList extends HookRequest<any>[]> = {
+    [P in keyof RHList]: Awaited<SuccessOnlyReturn<RHList[P]>>;
+};
+
+export type FailOnlyReturn<RM extends RouteRequest<any> | HookRequest<any>> = Required<RM>['return'] extends PublicError
+    ? Required<RM>['return']
+    : never;
+export type FailOnlyHooksResp<RHList extends HookRequest<any>[]> = {
+    [P in keyof RHList]: Awaited<FailOnlyReturn<RHList[P]>>;
+};
+
+// TODO investigate any possible benefits of an specific promise that
+export interface RouteCallPromise<RR extends RouteRequest<any>, RHList extends HookRequest<any>[]>
+    extends Promise<RemoteCallResponse<RR, HooksResponse<RHList>>> {
+    callThen(
+        onfulfilled?: (routeResp: SuccessOnlyReturn<RR>, ...hooksResponses: SuccessOnlyHooksResp<RHList>) => void
+    ): Promise<RemoteCallResponse<RR, HooksResponse<RHList>>>;
+
+    callCatch(
+        onrejected?: (failedRouteResp: FailOnlyReturn<RR>, ...failedHooksResponses: FailOnlyHooksResp<RHList>) => void
+    ): Promise<RemoteCallResponse<RR, HooksResponse<RHList>>>;
+
+    catchOthers(onrejected?: (otherErrors: PublicError[]) => any): Promise<RemoteCallResponse<RR, HooksResponse<RHList>>>;
+}
+
+export interface MethodRequest<RM extends RemoteMethod> {
+    pointer: string[];
+    id: RM['id'];
+    isResolved: boolean;
+    params: Parameters<RM['_handler']>;
+    return?: Awaited<ReturnType<RM['_handler']>>;
+}
+
+/** structure returned from the proxy, containing info of the remote route to execute
+ * Note routePointer is using as differentiating key from hookPointer in HookInfo, so types can't overlap.
+ */
+export interface RouteRequest<RR extends RemoteRoute> extends MethodRequest<RR> {
+    call: <RHList extends HookRequest<any>[]>(...hooks: RHList) => Promise<RemoteCallResponse<RR, RHList>>;
+}
+
+/** structure returned from the proxy, containing info of the remote hook to execute
+ * Note hookPointer is using as differentiating key from routePointer in RouteInfo, so types can't overlap.
+ */
+export interface HookRequest<RH extends RemoteHook | RemoteHeaderHook> extends MethodRequest<RH> {
+    persist: (storage?: StorageType) => void;
+}
+
+export type HookCall<RH extends RemoteHook | RemoteHeaderHook> = (...params: Parameters<RH['_handler']>) => HookRequest<RH>;
+
+export type RouteCall<RR extends RemoteRoute> = (...params: Parameters<RR['_handler']>) => RouteRequest<RR>;
+
+export type ClientMethods<RMS extends RemoteMethods<any>> = {
+    [Property in keyof RMS]: RMS[Property] extends RemoteRoute
+        ? RouteCall<RMS[Property]>
+        : RMS[Property] extends RemoteHook | RemoteHeaderHook
+        ? HookCall<RMS[Property]>
+        : RMS[Property] extends RemoteMethods<any>
+        ? ClientMethods<RMS[Property]>
         : never;
 };

--- a/packages/codegen/src/specCodegen.ts
+++ b/packages/codegen/src/specCodegen.ts
@@ -66,7 +66,6 @@ function recursiveSetHandlerTypeAndCreateRouteExecutables(
         } else {
             if (item.isRoute) {
                 setRemoteMethods(item, newPointer, exportName, routeExecutables);
-                delete item.executionPathPointers;
             }
             newRoutes[key] = {
                 ...item,

--- a/packages/codegen/src/test/expected.specapi.ts
+++ b/packages/codegen/src/test/expected.specapi.ts
@@ -4,13 +4,14 @@ export const PUBLIC_METHODS = {
     myApi: {
         auth: {
             isRoute: false,
-            id: 'Authorization',
+            id: 'auth',
             inHeader: true,
             _handler: expect.any(Function),
             handlerSerializedType: expect.any(Object),
             enableValidation: true,
             enableSerialization: true,
             params: ['token'],
+            headerName: 'Authorization',
         },
         users: {
             getUser: {
@@ -22,6 +23,7 @@ export const PUBLIC_METHODS = {
                 enableValidation: true,
                 enableSerialization: true,
                 params: ['id'],
+                executionPathPointers: [['auth'], ['users', 'getUser'], ['users', 'totalUsers']],
             },
             setUser: {
                 isRoute: true,
@@ -32,6 +34,7 @@ export const PUBLIC_METHODS = {
                 enableValidation: true,
                 enableSerialization: true,
                 params: ['user', 'user2'],
+                executionPathPointers: [['auth'], ['users', 'setUser'], ['users', 'totalUsers']],
             },
             totalUsers: {
                 isRoute: false,
@@ -54,6 +57,7 @@ export const PUBLIC_METHODS = {
                 enableValidation: true,
                 enableSerialization: true,
                 params: ['id'],
+                executionPathPointers: [['auth'], ['pets', 'getPet']],
             },
             setPet: {
                 isRoute: true,
@@ -64,6 +68,7 @@ export const PUBLIC_METHODS = {
                 enableValidation: true,
                 enableSerialization: true,
                 params: ['pet'],
+                executionPathPointers: [['auth'], ['pets', 'setPet']],
             },
         },
         utils: {
@@ -76,6 +81,7 @@ export const PUBLIC_METHODS = {
                 enableValidation: true,
                 enableSerialization: true,
                 params: ['s', 'n'],
+                executionPathPointers: [['auth'], ['utils', 'getNumber']],
             },
         },
         getItem: {
@@ -87,6 +93,7 @@ export const PUBLIC_METHODS = {
             enableValidation: true,
             enableSerialization: true,
             params: ['item'],
+            executionPathPointers: [['auth'], ['getItem']],
         },
         getPetOrUser: {
             isRoute: true,
@@ -97,6 +104,7 @@ export const PUBLIC_METHODS = {
             enableValidation: true,
             enableSerialization: true,
             params: ['item'],
+            executionPathPointers: [['auth'], ['getPetOrUser']],
         },
     },
     authApi: {
@@ -109,6 +117,7 @@ export const PUBLIC_METHODS = {
             enableValidation: true,
             enableSerialization: true,
             params: ['email', 'pass'],
+            executionPathPointers: [['login']],
         },
     },
 };

--- a/packages/codegen/src/types.ts
+++ b/packages/codegen/src/types.ts
@@ -27,7 +27,7 @@ export type ExportedRoutesMap = {
 };
 
 export type PublicMethodsSpec = {
-    [key: string]: PublicMethodsSpec | RemoteMethod | null;
+    [key: string]: PublicMethodsSpec | RemoteMethods<any> | null;
 };
 
 export type RoutesSpec = {

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,30 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+  </picture>
+</p>
+<p align="center">
+  <strong>mion standard hooks and routes.
+  </strong>
+</p>
+<p align=center>
+  <img src="https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square&maxAge=99999999" alt="npm"  style="max-width:100%;">
+  <img src="https://img.shields.io/badge/license-MIT-97ca00.svg?style=flat-square&maxAge=99999999" alt="npm"  style="max-width:100%;">
+</p>
+
+# `@mionkit/common`
+
+mion standard hooks and routes.
+
+- client: serve metadata about existing routes and public hooks (remoteMethods)
+
+todo:
+
+- log hook
+- cookies hooks
+
+- ***
+
+[MIT LICENSE](../../LICENSE)

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -1,0 +1,8 @@
+/* ########
+ * 2023 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+export * from './src/client.routes';

--- a/packages/common/jest.config.js
+++ b/packages/common/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  collectCoverage: true,
+  coverageDirectory: '.coverage',
+  collectCoverageFrom: ['src/**'],
+  testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
+};

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -59,6 +59,7 @@
     "url": "https://github.com/MionKit/mion/issues"
   },
   "dependencies": {
+    "@mionkit/core": "^0.4.2",
     "@mionkit/router": "^0.4.2"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@mionkit/common",
+  "version": "0.4.2",
+  "description": "mion standard hooks and routes",
+  "keywords": [
+    "typescript",
+    "API",
+    "RPC",
+    "json",
+    "schema",
+    "generate",
+    "server",
+    "serverless",
+    "framework",
+    "node",
+    "runtime types",
+    "deepkit"
+  ],
+  "author": "ma jerez <jerez.m82@gmail.com>",
+  "homepage": "https://github.com/MionKit/mion/tree/main/packages/client#readme",
+  "license": "MIT",
+  "main": ".dist/cjs/index.js",
+  "module": ".dist/esm/index.js",
+  "types": ".dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./.dist/cjs/index.js",
+      "default": "./.dist/esm/index.js"
+    }
+  },
+  "directories": {
+    "lib": ".dist"
+  },
+  "files": [
+    ".dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MionKit/mion.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "jest",
+    "dev": "rimraf .dist && tsc --build tsconfig.json --watch",
+    "dev:test": "jest --watch",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write src/**/*.ts",
+    "build:cjs": "rimraf .dist/cjs && tsc --project tsconfig.build.json",
+    "build:esm": "rimraf .dist/esm && tsc --project tsconfig.build.json --module ES2020 --outDir .dist/esm",
+    "build:types": "rimraf .dist/types && tsc --project tsconfig.build.json --outDir .dist/types --emitDeclarationOnly --declaration true --declarationMap true",
+    "build": "npm run build:cjs && npm run build:esm && npm run build:types",
+    "auto-readme": "embedme **/*.md && prettier --write **/*.md",
+    "clean": "rimraf .dist & rimraf .coverage",
+    "im-done": "rimraf .dist & rimraf .coverage && rimraf ./node_modules"
+  },
+  "bugs": {
+    "url": "https://github.com/MionKit/mion/issues"
+  },
+  "dependencies": {
+    "@mionkit/router": "^0.4.2"
+  }
+}

--- a/packages/common/src/client.routes.spec.ts
+++ b/packages/common/src/client.routes.spec.ts
@@ -1,0 +1,197 @@
+/* ########
+ * 2023 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {registerRoutes, initRouter, resetRouter, Routes, dispatchRoute, RawRequest} from '@mionkit/router';
+import {clientRoutes} from './client.routes';
+import {PublicError} from '@mionkit/core';
+
+describe('Client Routes should', () => {
+    const privateHook = (ctx): void => undefined;
+    const auth = (ctx, token: string): void => undefined;
+    const route1 = () => 'route1';
+    const route2 = {
+        route() {
+            return 'route2';
+        },
+    };
+
+    const routes = {
+        auth: {hook: auth}, // is public as has params
+        parse: {rawHook: (ctx, req, resp, opts): void => undefined}, // private
+        users: {
+            userBefore: {hook: privateHook}, // private
+            getUser: route1, // public
+            setUser: route2, // public
+            pets: {
+                getUserPet: route2, // public
+            },
+            userAfter: {hook: privateHook}, // private
+        },
+        pets: {
+            getPet: route1, // public
+            setPet: route2, // public
+        },
+        last: {hook: privateHook, canReturnData: true}, // public as canReturnData
+    } satisfies Routes;
+
+    const shared = {auth: {me: null as any}};
+    const getSharedData = (): typeof shared => shared;
+
+    const remoteMethods = {
+        auth: {
+            isRoute: false,
+            id: 'auth',
+            inHeader: false,
+            enableValidation: true,
+            enableSerialization: true,
+            params: ['token'],
+            executionPathPointers: null,
+            headerName: null,
+        },
+        'users-getUser': {
+            isRoute: true,
+            id: 'users-getUser',
+            inHeader: false,
+            enableValidation: true,
+            enableSerialization: true,
+            params: [],
+            executionPathPointers: [['auth'], ['users', 'getUser'], ['last']],
+            headerName: null,
+        },
+        'users-setUser': {
+            isRoute: true,
+            id: 'users-setUser',
+            inHeader: false,
+            enableValidation: true,
+            enableSerialization: true,
+            params: [],
+            executionPathPointers: [['auth'], ['users', 'setUser'], ['last']],
+            headerName: null,
+        },
+        'users-pets-getUserPet': {
+            isRoute: true,
+            id: 'users-pets-getUserPet',
+            inHeader: false,
+            enableValidation: true,
+            enableSerialization: true,
+            params: [],
+            executionPathPointers: [['auth'], ['users', 'pets', 'getUserPet'], ['last']],
+            headerName: null,
+        },
+        last: {
+            isRoute: false,
+            id: 'last',
+            inHeader: false,
+            enableValidation: true,
+            enableSerialization: true,
+            params: [],
+            executionPathPointers: null,
+            headerName: null,
+        },
+    };
+
+    const methodsPath = '/mionRemoteMethods';
+    const methodsId = 'mionRemoteMethods';
+    const routeMethodsPath = '/mionGetRouteRemoteMethods';
+    const routeMethodsId = 'mionGetRouteRemoteMethods';
+
+    afterEach(() => resetRouter());
+
+    it('get Remote Methods info from id', async () => {
+        initRouter({sharedDataFactory: getSharedData});
+        registerRoutes(routes);
+        registerRoutes(clientRoutes);
+
+        const methodIdList = ['auth', 'users-getUser', 'users-setUser', 'users-pets-getUserPet', 'last']; // all public methods
+        const request: RawRequest = {
+            headers: {},
+            body: JSON.stringify({
+                auth: ['token'], // hook is required
+                [methodsId]: [methodIdList],
+            }),
+        };
+
+        const response = await dispatchRoute(methodsPath, request, {});
+
+        const expectedResponse = remoteMethods;
+        expect(response.body[methodsId]).toEqual(expectedResponse);
+    });
+
+    it('get Remote Methods info from route path', async () => {
+        initRouter({sharedDataFactory: getSharedData});
+        registerRoutes(routes);
+        registerRoutes(clientRoutes);
+
+        const request: RawRequest = {
+            headers: {},
+            body: JSON.stringify({
+                auth: ['token'], // hook is required
+                [routeMethodsId]: ['/users-getUser'],
+            }),
+        };
+
+        const response = await dispatchRoute(routeMethodsPath, request, {});
+        const expectedResponse = {
+            auth: remoteMethods.auth,
+            'users-getUser': remoteMethods['users-getUser'],
+            last: remoteMethods.last,
+        };
+        expect(response.body[routeMethodsId]).toEqual(expectedResponse);
+    });
+
+    it('fail when remote method is private or not defined', async () => {
+        initRouter({sharedDataFactory: getSharedData});
+        registerRoutes(routes);
+        registerRoutes(clientRoutes);
+
+        const methodIdList = ['parse', 'helloWorld', 'users-userBefore']; // all public methods
+        const request: RawRequest = {
+            headers: {},
+            body: JSON.stringify({
+                auth: ['token'], // hook is required
+                [methodsId]: [methodIdList],
+            }),
+        };
+
+        const response = await dispatchRoute(methodsPath, request, {});
+
+        const expectedResponse = new PublicError({
+            message: 'RemoteMethods not found',
+            statusCode: 404,
+            name: 'Invalid RemoteMethods Request',
+            errorData: {
+                parse: 'Remote Method parse not found',
+                helloWorld: 'Remote Method helloWorld not found',
+                'users-userBefore': 'Remote Method users-userBefore not found',
+            },
+        });
+
+        expect(response.body[methodsId]).toEqual(expectedResponse);
+    });
+
+    it('fail when route path is not defined', async () => {
+        initRouter({sharedDataFactory: getSharedData});
+        registerRoutes(routes);
+        registerRoutes(clientRoutes);
+
+        const request: RawRequest = {
+            headers: {},
+            body: JSON.stringify({
+                auth: ['token'], // hook is required
+                [routeMethodsId]: ['/abcd'],
+            }),
+        };
+
+        const response = await dispatchRoute(routeMethodsPath, request, {});
+        const expectedResponse = new PublicError({
+            message: 'Route /abcd not found',
+            statusCode: 404,
+            name: 'Invalid RemoteMethods Request',
+        });
+        expect(response.body[routeMethodsId]).toEqual(expectedResponse);
+    });
+});

--- a/packages/common/src/client.routes.ts
+++ b/packages/common/src/client.routes.ts
@@ -5,7 +5,7 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {PublicError} from '@mionkit/core';
+import {GET_REMOTE_METHODS_BY_ID, GET_REMOTE_METHODS_BY_PATH, PublicError} from '@mionkit/core';
 import {
     RemoteMethod,
     getHookExecutable,
@@ -14,22 +14,50 @@ import {
     getRemoteMethodFromExecutable,
     getRouteExecutionPath,
     Routes,
+    getRouterOptions,
+    RouterOptions,
+    getTotalExecutables,
+    getAllExecutablesIds,
+    getAnyExecutable,
+    Executable,
 } from '@mionkit/router';
 
 export type RemoteMethodsDictionary = {[key: string]: RemoteMethod};
+export interface ClientRouteOptions extends RouterOptions {
+    getAllRemoteMethodsMaxNumber?: number;
+}
 
-export const getRemoteMethods = (ctx, methodsIds: string[]): RemoteMethodsDictionary | PublicError => {
+export const defaultClientRouteOptions = {
+    getAllRemoteMethodsMaxNumber: 100,
+};
+
+export const getRemoteMethods = (
+    ctx,
+    methodsIds: string[],
+    getAllRemoteMethods?: boolean
+): RemoteMethodsDictionary | PublicError => {
     const resp: RemoteMethodsDictionary = {};
     const errorData = {};
     let hasErrors = false;
-    methodsIds.forEach((id) => {
+    const maxMethods =
+        getRouterOptions<ClientRouteOptions>().getAllRemoteMethodsMaxNumber ||
+        defaultClientRouteOptions.getAllRemoteMethodsMaxNumber;
+    const shouldReturnAll = getAllRemoteMethods && getTotalExecutables() <= maxMethods;
+    const idsToReturn = shouldReturnAll
+        ? getAllExecutablesIds().filter(
+              (id) =>
+                  id !== GET_REMOTE_METHODS_BY_ID &&
+                  id !== GET_REMOTE_METHODS_BY_PATH &&
+                  !isPrivateExecutable(getAnyExecutable(id) as Executable)
+          )
+        : methodsIds;
+    idsToReturn.forEach((id) => {
         const executable = getHookExecutable(id) || getRouteExecutable(id);
         if (!executable || isPrivateExecutable(executable)) {
             errorData[id] = `Remote Method ${id} not found`;
             hasErrors = true;
             return;
         }
-
         resp[id] = getRemoteMethodFromExecutable(executable);
     });
 
@@ -43,18 +71,31 @@ export const getRemoteMethods = (ctx, methodsIds: string[]): RemoteMethodsDictio
     return resp;
 };
 
-export const getRouteRemoteMethods = (ctx, path: string): RemoteMethodsDictionary | PublicError => {
+export const getRouteRemoteMethods = (
+    ctx,
+    path: string,
+    getAllRemoteMethods?: boolean
+): RemoteMethodsDictionary | PublicError => {
     const executables = getRouteExecutionPath(path);
     if (!executables)
         return new PublicError({statusCode: 404, name: 'Invalid RemoteMethods Request', message: `Route ${path} not found`});
     const privateExecutables = executables.filter((e) => !isPrivateExecutable(e));
     return getRemoteMethods(
         ctx,
-        privateExecutables.map((e) => e.id)
+        privateExecutables.map((e) => e.id),
+        getAllRemoteMethods
     );
 };
 
 export const clientRoutes = {
-    mionRemoteMethods: getRemoteMethods,
-    mionGetRouteRemoteMethods: getRouteRemoteMethods,
+    [GET_REMOTE_METHODS_BY_ID]: {
+        // disable serialization as deserializer seems ti ignore handlerSerializedType
+        enableSerialization: false,
+        route: getRemoteMethods,
+    },
+    [GET_REMOTE_METHODS_BY_PATH]: {
+        enableSerialization: false,
+        // disable serialization as deserializer seems ti ignore handlerSerializedType
+        route: getRouteRemoteMethods,
+    },
 } satisfies Routes;

--- a/packages/common/src/client.routes.ts
+++ b/packages/common/src/client.routes.ts
@@ -1,0 +1,60 @@
+/* ########
+ * 2023 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {PublicError} from '@mionkit/core';
+import {
+    RemoteMethod,
+    getHookExecutable,
+    getRouteExecutable,
+    isPrivateExecutable,
+    getRemoteMethodFromExecutable,
+    getRouteExecutionPath,
+    Routes,
+} from '@mionkit/router';
+
+export type RemoteMethodsDictionary = {[key: string]: RemoteMethod};
+
+export const getRemoteMethods = (ctx, methodsIds: string[]): RemoteMethodsDictionary | PublicError => {
+    const resp: RemoteMethodsDictionary = {};
+    const errorData = {};
+    let hasErrors = false;
+    methodsIds.forEach((id) => {
+        const executable = getHookExecutable(id) || getRouteExecutable(id);
+        if (!executable || isPrivateExecutable(executable)) {
+            errorData[id] = `Remote Method ${id} not found`;
+            hasErrors = true;
+            return;
+        }
+
+        resp[id] = getRemoteMethodFromExecutable(executable);
+    });
+
+    if (hasErrors)
+        return new PublicError({
+            statusCode: 404,
+            name: 'Invalid RemoteMethods Request',
+            message: 'RemoteMethods not found',
+            errorData,
+        });
+    return resp;
+};
+
+export const getRouteRemoteMethods = (ctx, path: string): RemoteMethodsDictionary | PublicError => {
+    const executables = getRouteExecutionPath(path);
+    if (!executables)
+        return new PublicError({statusCode: 404, name: 'Invalid RemoteMethods Request', message: `Route ${path} not found`});
+    const privateExecutables = executables.filter((e) => !isPrivateExecutable(e));
+    return getRemoteMethods(
+        ctx,
+        privateExecutables.map((e) => e.id)
+    );
+};
+
+export const clientRoutes = {
+    mionRemoteMethods: getRemoteMethods,
+    mionGetRouteRemoteMethods: getRouteRemoteMethods,
+} satisfies Routes;

--- a/packages/common/tsconfig.build.json
+++ b/packages/common/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": ".dist/cjs"
+  },
+  "reflection": true,
+  "include": ["."],
+  "exclude": ["node_modules", "**/*.spec.ts", ".dist"]
+}

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": ".dist/cjs"
+  },
+  "reflection": true,
+  "include": ["."],
+  "exclude": ["node_modules", ".dist"]
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -6,6 +6,7 @@
  * ######## */
 
 export * from './src/types';
+export * from './src/constants';
 export * from './src/errors';
 export * from './src/status-codes';
-export * from './src/constants';
+export * from './src/core';

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -12,25 +12,9 @@ export const DEFAULT_CORE_OPTIONS: CoreOptions = {
     autoGenerateErrorId: false,
 };
 
+export const PATH_SEPARATOR = '/';
+export const ROUTE_PATH_ROOT = PATH_SEPARATOR;
+
 export const GET_PUBLIC_METHODS_ID = 'mionGetPublicMethodsInfo';
 
 export const ROUTER_ITEM_SEPARATOR_CHAR = '-';
-
-// TODO move this to its own file whe we add more functionality to core package
-/**
- * Get the router id for Routes or Hooks
- * @param itemPointer - The pointer to the item within the Routes object
- * i.e:
- * const routes = {
- *   auth: () => {},
- *   users: {
- *    getUser: () => {}
- *   }
- *   login: () => {}
- * }
- *
- * then the pointer for getUser is => ['users', 'getUser']
- */
-export function getRouterItemId(itemPointer: string[]) {
-    return itemPointer.join(ROUTER_ITEM_SEPARATOR_CHAR);
-}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_CORE_OPTIONS: CoreOptions = {
 export const PATH_SEPARATOR = '/';
 export const ROUTE_PATH_ROOT = PATH_SEPARATOR;
 
-export const GET_PUBLIC_METHODS_ID = 'mionGetPublicMethodsInfo';
+export const GET_REMOTE_METHODS_BY_ID = 'mionGetRemoteMethodsInfoById';
+export const GET_REMOTE_METHODS_BY_PATH = 'mionGetRemoteMethodsInfoByPath';
 
 export const ROUTER_ITEM_SEPARATOR_CHAR = '-';

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,0 +1,36 @@
+/* ########
+ * 2023 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {PATH_SEPARATOR, ROUTER_ITEM_SEPARATOR_CHAR, ROUTE_PATH_ROOT} from './constants';
+
+/**
+ * Get the router id for Routes or Hooks
+ * @param itemPointer - The pointer to the item within the Routes object
+ * i.e:
+ * const routes = {
+ *   auth: () => {},
+ *   users: {
+ *    getUser: () => {}
+ *   }
+ *   login: () => {}
+ * }
+ *
+ * then the pointer for getUser is => ['users', 'getUser']
+ */
+export function getRouterItemId(itemPointer: string[]) {
+    return itemPointer.join(ROUTER_ITEM_SEPARATOR_CHAR);
+}
+
+/** Gets a route path from a route pointer */
+export function getRoutePath(pathPointer: string[], routerOptions: {prefix: string; suffix: string}) {
+    const pathId = getRouterItemId(pathPointer);
+    const prefix = routerOptions.prefix.startsWith(ROUTE_PATH_ROOT)
+        ? routerOptions.prefix
+        : `${ROUTE_PATH_ROOT}${routerOptions.prefix}`;
+    const routePath = prefix.endsWith(PATH_SEPARATOR) ? `${prefix}${pathId}` : `${prefix}${PATH_SEPARATOR}${pathId}`;
+    return routerOptions.suffix ? routePath + routerOptions.suffix : routePath;
+}

--- a/packages/core/src/errors.spec.ts
+++ b/packages/core/src/errors.spec.ts
@@ -26,7 +26,7 @@ describe('Route errors should', () => {
             statusCode: 400,
             publicMessage: 'this is a public message',
             message: 'this is a private message',
-            publicData: {data: 'data'},
+            errorData: {data: 'data'},
         });
         const publicError = error.toPublicError();
 
@@ -42,7 +42,7 @@ describe('Route errors should', () => {
             statusCode: 400,
             publicMessage: 'this is a message',
             message: 'this is a message',
-            publicData: {data: 'data'},
+            errorData: {data: 'data'},
         });
         const publicErrorWithSameMessage = errorWithSameMessage.toPublicError();
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -24,9 +24,9 @@ export class RouteError extends Error {
     /** the message that will be returned in the response */
     public readonly publicMessage: string;
     /** options data related to the error, ie validation data */
-    public readonly publicData?: Readonly<unknown>;
+    public readonly errorData?: Readonly<unknown>;
 
-    constructor({statusCode, message, publicMessage, originalError, publicData, name, id}: RouteErrorParams) {
+    constructor({statusCode, message, publicMessage, originalError, errorData, name, id}: RouteErrorParams) {
         super(message || originalError?.message || publicMessage);
         super.name = name || statusCodeToReasonPhrase[statusCode] || 'UnknownError';
         if (originalError?.stack) super.stack = originalError?.stack;
@@ -34,7 +34,7 @@ export class RouteError extends Error {
         this.id = id || autoGenerateErrorId ? `${new Date().toISOString()}@${randomUUID()}` : undefined;
         this.statusCode = statusCode;
         this.publicMessage = publicMessage;
-        this.publicData = publicData as Readonly<unknown>;
+        this.errorData = errorData as Readonly<unknown>;
         Object.setPrototypeOf(this, RouteError.prototype);
         // sets proper json serialization
         if (message !== publicMessage) Object.defineProperty(this, 'message', {enumerable: true});
@@ -46,7 +46,7 @@ export class RouteError extends Error {
             statusCode: this.statusCode,
             message: this.publicMessage,
             id: this.id,
-            errorData: this.publicData,
+            errorData: this.errorData,
         });
     }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -69,3 +69,30 @@ export class PublicError extends Error {
         Object.defineProperty(this, 'message', {enumerable: true});
     }
 }
+
+// #######  Error Type Guards #######
+
+const hasUnknownKeys = (knownKeys, error) => {
+    if (typeof error !== 'object') return true;
+    const unknownKeys = Object.keys(error);
+    return unknownKeys.some((ukn) => !knownKeys.includes(ukn));
+};
+
+/** Returns true if the error is a PublicError or has the same structure. */
+export function isPublicError(error: any): error is PublicError {
+    if (!error) return false;
+    if (error instanceof PublicError) return true;
+    return (
+        error &&
+        typeof error?.statusCode === 'number' &&
+        typeof error?.message === 'string' &&
+        typeof error?.name === 'string' &&
+        (typeof error?.id === 'string' || typeof error?.id === 'number' || error?.id === undefined) &&
+        !hasUnknownKeys(['id', 'statusCode', 'message', 'name', 'errorData'], error)
+    );
+}
+
+export function deserializeIfIsPublicError(value: any): PublicError | any {
+    if (!isPublicError(value) || value instanceof PublicError) return value;
+    return new PublicError(value);
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,8 +5,6 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {PublicError} from '..';
-
 // ####### Options #######
 
 export type CoreOptions = {
@@ -36,15 +34,6 @@ export type RouteErrorParams = {
     /** name of the error, if not defined it is assigned from status code */
     name?: string;
 };
-
-// #######  Type Guards #######
-
-export function isPublicError(error: any): error is PublicError {
-    if (error instanceof PublicError) return true;
-    return (
-        error && typeof error?.statusCode === 'number' && typeof error?.message === 'string' && typeof error?.name === 'string'
-    );
-}
 
 // #######  Others #######
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,7 +28,7 @@ export type RouteErrorParams = {
      */
     message?: string;
     /** options data related to the error, ie validation data */
-    publicData?: unknown;
+    errorData?: unknown;
     /** original error used to create the RouteError */
     originalError?: Error;
     /** name of the error, if not defined it is assigned from status code */

--- a/packages/http/src/mionHttp.spec.ts
+++ b/packages/http/src/mionHttp.spec.ts
@@ -8,6 +8,9 @@ import {registerRoutes} from '@mionkit/router';
 import {initHttpRouter, resetHttpRouter, startHttpServer} from './mionHttp';
 import type {CallContext, Route} from '@mionkit/router';
 import {PublicError} from '@mionkit/core';
+// In theory node 18 supports fetch but not working fine with jest, we should update to jest 29
+// update to jest 29 gonna take some changes as all globals must be imported from @jest/globals
+// also the types for fetch are not available in node 18, fix here: https://stackoverflow.com/questions/71294230/how-can-i-use-native-fetch-with-node-in-typescript-node-v17-6#answer-75676044
 import fetch from 'node-fetch';
 
 describe('serverless router should', () => {

--- a/packages/http/src/mionHttp.spec.ts
+++ b/packages/http/src/mionHttp.spec.ts
@@ -8,6 +8,7 @@ import {registerRoutes} from '@mionkit/router';
 import {initHttpRouter, resetHttpRouter, startHttpServer} from './mionHttp';
 import type {CallContext, Route} from '@mionkit/router';
 import {PublicError} from '@mionkit/core';
+import fetch from 'node-fetch';
 
 describe('serverless router should', () => {
     resetHttpRouter();

--- a/packages/http/src/mionHttp.spec.ts
+++ b/packages/http/src/mionHttp.spec.ts
@@ -5,7 +5,6 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 import {registerRoutes} from '@mionkit/router';
-import fetch from 'node-fetch'; // must be node-fetch v2 as v3 is an ES6 module non compatible whit current setup
 import {initHttpRouter, resetHttpRouter, startHttpServer} from './mionHttp';
 import type {CallContext, Route} from '@mionkit/router';
 import {PublicError} from '@mionkit/core';

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -5,7 +5,6 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import * as undici_types from 'undici';
 import {Headers, RouterOptions} from '@mionkit/router';
 import {IncomingMessage, ServerResponse} from 'http';
 import {ServerOptions} from 'https';
@@ -34,24 +33,24 @@ export type HttpOptions = {
 
 export type HttpRequest = IncomingMessage & {body: string};
 
-// fix for missing fetch types in node 18
-// @see https://stackoverflow.com/questions/71294230/how-can-i-use-native-fetch-with-node-in-typescript-node-v17-6
-declare global {
-    export const {fetch, FormData, Headers, Request, Response}: typeof import('undici');
+// // fix for missing fetch types in node 18
+// // @see https://stackoverflow.com/questions/71294230/how-can-i-use-native-fetch-with-node-in-typescript-node-v17-6
+// declare global {
+//     export const {fetch, FormData, Headers, Request, Response}: typeof import('undici');
 
-    type FormData = undici_types.FormData;
-    type Headers = undici_types.Headers;
-    type HeadersInit = undici_types.HeadersInit;
-    type BodyInit = undici_types.BodyInit;
-    type Request = undici_types.Request;
-    type RequestInit = undici_types.RequestInit;
-    type RequestInfo = undici_types.RequestInfo;
-    type RequestMode = undici_types.RequestMode;
-    type RequestRedirect = undici_types.RequestRedirect;
-    type RequestCredentials = undici_types.RequestCredentials;
-    type RequestDestination = undici_types.RequestDestination;
-    type ReferrerPolicy = undici_types.ReferrerPolicy;
-    type Response = undici_types.Response;
-    type ResponseInit = undici_types.ResponseInit;
-    type ResponseType = undici_types.ResponseType;
-}
+//     type FormData = undici_types.FormData;
+//     type Headers = undici_types.Headers;
+//     type HeadersInit = undici_types.HeadersInit;
+//     type BodyInit = undici_types.BodyInit;
+//     type Request = undici_types.Request;
+//     type RequestInit = undici_types.RequestInit;
+//     type RequestInfo = undici_types.RequestInfo;
+//     type RequestMode = undici_types.RequestMode;
+//     type RequestRedirect = undici_types.RequestRedirect;
+//     type RequestCredentials = undici_types.RequestCredentials;
+//     type RequestDestination = undici_types.RequestDestination;
+//     type ReferrerPolicy = undici_types.ReferrerPolicy;
+//     type Response = undici_types.Response;
+//     type ResponseInit = undici_types.ResponseInit;
+//     type ResponseType = undici_types.ResponseType;
+// }

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -5,6 +5,7 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
+import * as undici_types from 'undici';
 import {Headers, RouterOptions} from '@mionkit/router';
 import {IncomingMessage, ServerResponse} from 'http';
 import {ServerOptions} from 'https';
@@ -32,3 +33,25 @@ export type HttpOptions = {
 } & Partial<RouterOptions<HttpRequest>>;
 
 export type HttpRequest = IncomingMessage & {body: string};
+
+// fix for missing fetch types in node 18
+// @see https://stackoverflow.com/questions/71294230/how-can-i-use-native-fetch-with-node-in-typescript-node-v17-6
+declare global {
+    export const {fetch, FormData, Headers, Request, Response}: typeof import('undici');
+
+    type FormData = undici_types.FormData;
+    type Headers = undici_types.Headers;
+    type HeadersInit = undici_types.HeadersInit;
+    type BodyInit = undici_types.BodyInit;
+    type Request = undici_types.Request;
+    type RequestInit = undici_types.RequestInit;
+    type RequestInfo = undici_types.RequestInfo;
+    type RequestMode = undici_types.RequestMode;
+    type RequestRedirect = undici_types.RequestRedirect;
+    type RequestCredentials = undici_types.RequestCredentials;
+    type RequestDestination = undici_types.RequestDestination;
+    type ReferrerPolicy = undici_types.ReferrerPolicy;
+    type Response = undici_types.Response;
+    type ResponseInit = undici_types.ResponseInit;
+    type ResponseType = undici_types.ResponseType;
+}

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -242,8 +242,8 @@ Ie: calling the route `/api/sayHello` with an invalid json body would return bel
 
 ```json
 {
-  // parseJsonRequestBody is the name of the json parser Raw Hook used internally by mion router
-  "parseJsonRequestBody": [
+  // mionParseJsonRequestBody is the name of the json parser Raw Hook used internally by mion router
+  "mionParseJsonRequestBody": [
     null, // return value is null
     {"statusCode": 400, "name": "Invalid Request", "message": "Wrong request body ..."}
   ]

--- a/packages/router/index.ts
+++ b/packages/router/index.ts
@@ -5,8 +5,9 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
+export * from './src/types';
+export * from './src/constants';
 export * from './src/router';
 export * from './src/dispatch';
 export * from './src/errors';
-export * from './src/types';
-export * from './src/constants';
+export * from './src/remoteMethods';

--- a/packages/router/src/constants.ts
+++ b/packages/router/src/constants.ts
@@ -8,8 +8,6 @@
 import {HookDef, RawRequest, RouteDef, RouterOptions} from './types';
 import {DEFAULT_REFLECTION_OPTIONS} from '@mionkit/runtype';
 
-export const ROUTE_PATH_ROOT = '/';
-
 export const DEFAULT_ROUTE: Readonly<Required<RouteDef>> = {
     description: '',
     enableValidation: true,

--- a/packages/router/src/dispatch.spec.ts
+++ b/packages/router/src/dispatch.spec.ts
@@ -200,12 +200,12 @@ describe('Dispatch routes', () => {
             const request = getDefaultRequest('changeUserName', [{name: 'Leo', surname: 'Tungsten'}]);
 
             const response = await dispatchRoute('/changeUserName', request, {});
-            const error = response.body?.Authorization;
+            const error = response.body?.auth;
             expect(error).toEqual(
                 new PublicError({
                     statusCode: 400,
                     name: 'Validation Error',
-                    message: `Invalid params in 'Authorization', validation failed.`,
+                    message: `Invalid params in 'auth', validation failed.`,
                     errorData: expect.anything(),
                 })
             );

--- a/packages/router/src/dispatch.spec.ts
+++ b/packages/router/src/dispatch.spec.ts
@@ -221,7 +221,7 @@ describe('Dispatch routes', () => {
             };
 
             const response = await dispatchRoute('/changeUserName', request, {});
-            const error = response.body['parseJsonRequestBody'];
+            const error = response.body['mionParseJsonRequestBody'];
             expect(error).toEqual(
                 new PublicError({
                     statusCode: 400,
@@ -236,7 +236,7 @@ describe('Dispatch routes', () => {
             };
 
             const response2 = await dispatchRoute('/changeUserName', request2, {});
-            const errorResp = response2.body['parseJsonRequestBody'];
+            const errorResp = response2.body['mionParseJsonRequestBody'];
             expect(errorResp).toEqual(
                 new PublicError({
                     statusCode: 422,

--- a/packages/router/src/jsonBodyParser.ts
+++ b/packages/router/src/jsonBodyParser.ts
@@ -5,7 +5,7 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {Response, Request, RouterOptions, RawRequest, RawHooksCollection, CallContext, ErrorReturn} from './types';
+import {Response, Request, RouterOptions, RawRequest, HooksCollection, CallContext, ErrorReturn} from './types';
 import {RouteError, StatusCodes, Obj, Mutable} from '@mionkit/core';
 import {handleRouteErrors} from './dispatch';
 
@@ -74,10 +74,10 @@ export function stringifyResponseBody(
 }
 
 export const bodyParserHooks = {
-    parseJsonRequestBody: {
+    mionParseJsonRequestBody: {
         rawHook: parseRequestBody,
     },
-    stringifyJsonResponseBody: {
+    mionStringifyJsonResponseBody: {
         rawHook: stringifyResponseBody,
     },
-} satisfies RawHooksCollection;
+} satisfies HooksCollection;

--- a/packages/router/src/remoteMethods.spec.ts
+++ b/packages/router/src/remoteMethods.spec.ts
@@ -187,14 +187,14 @@ describe('Public Mothods should', () => {
         });
     });
 
-    it('should throw an error when route pr hook is not already created in the router', () => {
+    it('should throw an error when route or hook is not already created in the router', () => {
         const testR1 = {route1};
         const testR2 = {hook1: {hook: paramsHook}};
         expect(() => getRemoteMethods(testR1)).toThrow(
-            `Route 'route1' not found in router. Please check you have called router.addRoutes first!`
+            `Route or Hook route1 not found. Please check you have called router.registerRoutes first.`
         );
         expect(() => getRemoteMethods(testR2)).toThrow(
-            `Hook 'hook1' not found in router. Please check you have called router.addRoutes first!`
+            `Route or Hook hook1 not found. Please check you have called router.registerRoutes first.`
         );
     });
 

--- a/packages/router/src/remoteMethods.spec.ts
+++ b/packages/router/src/remoteMethods.spec.ts
@@ -5,7 +5,7 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {DEFAULT_ROUTE_OPTIONS, DEFAULT_HOOK} from './constants';
+import {DEFAULT_ROUTE_OPTIONS} from './constants';
 import {getRemoteMethods} from './remoteMethods';
 import {registerRoutes, initRouter, resetRouter, getRouteDefaultParams} from './router';
 import {getFunctionReflectionMethods} from '@mionkit/runtype';
@@ -198,7 +198,7 @@ describe('Public Mothods should', () => {
         );
     });
 
-    it('should serialize type skipping the context parameter', () => {
+    it('should serialize remote method type skipping the context parameter', () => {
         initRouter({sharedDataFactory: getSharedData, getPublicRoutesData: true});
         const routes = {
             sayHello: (ctx: CallContext, name: string): string => `Hello ${name}`,

--- a/packages/router/src/remoteMethods.ts
+++ b/packages/router/src/remoteMethods.ts
@@ -35,6 +35,9 @@ import {Obj, getRoutePath, getRouterItemId} from '@mionkit/core';
 const remoteMethodsById: Map<string, RemoteMethod> = new Map();
 
 // ############# PUBLIC METHODS #############
+export function resetRemoteMethods() {
+    remoteMethodsById.clear();
+}
 
 /**
  * Returns a data structure containing all public information and types of the routes.

--- a/packages/router/src/remoteMethods.ts
+++ b/packages/router/src/remoteMethods.ts
@@ -59,7 +59,8 @@ function recursiveGetRemoteMethods<R extends Routes>(routes: R, currentPointer: 
         } else if (isHookDef(item) || isHeaderHookDef(item) || isRoute(item)) {
             const id = getRouterItemId(itemPointer);
             const executable = getHookExecutable(id) || getRouteExecutable(id);
-            if (!executable) throw new Error(`Executable ${id}' not found.`);
+            if (!executable)
+                throw new Error(`Route or Hook ${id} not found. Please check you have called router.registerRoutes first.`);
             publicData[key] = getRemoteMethodFromExecutable(executable);
         } else {
             const subRoutes: Routes = routes[key] as Routes;
@@ -84,7 +85,7 @@ export function getRemoteMethodFromExecutable<H extends Handler>(executable: Rou
         isRoute: executable.isRoute,
         id: executable.id,
         inHeader: executable.inHeader,
-        // handler is included just for static typing purposes and shouldn't be called directly
+        // handler is included just for static typing purposes and should never be called directly
         _handler: getHandlerSrcCodePointer(executable) as any as RemoteHandler<H>,
         handlerSerializedType: getSerializedFunctionType(executable.handler, getRouteDefaultParams().length),
         enableValidation: executable.enableValidation,

--- a/packages/router/src/router.spec.ts
+++ b/packages/router/src/router.spec.ts
@@ -17,6 +17,7 @@ import {
     initRouter,
     addStartHooks,
     addEndHooks,
+    getRouteEntries,
 } from './router';
 import {Handler, HookDef, RouteDef, Routes} from './types';
 
@@ -116,7 +117,7 @@ describe('Create routes should', () => {
         expect(geRoutesSize()).toEqual(5);
         expect(geHooksSize()).toEqual(5);
 
-        expect(getRouteExecutionPath('/users/getUser')).toEqual(
+        expect(getRouteExecutionPath('/users-getUser')).toEqual(
             addDefaultExecutables([
                 expect.objectContaining({...hookExecutables.first}),
                 expect.objectContaining({...hookExecutables.userBefore}),
@@ -125,8 +126,8 @@ describe('Create routes should', () => {
                 expect.objectContaining({...hookExecutables.last}),
             ])
         );
-        expect(getRouteExecutionPath('/users/setUser')).toBeTruthy();
-        expect(getRouteExecutionPath('/users/pets/getUserPet')).toEqual(
+        expect(getRouteExecutionPath('/users-setUser')).toBeTruthy();
+        expect(getRouteExecutionPath('/users-pets-getUserPet')).toEqual(
             addDefaultExecutables([
                 expect.objectContaining({...hookExecutables.first}),
                 expect.objectContaining({...hookExecutables.userBefore}),
@@ -136,14 +137,14 @@ describe('Create routes should', () => {
                 expect.objectContaining({...hookExecutables.last}),
             ])
         );
-        expect(getRouteExecutionPath('/pets/getPet')).toEqual(
+        expect(getRouteExecutionPath('/pets-getPet')).toEqual(
             addDefaultExecutables([
                 expect.objectContaining({...hookExecutables.first}),
                 expect.objectContaining({...routeExecutables.petsGetPet}),
                 expect.objectContaining({...hookExecutables.last}),
             ])
         );
-        expect(getRouteExecutionPath('/pets/setPet')).toBeTruthy();
+        expect(getRouteExecutionPath('/pets-setPet')).toBeTruthy();
     });
 
     it('should support methods', () => {
@@ -207,11 +208,11 @@ describe('Create routes should', () => {
         expect(geRoutesSize()).toEqual(5);
         expect(geHooksSize()).toEqual(5);
 
-        expect(getRouteExecutionPath('/api/v1/users/getUser.json')).toBeTruthy();
-        expect(getRouteExecutionPath('/api/v1/users/setUser.json')).toBeTruthy();
-        expect(getRouteExecutionPath('/api/v1/users/pets/getUserPet.json')).toBeTruthy();
-        expect(getRouteExecutionPath('/api/v1/pets/getPet.json')).toBeTruthy();
-        expect(getRouteExecutionPath('/api/v1/pets/setPet.json')).toBeTruthy();
+        expect(getRouteExecutionPath('/api/v1/users-getUser.json')).toBeTruthy();
+        expect(getRouteExecutionPath('/api/v1/users-setUser.json')).toBeTruthy();
+        expect(getRouteExecutionPath('/api/v1/users-pets-getUserPet.json')).toBeTruthy();
+        expect(getRouteExecutionPath('/api/v1/pets-getPet.json')).toBeTruthy();
+        expect(getRouteExecutionPath('/api/v1/pets-setPet.json')).toBeTruthy();
     });
 
     it('throw an error when a routes are invalid', () => {
@@ -334,7 +335,7 @@ describe('Create routes should', () => {
             expect.objectContaining({id: 'a2', isRoute: false}),
         ]);
 
-        expect(getRouteExecutionPath('/pets/getPet')).toEqual(expectedExecutionPath);
+        expect(getRouteExecutionPath('/pets-getPet')).toEqual(expectedExecutionPath);
         expect(() => addStartHooks(prependHooks)).toThrow('Can not add start hooks after the router has been initialized');
         expect(() => addEndHooks(appendHooks)).toThrow('Can not add end hooks after the router has been initialized');
     });

--- a/packages/router/src/router.spec.ts
+++ b/packages/router/src/router.spec.ts
@@ -88,23 +88,23 @@ describe('Create routes should', () => {
     };
 
     const defaultExecutables = {
-        parseJsonRequestBody: {
+        mionParseJsonRequestBody: {
             isRoute: false,
             isRawExecutable: true,
-            id: 'parseJsonRequestBody',
+            id: 'mionParseJsonRequestBody',
         },
-        stringifyJsonResponseBody: {
+        mionStringifyJsonResponseBody: {
             isRoute: false,
             isRawExecutable: true,
-            id: 'stringifyJsonResponseBody',
+            id: 'mionStringifyJsonResponseBody',
         },
     };
 
     function addDefaultExecutables(exec: any[]) {
         return [
-            expect.objectContaining({...defaultExecutables.parseJsonRequestBody}),
+            expect.objectContaining({...defaultExecutables.mionParseJsonRequestBody}),
             ...exec,
-            expect.objectContaining({...defaultExecutables.stringifyJsonResponseBody}),
+            expect.objectContaining({...defaultExecutables.mionStringifyJsonResponseBody}),
         ];
     }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -39,7 +39,7 @@ import {
 import {ReflectionOptions, getFunctionReflectionMethods} from '@mionkit/runtype';
 import {bodyParserHooks} from './jsonBodyParser';
 import {RouteError, StatusCodes, getRouterItemId, setErrorOptions, getRoutePath} from '@mionkit/core';
-import {getRemoteMethods} from './remoteMethods';
+import {getRemoteMethods, resetRemoteMethods} from './remoteMethods';
 
 type RouterKeyEntryList = [string, RouterEntry][];
 type RoutesWithId = {
@@ -94,6 +94,7 @@ export const resetRouter = () => {
     endHooks = [];
     isRouterInitialized = false;
     looselyReflectionOptions = undefined;
+    resetRemoteMethods();
 };
 
 /**

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -78,6 +78,7 @@ export const getHookExecutable = (id: string) => hooksById.get(id);
 export const geHooksSize = () => hooksById.size;
 export const getComplexity = () => complexity;
 export const getRouterOptions = <Opts extends RouterOptions>(): Readonly<Opts> => routerOptions as Opts;
+export const getAnyExecutable = (id: string) => routesById.get(id) || hooksById.get(id) || rawHooksById.get(id);
 
 export const resetRouter = () => {
     flatRouter.clear();
@@ -182,6 +183,14 @@ export function isPrivateExecutable(executable: Executable): boolean {
     if (executable.isRoute) return false;
     const hasPublicParams = executable.handler.length > getRouteDefaultParams().length;
     return !hasPublicParams && !executable.canReturnData;
+}
+
+export function getTotalExecutables(): number {
+    return routesById.size + hooksById.size + rawHooksById.size;
+}
+
+export function getAllExecutablesIds(): string[] {
+    return [...routesById.keys(), ...hooksById.keys(), ...rawHooksById.keys()];
 }
 
 // ############# PRIVATE METHODS #############

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -217,7 +217,7 @@ export type Request = {
     /** parsed body */
     readonly body: Readonly<Obj>;
     /** All errors thrown during the call are stored here so they can bee logged or handler by a some error handler hook */
-    readonly internalErrors: Readonly<RouteError[]>;
+    readonly internalErrors: Readonly<(RouteError | PublicError)[]>;
 };
 
 /** Any request used by the router must follow this interface */

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -250,13 +250,13 @@ export type SharedDataFactory<SharedData> = () => SharedData;
 
 export type ErrorReturn = void | RouteError | Promise<RouteError | void>;
 
-export type RawHooksCollection<
+export type HooksCollection<
     Context extends CallContext = CallContext,
     RawReq extends RawRequest = RawRequest,
     RawResp = unknown,
     Opts extends RouterOptions<RawReq> = RouterOptions<RawReq>
 > = {
-    [key: string]: RawHookDef<Context, RawReq, RawResp, Opts>;
+    [key: string]: RawHookDef<Context, RawReq, RawResp, Opts> | HookDef<Context> | HeaderHookDef<Context>;
 };
 
 // ####### Private Hooks #######

--- a/packages/runtype/package.json
+++ b/packages/runtype/package.json
@@ -58,7 +58,8 @@
     "url": "https://github.com/MionKit/mion/issues"
   },
   "dependencies": {
-    "@deepkit/type": "^1.0.1-alpha.97"
+    "@deepkit/type": "1.0.1-alpha.97",
+    "@mionkit/core": "0.4.2"
   },
   "gitHead": "2efdcd77c572e64f2b9621b4921ffd2f5e83bc0a"
 }

--- a/packages/runtype/src/reflection.ts
+++ b/packages/runtype/src/reflection.ts
@@ -5,16 +5,7 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {
-    JSONPartial,
-    ReflectionKind,
-    SerializedTypes,
-    Type,
-    TypeFunction,
-    deserializeType,
-    reflect,
-    serializeType,
-} from '@deepkit/type';
+import {JSONPartial, ReflectionKind, SerializedTypes, Type, TypeFunction, deserializeType, serializeType} from '@deepkit/type';
 import {
     FunctionReflection,
     ParamsValidationResponse,
@@ -139,7 +130,7 @@ export function getFunctionReflectionMethods(
 
 // TODO: serialized types is including the context which we don't want to send over the wire
 /** Gets a data structure that can be serialized in json and transmitted over the wire  */
-export const getSerializedFunctionType = (handlerOrType: Handler, skipInitialParams = 0): SerializedTypes => {
+export function getSerializedFunctionType(handlerOrType: Handler, skipInitialParams = 0): SerializedTypes {
     const handlerType = getHandlerType(handlerOrType);
     // THIS IS NOT OFFICIALLY SUPPORTED BY DEEPKIT MIGHT BREAK IN THE FUTURE
     // TODO investigate if this is not braking anything
@@ -149,11 +140,11 @@ export const getSerializedFunctionType = (handlerOrType: Handler, skipInitialPar
     // restore original params in case the type is being cached
     handlerType.parameters = originalParams;
     return serializedTypes;
-};
+}
 
 /** Gets a Type from a serializedTypes */
-export const getDeserializedFunctionType = (serializedTypes: SerializedTypes): TypeFunction => {
+export function getDeserializedFunctionType(serializedTypes: SerializedTypes): TypeFunction {
     const type = deserializeType(serializedTypes);
     if (type.kind !== ReflectionKind.function) throw new Error('Invalid serialized type is not from a function');
     return type;
-};
+}

--- a/packages/runtype/src/serialization.ts
+++ b/packages/runtype/src/serialization.ts
@@ -65,7 +65,7 @@ export function getFunctionParamsSerializer(
  * @returns
  */
 export function serializeFunctionParams<T = any>(serializers: FunctionParamSerializer[], params: any[]): JSONPartial<T>[] {
-    if (params.length !== serializers.length) throw new Error('Invalid number of parameters');
+    if (params.length > serializers.length) throw new Error('Invalid number of parameters');
     return serializers.map((serializer, index) => serializer(params[index]));
 }
 
@@ -77,7 +77,7 @@ export function serializeFunctionParams<T = any>(serializers: FunctionParamSeria
  * @returns
  */
 export function deserializeFunctionParams<T = any>(deSerializers: FunctionParamDeserializer[], params: JSONPartial<T>[]): any[] {
-    if (params.length !== deSerializers.length) throw new Error('Invalid number of parameters');
+    if (params.length > deSerializers.length) throw new Error('Invalid number of parameters');
     return deSerializers.map((deserializer, index) => deserializer(params[index]));
 }
 


### PR DESCRIPTION
* Client package working (pending upgrade to jest > 28 ans implement unit testing)
* Add @mionkit/commons with routes to get remote methods metadata
* fix routes union  serialization not working, ie `(): string | RouteError => 'hello'` was not working
* Fix routes handling `RouteErrors` as well as `PublicErrors`

Pending finish unit test and documentation