### PR TITLE
feat: Use loose union matching with ESLint rules for compile-time detection

### DIFF
--- a/packages/eslint-plugin/build/cjs/index.js
+++ b/packages/eslint-plugin/build/cjs/index.js
@@ -1,17 +1,24 @@
 "use strict";
 const rules_noTypeofRuntype = require("./rules/no-typeof-runtype.js");
 const rules_strongTypedRoutes = require("./rules/strong-typed-routes.js");
+const rules_noUnreachableUnionTypes = require("./rules/no-unreachable-union-types.js");
+const rules_noMixedUnionProperties = require("./rules/no-mixed-union-properties.js");
 const plugin = {
   rules: {
     "no-typeof-runtype": rules_noTypeofRuntype,
-    "strong-typed-routes": rules_strongTypedRoutes
+    "strong-typed-routes": rules_strongTypedRoutes,
+    "no-unreachable-union-types": rules_noUnreachableUnionTypes,
+    "no-mixed-union-properties": rules_noMixedUnionProperties
   },
   configs: {
     recommended: {
       extends: [],
       rules: {
         "@mionkit/no-typeof-runtype": "error",
-        "@mionkit/strong-typed-routes": "error"
+        "@mionkit/strong-typed-routes": "error",
+        "@mionkit/no-unreachable-union-types": "error"
+        // disabled as seems is not too useful and overlaps with some ts rules
+        // '@mionkit/no-mixed-union-properties': 'warn',
       }
     }
   }

--- a/packages/eslint-plugin/build/cjs/rules/no-mixed-union-properties.js
+++ b/packages/eslint-plugin/build/cjs/rules/no-mixed-union-properties.js
@@ -1,0 +1,221 @@
+"use strict";
+const utils = require("@typescript-eslint/utils");
+function getObjectTypeProperties(node) {
+  if (node.type === utils.AST_NODE_TYPES.TSTypeLiteral) {
+    const props = [];
+    for (const member of node.members) {
+      if (member.type === utils.AST_NODE_TYPES.TSPropertySignature && member.key.type === utils.AST_NODE_TYPES.Identifier) {
+        props.push({ name: member.key.name, isOptional: !!member.optional });
+      }
+    }
+    return props;
+  }
+  return null;
+}
+function getUnionObjectTypes(unionNode) {
+  const types = [];
+  for (const typeNode of unionNode.types) {
+    const props = getObjectTypeProperties(typeNode);
+    if (props && props.length > 0) {
+      types.push({ node: typeNode, properties: props });
+    }
+  }
+  return types;
+}
+function getObjectLiteralPropertyNames(node) {
+  const names = [];
+  for (const prop of node.properties) {
+    if (prop.type === utils.AST_NODE_TYPES.Property && prop.key.type === utils.AST_NODE_TYPES.Identifier) {
+      names.push(prop.key.name);
+    }
+  }
+  return names;
+}
+function getMatchingUnionTypes(objectProps, unionTypes) {
+  const matchingIndices = [];
+  for (let i = 0; i < unionTypes.length; i++) {
+    const unionPropNames = new Set(unionTypes[i].properties.map((p) => p.name));
+    if (objectProps.some((prop) => unionPropNames.has(prop))) {
+      matchingIndices.push(i);
+    }
+  }
+  return matchingIndices;
+}
+function getUniquePropertiesPerType(unionTypes) {
+  const allProps = /* @__PURE__ */ new Map();
+  for (let i = 0; i < unionTypes.length; i++) {
+    for (const prop of unionTypes[i].properties) {
+      const existing = allProps.get(prop.name) || [];
+      existing.push(i);
+      allProps.set(prop.name, existing);
+    }
+  }
+  const uniqueProps = /* @__PURE__ */ new Map();
+  for (let i = 0; i < unionTypes.length; i++) {
+    const unique = /* @__PURE__ */ new Set();
+    for (const prop of unionTypes[i].properties) {
+      if ((allProps.get(prop.name) || []).length === 1) {
+        unique.add(prop.name);
+      }
+    }
+    uniqueProps.set(i, unique);
+  }
+  return uniqueProps;
+}
+function resolveTypeReference(node, context) {
+  if (node.type !== utils.AST_NODE_TYPES.TSTypeReference) {
+    return null;
+  }
+  if (node.typeName.type !== utils.AST_NODE_TYPES.Identifier) {
+    return null;
+  }
+  const typeName = node.typeName.name;
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === utils.AST_NODE_TYPES.TSTypeAliasDeclaration) {
+      if (statement.id.name === typeName && statement.typeAnnotation.type === utils.AST_NODE_TYPES.TSUnionType) {
+        return statement.typeAnnotation;
+      }
+    }
+  }
+  return null;
+}
+function getReturnTypeAnnotation(func, context) {
+  var _a;
+  const returnType = (_a = func.returnType) == null ? void 0 : _a.typeAnnotation;
+  if (!returnType) {
+    return null;
+  }
+  if (returnType.type === utils.AST_NODE_TYPES.TSUnionType) {
+    return returnType;
+  }
+  if (returnType.type === utils.AST_NODE_TYPES.TSTypeReference) {
+    return resolveTypeReference(returnType, context);
+  }
+  return null;
+}
+function findReturnStatements(func) {
+  const returns = [];
+  if (func.type === utils.AST_NODE_TYPES.ArrowFunctionExpression && func.expression && func.body.type !== utils.AST_NODE_TYPES.BlockStatement) {
+    returns.push(func.body);
+    return returns;
+  }
+  if (func.body.type === utils.AST_NODE_TYPES.BlockStatement) {
+    findReturnsInBlock(func.body, returns);
+  }
+  return returns;
+}
+function findReturnsInBlock(block, returns) {
+  var _a, _b;
+  for (const statement of block.body) {
+    if (statement.type === utils.AST_NODE_TYPES.ReturnStatement && statement.argument) {
+      returns.push(statement.argument);
+    } else if (statement.type === utils.AST_NODE_TYPES.IfStatement) {
+      if (statement.consequent.type === utils.AST_NODE_TYPES.BlockStatement) {
+        findReturnsInBlock(statement.consequent, returns);
+      } else if (statement.consequent.type === utils.AST_NODE_TYPES.ReturnStatement && statement.consequent.argument) {
+        returns.push(statement.consequent.argument);
+      }
+      if (((_a = statement.alternate) == null ? void 0 : _a.type) === utils.AST_NODE_TYPES.BlockStatement) {
+        findReturnsInBlock(statement.alternate, returns);
+      } else if (((_b = statement.alternate) == null ? void 0 : _b.type) === utils.AST_NODE_TYPES.ReturnStatement && statement.alternate.argument) {
+        returns.push(statement.alternate.argument);
+      }
+    }
+  }
+}
+function getConflictDescription(objectProps, unionTypes, matchingIndices) {
+  const uniqueProps = getUniquePropertiesPerType(unionTypes);
+  const conflicts = [];
+  for (const idx of matchingIndices) {
+    const unique = uniqueProps.get(idx) || /* @__PURE__ */ new Set();
+    const matchingProps = objectProps.filter((p) => unique.has(p));
+    if (matchingProps.length > 0) {
+      conflicts.push(`'${matchingProps.join("', '")}' from type ${idx + 1}`);
+    }
+  }
+  return conflicts.join(" and ");
+}
+function isRouterFunction(node, context) {
+  let current = node;
+  while (current) {
+    if (current.type === utils.AST_NODE_TYPES.CallExpression) {
+      return isRouterFunctionCall(current, context);
+    }
+    current = current.parent;
+  }
+  return false;
+}
+function isRouterFunctionCall(node, context) {
+  const routerFunctions = ["route", "hook", "headersHook"];
+  if (node.callee.type !== utils.AST_NODE_TYPES.Identifier || !routerFunctions.includes(node.callee.name)) {
+    return false;
+  }
+  return isImportedFromMionRouter(node.callee.name, context);
+}
+function isImportedFromMionRouter(name, context) {
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === utils.AST_NODE_TYPES.ImportDeclaration) {
+      const source = statement.source.value;
+      if (source === "@mionkit/router" || source === "@mionkit/router/") {
+        for (const specifier of statement.specifiers) {
+          if (specifier.type === utils.AST_NODE_TYPES.ImportSpecifier && specifier.imported.type === utils.AST_NODE_TYPES.Identifier && specifier.imported.name === name) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+function checkFunction(func, context) {
+  if (!isRouterFunction(func, context)) return;
+  const unionType = getReturnTypeAnnotation(func, context);
+  if (!unionType) return;
+  const unionTypes = getUnionObjectTypes(unionType);
+  if (unionTypes.length < 2) return;
+  const returnStatements = findReturnStatements(func);
+  for (const returnNode of returnStatements) {
+    if (returnNode.type !== utils.AST_NODE_TYPES.ObjectExpression) continue;
+    const objectProps = getObjectLiteralPropertyNames(returnNode);
+    if (objectProps.length === 0) continue;
+    const matchingIndices = getMatchingUnionTypes(objectProps, unionTypes);
+    const uniqueProps = getUniquePropertiesPerType(unionTypes);
+    const typesWithUniqueMatches = matchingIndices.filter((idx) => {
+      const unique = uniqueProps.get(idx) || /* @__PURE__ */ new Set();
+      return objectProps.some((prop) => unique.has(prop));
+    });
+    if (typesWithUniqueMatches.length > 1) {
+      const conflicts = getConflictDescription(objectProps, unionTypes, typesWithUniqueMatches);
+      context.report({ node: returnNode, messageId: "mixedUnionProperties", data: { conflicts } });
+    }
+  }
+}
+const rule = {
+  meta: {
+    type: "problem",
+    docs: { description: "Detect object literals with properties from multiple union types in router handlers" },
+    messages: {
+      mixedUnionProperties: "Object literal has properties from multiple union types: {{conflicts}}. With loose union matching, only the first matching type will be used for serialization."
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ArrowFunctionExpression(node) {
+        checkFunction(node, context);
+      },
+      FunctionExpression(node) {
+        checkFunction(node, context);
+      },
+      FunctionDeclaration(node) {
+        checkFunction(node, context);
+      }
+    };
+  }
+};
+module.exports = rule;

--- a/packages/eslint-plugin/build/cjs/rules/no-unreachable-union-types.js
+++ b/packages/eslint-plugin/build/cjs/rules/no-unreachable-union-types.js
@@ -185,7 +185,7 @@ const rule = {
         const issues = findUnreachableTypes(node);
         for (const issue of issues) {
           context.report({
-            node: issue.unreachable,
+            node,
             messageId: "unreachableUnionType",
             data: {
               unreachableType: getTypeDescription(issue.unreachable),
@@ -205,7 +205,7 @@ const rule = {
         const issues = findUnreachableTypes(unionType);
         for (const issue of issues) {
           context.report({
-            node: issue.unreachable,
+            node,
             messageId: "unreachableUnionType",
             data: {
               unreachableType: getTypeDescription(issue.unreachable),

--- a/packages/eslint-plugin/build/cjs/rules/no-unreachable-union-types.js
+++ b/packages/eslint-plugin/build/cjs/rules/no-unreachable-union-types.js
@@ -1,0 +1,220 @@
+"use strict";
+const utils = require("@typescript-eslint/utils");
+function getObjectTypeProperties(node) {
+  if (node.type === utils.AST_NODE_TYPES.TSTypeLiteral) {
+    const props = [];
+    for (const member of node.members) {
+      if (member.type === utils.AST_NODE_TYPES.TSPropertySignature && member.key.type === utils.AST_NODE_TYPES.Identifier) {
+        props.push({ name: member.key.name, isOptional: !!member.optional });
+      }
+    }
+    return props;
+  }
+  return null;
+}
+function isSupersetOf(typeAProps, typeBProps) {
+  const typeARequired = typeAProps.filter((p) => !p.isOptional);
+  const typeBRequired = typeBProps.filter((p) => !p.isOptional);
+  if (typeARequired.length < typeBRequired.length) return false;
+  const isMoreSpecific = typeAProps.length > typeBProps.length || typeAProps.length === typeBProps.length && typeARequired.length > typeBRequired.length;
+  if (!isMoreSpecific) return false;
+  for (const propB of typeBProps) {
+    const propA = typeAProps.find((p) => p.name === propB.name);
+    if (!propA) return false;
+  }
+  return true;
+}
+function findUnreachableTypes(unionNode) {
+  const issues = [];
+  const typesWithProps = [];
+  for (const typeNode of unionNode.types) {
+    const props = getObjectTypeProperties(typeNode);
+    if (props && props.length > 0) {
+      typesWithProps.push({ node: typeNode, props });
+    }
+  }
+  for (let i = 0; i < typesWithProps.length; i++) {
+    for (let j = i + 1; j < typesWithProps.length; j++) {
+      const typeA = typesWithProps[i];
+      const typeB = typesWithProps[j];
+      if (isSupersetOf(typeB.props, typeA.props)) {
+        issues.push({ unreachable: typeB.node, blocker: typeA.node });
+      }
+    }
+  }
+  return issues;
+}
+function getTypeDescription(node) {
+  if (node.type === utils.AST_NODE_TYPES.TSTypeLiteral) {
+    const props = getObjectTypeProperties(node);
+    if (props) {
+      return `{${props.map((p) => p.isOptional ? `${p.name}?` : p.name).join(", ")}}`;
+    }
+  }
+  return "object type";
+}
+function getRouterFunctionName(func, context) {
+  const parent = func.parent;
+  if ((parent == null ? void 0 : parent.type) === utils.AST_NODE_TYPES.CallExpression) {
+    if (parent.callee.type === utils.AST_NODE_TYPES.Identifier) {
+      const functionName = parent.callee.name;
+      if (["route", "hook", "headersHook"].includes(functionName) && isImportedFromMionRouter(functionName, context)) {
+        return functionName;
+      }
+    }
+  }
+  return null;
+}
+function isInCheckableParameter(node, func, routerFunctionName) {
+  let current = node.parent;
+  while (current && current !== func) {
+    if (current.type === utils.AST_NODE_TYPES.Identifier || current.type === utils.AST_NODE_TYPES.ArrayPattern || current.type === utils.AST_NODE_TYPES.ObjectPattern) {
+      const paramIndex = func.params.indexOf(current);
+      if (paramIndex !== -1) {
+        if ((routerFunctionName === "route" || routerFunctionName === "hook") && paramIndex >= 1) {
+          return true;
+        }
+        if (routerFunctionName === "headersHook" && paramIndex >= 2) {
+          return true;
+        }
+        return false;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+function isRouterUnionType(node, context) {
+  var _a, _b;
+  let current = node.parent;
+  while (current) {
+    if (current.type === utils.AST_NODE_TYPES.ArrowFunctionExpression || current.type === utils.AST_NODE_TYPES.FunctionExpression || current.type === utils.AST_NODE_TYPES.FunctionDeclaration) {
+      const routerFunctionName = getRouterFunctionName(current, context);
+      if (routerFunctionName) {
+        if (((_a = current.returnType) == null ? void 0 : _a.typeAnnotation) === node || isDescendantOf(node, (_b = current.returnType) == null ? void 0 : _b.typeAnnotation)) {
+          return true;
+        }
+        if (isInCheckableParameter(node, current, routerFunctionName)) {
+          return true;
+        }
+      }
+    }
+    if (current.type === utils.AST_NODE_TYPES.TSTypeAnnotation) {
+      const typeAnnotationParent = current.parent;
+      if ((typeAnnotationParent == null ? void 0 : typeAnnotationParent.type) === utils.AST_NODE_TYPES.Identifier) {
+        const declarator = typeAnnotationParent.parent;
+        if ((declarator == null ? void 0 : declarator.type) === utils.AST_NODE_TYPES.VariableDeclarator) {
+          if (current.typeAnnotation.type === utils.AST_NODE_TYPES.TSTypeReference) {
+            const typeName = current.typeAnnotation.typeName;
+            if (typeName.type === utils.AST_NODE_TYPES.Identifier) {
+              if ((typeName.name === "Handler" || typeName.name === "HeaderHandler") && isImportedFromMionRouter(typeName.name, context)) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+function isDescendantOf(node, ancestor) {
+  if (!node || !ancestor) return false;
+  let current = node;
+  while (current) {
+    if (current === ancestor) return true;
+    current = current.parent;
+  }
+  return false;
+}
+function isImportedFromMionRouter(name, context) {
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === utils.AST_NODE_TYPES.ImportDeclaration) {
+      const source = statement.source.value;
+      if (source === "@mionkit/router" || source === "@mionkit/router/") {
+        for (const specifier of statement.specifiers) {
+          if (specifier.type === utils.AST_NODE_TYPES.ImportSpecifier && specifier.imported.type === utils.AST_NODE_TYPES.Identifier && specifier.imported.name === name) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+function resolveTypeReference(node, context) {
+  if (node.type !== utils.AST_NODE_TYPES.TSTypeReference) {
+    return null;
+  }
+  if (node.typeName.type !== utils.AST_NODE_TYPES.Identifier) {
+    return null;
+  }
+  const typeName = node.typeName.name;
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === utils.AST_NODE_TYPES.TSTypeAliasDeclaration) {
+      if (statement.id.name === typeName && statement.typeAnnotation.type === utils.AST_NODE_TYPES.TSUnionType) {
+        return statement.typeAnnotation;
+      }
+    }
+  }
+  return null;
+}
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Detect union types where one interface is unreachable at runtime when using isType function because a subset type comes before it"
+    },
+    messages: {
+      unreachableUnionType: "Union type {{unreachableType}} is unreachable at runtime when doing type checking because {{blockerType}} will always match first. To fix this move the more specific type {{unreachableType}} first within the union, ie: {{unreachableType}} | {{blockerType}} "
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      TSUnionType(node) {
+        if (!isRouterUnionType(node, context)) {
+          return;
+        }
+        const issues = findUnreachableTypes(node);
+        for (const issue of issues) {
+          context.report({
+            node: issue.unreachable,
+            messageId: "unreachableUnionType",
+            data: {
+              unreachableType: getTypeDescription(issue.unreachable),
+              blockerType: getTypeDescription(issue.blocker)
+            }
+          });
+        }
+      },
+      TSTypeReference(node) {
+        const unionType = resolveTypeReference(node, context);
+        if (!unionType) {
+          return;
+        }
+        if (!isRouterUnionType(node, context)) {
+          return;
+        }
+        const issues = findUnreachableTypes(unionType);
+        for (const issue of issues) {
+          context.report({
+            node: issue.unreachable,
+            messageId: "unreachableUnionType",
+            data: {
+              unreachableType: getTypeDescription(issue.unreachable),
+              blockerType: getTypeDescription(issue.blocker)
+            }
+          });
+        }
+      }
+    };
+  }
+};
+module.exports = rule;

--- a/packages/eslint-plugin/build/cjs/src/index.d.ts
+++ b/packages/eslint-plugin/build/cjs/src/index.d.ts
@@ -2,6 +2,8 @@ declare const plugin: {
     rules: {
         'no-typeof-runtype': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"noTypeof", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
         'strong-typed-routes': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"missingReturnType" | "missingParamTypes" | "missingReturnTypeRouter" | "missingParamTypesRouter", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
+        'no-unreachable-union-types': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"unreachableUnionType", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
+        'no-mixed-union-properties': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"mixedUnionProperties", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
     };
     configs: {
         recommended: {
@@ -9,6 +11,7 @@ declare const plugin: {
             rules: {
                 '@mionkit/no-typeof-runtype': string;
                 '@mionkit/strong-typed-routes': string;
+                '@mionkit/no-unreachable-union-types': string;
             };
         };
     };

--- a/packages/eslint-plugin/build/cjs/src/rules/no-mixed-union-properties.d.ts
+++ b/packages/eslint-plugin/build/cjs/src/rules/no-mixed-union-properties.d.ts
@@ -1,0 +1,3 @@
+import { TSESLint } from '@typescript-eslint/utils';
+declare const rule: TSESLint.RuleModule<'mixedUnionProperties', []>;
+export default rule;

--- a/packages/eslint-plugin/build/cjs/src/rules/no-unreachable-union-types.d.ts
+++ b/packages/eslint-plugin/build/cjs/src/rules/no-unreachable-union-types.d.ts
@@ -1,0 +1,3 @@
+import { TSESLint } from '@typescript-eslint/utils';
+declare const rule: TSESLint.RuleModule<'unreachableUnionType', []>;
+export default rule;

--- a/packages/eslint-plugin/build/esm/index.js
+++ b/packages/eslint-plugin/build/esm/index.js
@@ -1,16 +1,23 @@
-import rule$1 from "./rules/no-typeof-runtype.js";
-import rule from "./rules/strong-typed-routes.js";
+import rule$3 from "./rules/no-typeof-runtype.js";
+import rule$2 from "./rules/strong-typed-routes.js";
+import rule$1 from "./rules/no-unreachable-union-types.js";
+import rule from "./rules/no-mixed-union-properties.js";
 const plugin = {
   rules: {
-    "no-typeof-runtype": rule$1,
-    "strong-typed-routes": rule
+    "no-typeof-runtype": rule$3,
+    "strong-typed-routes": rule$2,
+    "no-unreachable-union-types": rule$1,
+    "no-mixed-union-properties": rule
   },
   configs: {
     recommended: {
       extends: [],
       rules: {
         "@mionkit/no-typeof-runtype": "error",
-        "@mionkit/strong-typed-routes": "error"
+        "@mionkit/strong-typed-routes": "error",
+        "@mionkit/no-unreachable-union-types": "error"
+        // disabled as seems is not too useful and overlaps with some ts rules
+        // '@mionkit/no-mixed-union-properties': 'warn',
       }
     }
   }

--- a/packages/eslint-plugin/build/esm/rules/no-mixed-union-properties.js
+++ b/packages/eslint-plugin/build/esm/rules/no-mixed-union-properties.js
@@ -1,0 +1,222 @@
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+function getObjectTypeProperties(node) {
+  if (node.type === AST_NODE_TYPES.TSTypeLiteral) {
+    const props = [];
+    for (const member of node.members) {
+      if (member.type === AST_NODE_TYPES.TSPropertySignature && member.key.type === AST_NODE_TYPES.Identifier) {
+        props.push({ name: member.key.name, isOptional: !!member.optional });
+      }
+    }
+    return props;
+  }
+  return null;
+}
+function getUnionObjectTypes(unionNode) {
+  const types = [];
+  for (const typeNode of unionNode.types) {
+    const props = getObjectTypeProperties(typeNode);
+    if (props && props.length > 0) {
+      types.push({ node: typeNode, properties: props });
+    }
+  }
+  return types;
+}
+function getObjectLiteralPropertyNames(node) {
+  const names = [];
+  for (const prop of node.properties) {
+    if (prop.type === AST_NODE_TYPES.Property && prop.key.type === AST_NODE_TYPES.Identifier) {
+      names.push(prop.key.name);
+    }
+  }
+  return names;
+}
+function getMatchingUnionTypes(objectProps, unionTypes) {
+  const matchingIndices = [];
+  for (let i = 0; i < unionTypes.length; i++) {
+    const unionPropNames = new Set(unionTypes[i].properties.map((p) => p.name));
+    if (objectProps.some((prop) => unionPropNames.has(prop))) {
+      matchingIndices.push(i);
+    }
+  }
+  return matchingIndices;
+}
+function getUniquePropertiesPerType(unionTypes) {
+  const allProps = /* @__PURE__ */ new Map();
+  for (let i = 0; i < unionTypes.length; i++) {
+    for (const prop of unionTypes[i].properties) {
+      const existing = allProps.get(prop.name) || [];
+      existing.push(i);
+      allProps.set(prop.name, existing);
+    }
+  }
+  const uniqueProps = /* @__PURE__ */ new Map();
+  for (let i = 0; i < unionTypes.length; i++) {
+    const unique = /* @__PURE__ */ new Set();
+    for (const prop of unionTypes[i].properties) {
+      if ((allProps.get(prop.name) || []).length === 1) {
+        unique.add(prop.name);
+      }
+    }
+    uniqueProps.set(i, unique);
+  }
+  return uniqueProps;
+}
+function resolveTypeReference(node, context) {
+  if (node.type !== AST_NODE_TYPES.TSTypeReference) {
+    return null;
+  }
+  if (node.typeName.type !== AST_NODE_TYPES.Identifier) {
+    return null;
+  }
+  const typeName = node.typeName.name;
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === AST_NODE_TYPES.TSTypeAliasDeclaration) {
+      if (statement.id.name === typeName && statement.typeAnnotation.type === AST_NODE_TYPES.TSUnionType) {
+        return statement.typeAnnotation;
+      }
+    }
+  }
+  return null;
+}
+function getReturnTypeAnnotation(func, context) {
+  var _a;
+  const returnType = (_a = func.returnType) == null ? void 0 : _a.typeAnnotation;
+  if (!returnType) {
+    return null;
+  }
+  if (returnType.type === AST_NODE_TYPES.TSUnionType) {
+    return returnType;
+  }
+  if (returnType.type === AST_NODE_TYPES.TSTypeReference) {
+    return resolveTypeReference(returnType, context);
+  }
+  return null;
+}
+function findReturnStatements(func) {
+  const returns = [];
+  if (func.type === AST_NODE_TYPES.ArrowFunctionExpression && func.expression && func.body.type !== AST_NODE_TYPES.BlockStatement) {
+    returns.push(func.body);
+    return returns;
+  }
+  if (func.body.type === AST_NODE_TYPES.BlockStatement) {
+    findReturnsInBlock(func.body, returns);
+  }
+  return returns;
+}
+function findReturnsInBlock(block, returns) {
+  var _a, _b;
+  for (const statement of block.body) {
+    if (statement.type === AST_NODE_TYPES.ReturnStatement && statement.argument) {
+      returns.push(statement.argument);
+    } else if (statement.type === AST_NODE_TYPES.IfStatement) {
+      if (statement.consequent.type === AST_NODE_TYPES.BlockStatement) {
+        findReturnsInBlock(statement.consequent, returns);
+      } else if (statement.consequent.type === AST_NODE_TYPES.ReturnStatement && statement.consequent.argument) {
+        returns.push(statement.consequent.argument);
+      }
+      if (((_a = statement.alternate) == null ? void 0 : _a.type) === AST_NODE_TYPES.BlockStatement) {
+        findReturnsInBlock(statement.alternate, returns);
+      } else if (((_b = statement.alternate) == null ? void 0 : _b.type) === AST_NODE_TYPES.ReturnStatement && statement.alternate.argument) {
+        returns.push(statement.alternate.argument);
+      }
+    }
+  }
+}
+function getConflictDescription(objectProps, unionTypes, matchingIndices) {
+  const uniqueProps = getUniquePropertiesPerType(unionTypes);
+  const conflicts = [];
+  for (const idx of matchingIndices) {
+    const unique = uniqueProps.get(idx) || /* @__PURE__ */ new Set();
+    const matchingProps = objectProps.filter((p) => unique.has(p));
+    if (matchingProps.length > 0) {
+      conflicts.push(`'${matchingProps.join("', '")}' from type ${idx + 1}`);
+    }
+  }
+  return conflicts.join(" and ");
+}
+function isRouterFunction(node, context) {
+  let current = node;
+  while (current) {
+    if (current.type === AST_NODE_TYPES.CallExpression) {
+      return isRouterFunctionCall(current, context);
+    }
+    current = current.parent;
+  }
+  return false;
+}
+function isRouterFunctionCall(node, context) {
+  const routerFunctions = ["route", "hook", "headersHook"];
+  if (node.callee.type !== AST_NODE_TYPES.Identifier || !routerFunctions.includes(node.callee.name)) {
+    return false;
+  }
+  return isImportedFromMionRouter(node.callee.name, context);
+}
+function isImportedFromMionRouter(name, context) {
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === AST_NODE_TYPES.ImportDeclaration) {
+      const source = statement.source.value;
+      if (source === "@mionkit/router" || source === "@mionkit/router/") {
+        for (const specifier of statement.specifiers) {
+          if (specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.imported.type === AST_NODE_TYPES.Identifier && specifier.imported.name === name) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+function checkFunction(func, context) {
+  if (!isRouterFunction(func, context)) return;
+  const unionType = getReturnTypeAnnotation(func, context);
+  if (!unionType) return;
+  const unionTypes = getUnionObjectTypes(unionType);
+  if (unionTypes.length < 2) return;
+  const returnStatements = findReturnStatements(func);
+  for (const returnNode of returnStatements) {
+    if (returnNode.type !== AST_NODE_TYPES.ObjectExpression) continue;
+    const objectProps = getObjectLiteralPropertyNames(returnNode);
+    if (objectProps.length === 0) continue;
+    const matchingIndices = getMatchingUnionTypes(objectProps, unionTypes);
+    const uniqueProps = getUniquePropertiesPerType(unionTypes);
+    const typesWithUniqueMatches = matchingIndices.filter((idx) => {
+      const unique = uniqueProps.get(idx) || /* @__PURE__ */ new Set();
+      return objectProps.some((prop) => unique.has(prop));
+    });
+    if (typesWithUniqueMatches.length > 1) {
+      const conflicts = getConflictDescription(objectProps, unionTypes, typesWithUniqueMatches);
+      context.report({ node: returnNode, messageId: "mixedUnionProperties", data: { conflicts } });
+    }
+  }
+}
+const rule = {
+  meta: {
+    type: "problem",
+    docs: { description: "Detect object literals with properties from multiple union types in router handlers" },
+    messages: {
+      mixedUnionProperties: "Object literal has properties from multiple union types: {{conflicts}}. With loose union matching, only the first matching type will be used for serialization."
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ArrowFunctionExpression(node) {
+        checkFunction(node, context);
+      },
+      FunctionExpression(node) {
+        checkFunction(node, context);
+      },
+      FunctionDeclaration(node) {
+        checkFunction(node, context);
+      }
+    };
+  }
+};
+export {
+  rule as default
+};

--- a/packages/eslint-plugin/build/esm/rules/no-unreachable-union-types.js
+++ b/packages/eslint-plugin/build/esm/rules/no-unreachable-union-types.js
@@ -184,7 +184,7 @@ const rule = {
         const issues = findUnreachableTypes(node);
         for (const issue of issues) {
           context.report({
-            node: issue.unreachable,
+            node,
             messageId: "unreachableUnionType",
             data: {
               unreachableType: getTypeDescription(issue.unreachable),
@@ -204,7 +204,7 @@ const rule = {
         const issues = findUnreachableTypes(unionType);
         for (const issue of issues) {
           context.report({
-            node: issue.unreachable,
+            node,
             messageId: "unreachableUnionType",
             data: {
               unreachableType: getTypeDescription(issue.unreachable),

--- a/packages/eslint-plugin/build/esm/rules/no-unreachable-union-types.js
+++ b/packages/eslint-plugin/build/esm/rules/no-unreachable-union-types.js
@@ -1,0 +1,221 @@
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+function getObjectTypeProperties(node) {
+  if (node.type === AST_NODE_TYPES.TSTypeLiteral) {
+    const props = [];
+    for (const member of node.members) {
+      if (member.type === AST_NODE_TYPES.TSPropertySignature && member.key.type === AST_NODE_TYPES.Identifier) {
+        props.push({ name: member.key.name, isOptional: !!member.optional });
+      }
+    }
+    return props;
+  }
+  return null;
+}
+function isSupersetOf(typeAProps, typeBProps) {
+  const typeARequired = typeAProps.filter((p) => !p.isOptional);
+  const typeBRequired = typeBProps.filter((p) => !p.isOptional);
+  if (typeARequired.length < typeBRequired.length) return false;
+  const isMoreSpecific = typeAProps.length > typeBProps.length || typeAProps.length === typeBProps.length && typeARequired.length > typeBRequired.length;
+  if (!isMoreSpecific) return false;
+  for (const propB of typeBProps) {
+    const propA = typeAProps.find((p) => p.name === propB.name);
+    if (!propA) return false;
+  }
+  return true;
+}
+function findUnreachableTypes(unionNode) {
+  const issues = [];
+  const typesWithProps = [];
+  for (const typeNode of unionNode.types) {
+    const props = getObjectTypeProperties(typeNode);
+    if (props && props.length > 0) {
+      typesWithProps.push({ node: typeNode, props });
+    }
+  }
+  for (let i = 0; i < typesWithProps.length; i++) {
+    for (let j = i + 1; j < typesWithProps.length; j++) {
+      const typeA = typesWithProps[i];
+      const typeB = typesWithProps[j];
+      if (isSupersetOf(typeB.props, typeA.props)) {
+        issues.push({ unreachable: typeB.node, blocker: typeA.node });
+      }
+    }
+  }
+  return issues;
+}
+function getTypeDescription(node) {
+  if (node.type === AST_NODE_TYPES.TSTypeLiteral) {
+    const props = getObjectTypeProperties(node);
+    if (props) {
+      return `{${props.map((p) => p.isOptional ? `${p.name}?` : p.name).join(", ")}}`;
+    }
+  }
+  return "object type";
+}
+function getRouterFunctionName(func, context) {
+  const parent = func.parent;
+  if ((parent == null ? void 0 : parent.type) === AST_NODE_TYPES.CallExpression) {
+    if (parent.callee.type === AST_NODE_TYPES.Identifier) {
+      const functionName = parent.callee.name;
+      if (["route", "hook", "headersHook"].includes(functionName) && isImportedFromMionRouter(functionName, context)) {
+        return functionName;
+      }
+    }
+  }
+  return null;
+}
+function isInCheckableParameter(node, func, routerFunctionName) {
+  let current = node.parent;
+  while (current && current !== func) {
+    if (current.type === AST_NODE_TYPES.Identifier || current.type === AST_NODE_TYPES.ArrayPattern || current.type === AST_NODE_TYPES.ObjectPattern) {
+      const paramIndex = func.params.indexOf(current);
+      if (paramIndex !== -1) {
+        if ((routerFunctionName === "route" || routerFunctionName === "hook") && paramIndex >= 1) {
+          return true;
+        }
+        if (routerFunctionName === "headersHook" && paramIndex >= 2) {
+          return true;
+        }
+        return false;
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+function isRouterUnionType(node, context) {
+  var _a, _b;
+  let current = node.parent;
+  while (current) {
+    if (current.type === AST_NODE_TYPES.ArrowFunctionExpression || current.type === AST_NODE_TYPES.FunctionExpression || current.type === AST_NODE_TYPES.FunctionDeclaration) {
+      const routerFunctionName = getRouterFunctionName(current, context);
+      if (routerFunctionName) {
+        if (((_a = current.returnType) == null ? void 0 : _a.typeAnnotation) === node || isDescendantOf(node, (_b = current.returnType) == null ? void 0 : _b.typeAnnotation)) {
+          return true;
+        }
+        if (isInCheckableParameter(node, current, routerFunctionName)) {
+          return true;
+        }
+      }
+    }
+    if (current.type === AST_NODE_TYPES.TSTypeAnnotation) {
+      const typeAnnotationParent = current.parent;
+      if ((typeAnnotationParent == null ? void 0 : typeAnnotationParent.type) === AST_NODE_TYPES.Identifier) {
+        const declarator = typeAnnotationParent.parent;
+        if ((declarator == null ? void 0 : declarator.type) === AST_NODE_TYPES.VariableDeclarator) {
+          if (current.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference) {
+            const typeName = current.typeAnnotation.typeName;
+            if (typeName.type === AST_NODE_TYPES.Identifier) {
+              if ((typeName.name === "Handler" || typeName.name === "HeaderHandler") && isImportedFromMionRouter(typeName.name, context)) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
+    current = current.parent;
+  }
+  return false;
+}
+function isDescendantOf(node, ancestor) {
+  if (!node || !ancestor) return false;
+  let current = node;
+  while (current) {
+    if (current === ancestor) return true;
+    current = current.parent;
+  }
+  return false;
+}
+function isImportedFromMionRouter(name, context) {
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === AST_NODE_TYPES.ImportDeclaration) {
+      const source = statement.source.value;
+      if (source === "@mionkit/router" || source === "@mionkit/router/") {
+        for (const specifier of statement.specifiers) {
+          if (specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.imported.type === AST_NODE_TYPES.Identifier && specifier.imported.name === name) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+function resolveTypeReference(node, context) {
+  if (node.type !== AST_NODE_TYPES.TSTypeReference) {
+    return null;
+  }
+  if (node.typeName.type !== AST_NODE_TYPES.Identifier) {
+    return null;
+  }
+  const typeName = node.typeName.name;
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  for (const statement of program.body) {
+    if (statement.type === AST_NODE_TYPES.TSTypeAliasDeclaration) {
+      if (statement.id.name === typeName && statement.typeAnnotation.type === AST_NODE_TYPES.TSUnionType) {
+        return statement.typeAnnotation;
+      }
+    }
+  }
+  return null;
+}
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Detect union types where one interface is unreachable at runtime when using isType function because a subset type comes before it"
+    },
+    messages: {
+      unreachableUnionType: "Union type {{unreachableType}} is unreachable at runtime when doing type checking because {{blockerType}} will always match first. To fix this move the more specific type {{unreachableType}} first within the union, ie: {{unreachableType}} | {{blockerType}} "
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      TSUnionType(node) {
+        if (!isRouterUnionType(node, context)) {
+          return;
+        }
+        const issues = findUnreachableTypes(node);
+        for (const issue of issues) {
+          context.report({
+            node: issue.unreachable,
+            messageId: "unreachableUnionType",
+            data: {
+              unreachableType: getTypeDescription(issue.unreachable),
+              blockerType: getTypeDescription(issue.blocker)
+            }
+          });
+        }
+      },
+      TSTypeReference(node) {
+        const unionType = resolveTypeReference(node, context);
+        if (!unionType) {
+          return;
+        }
+        if (!isRouterUnionType(node, context)) {
+          return;
+        }
+        const issues = findUnreachableTypes(unionType);
+        for (const issue of issues) {
+          context.report({
+            node: issue.unreachable,
+            messageId: "unreachableUnionType",
+            data: {
+              unreachableType: getTypeDescription(issue.unreachable),
+              blockerType: getTypeDescription(issue.blocker)
+            }
+          });
+        }
+      }
+    };
+  }
+};
+export {
+  rule as default
+};

--- a/packages/eslint-plugin/build/esm/src/index.d.ts
+++ b/packages/eslint-plugin/build/esm/src/index.d.ts
@@ -2,6 +2,8 @@ declare const plugin: {
     rules: {
         'no-typeof-runtype': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"noTypeof", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
         'strong-typed-routes': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"missingReturnType" | "missingParamTypes" | "missingReturnTypeRouter" | "missingParamTypesRouter", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
+        'no-unreachable-union-types': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"unreachableUnionType", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
+        'no-mixed-union-properties': import('@typescript-eslint/utils/dist/ts-eslint').RuleModule<"mixedUnionProperties", [], unknown, import('@typescript-eslint/utils/dist/ts-eslint').RuleListener>;
     };
     configs: {
         recommended: {
@@ -9,6 +11,7 @@ declare const plugin: {
             rules: {
                 '@mionkit/no-typeof-runtype': string;
                 '@mionkit/strong-typed-routes': string;
+                '@mionkit/no-unreachable-union-types': string;
             };
         };
     };

--- a/packages/eslint-plugin/build/esm/src/rules/no-mixed-union-properties.d.ts
+++ b/packages/eslint-plugin/build/esm/src/rules/no-mixed-union-properties.d.ts
@@ -1,0 +1,3 @@
+import { TSESLint } from '@typescript-eslint/utils';
+declare const rule: TSESLint.RuleModule<'mixedUnionProperties', []>;
+export default rule;

--- a/packages/eslint-plugin/build/esm/src/rules/no-unreachable-union-types.d.ts
+++ b/packages/eslint-plugin/build/esm/src/rules/no-unreachable-union-types.d.ts
@@ -1,0 +1,3 @@
+import { TSESLint } from '@typescript-eslint/utils';
+declare const rule: TSESLint.RuleModule<'unreachableUnionType', []>;
+export default rule;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,11 +7,13 @@
 
 import noTypeofRunType from './rules/no-typeof-runtype';
 import strongTypedRoutes from './rules/strong-typed-routes';
+import noUnreachableUnionTypes from './rules/no-unreachable-union-types';
 
 const plugin = {
     rules: {
         'no-typeof-runtype': noTypeofRunType,
         'strong-typed-routes': strongTypedRoutes,
+        'no-unreachable-union-types': noUnreachableUnionTypes,
     },
     configs: {
         recommended: {
@@ -19,6 +21,7 @@ const plugin = {
             rules: {
                 '@mionkit/no-typeof-runtype': 'error',
                 '@mionkit/strong-typed-routes': 'error',
+                '@mionkit/no-unreachable-union-types': 'warn',
             },
         },
     },

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -24,7 +24,8 @@ const plugin = {
                 '@mionkit/no-typeof-runtype': 'error',
                 '@mionkit/strong-typed-routes': 'error',
                 '@mionkit/no-unreachable-union-types': 'error',
-                '@mionkit/no-mixed-union-properties': 'warn',
+                // disabled as seems is not too useful and overlaps with some ts rules
+                // '@mionkit/no-mixed-union-properties': 'warn',
             },
         },
     },

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -8,12 +8,14 @@
 import noTypeofRunType from './rules/no-typeof-runtype';
 import strongTypedRoutes from './rules/strong-typed-routes';
 import noUnreachableUnionTypes from './rules/no-unreachable-union-types';
+import noMixedUnionProperties from './rules/no-mixed-union-properties';
 
 const plugin = {
     rules: {
         'no-typeof-runtype': noTypeofRunType,
         'strong-typed-routes': strongTypedRoutes,
         'no-unreachable-union-types': noUnreachableUnionTypes,
+        'no-mixed-union-properties': noMixedUnionProperties,
     },
     configs: {
         recommended: {
@@ -22,6 +24,7 @@ const plugin = {
                 '@mionkit/no-typeof-runtype': 'error',
                 '@mionkit/strong-typed-routes': 'error',
                 '@mionkit/no-unreachable-union-types': 'warn',
+                '@mionkit/no-mixed-union-properties': 'warn',
             },
         },
     },

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -23,7 +23,7 @@ const plugin = {
             rules: {
                 '@mionkit/no-typeof-runtype': 'error',
                 '@mionkit/strong-typed-routes': 'error',
-                '@mionkit/no-unreachable-union-types': 'warn',
+                '@mionkit/no-unreachable-union-types': 'error',
                 '@mionkit/no-mixed-union-properties': 'warn',
             },
         },

--- a/packages/eslint-plugin/src/rules/no-mixed-union-properties.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-union-properties.spec.ts
@@ -120,5 +120,46 @@ ruleTester.run('no-mixed-union-properties', rule, {
             `,
             errors: [{messageId: 'mixedUnionProperties'}, {messageId: 'mixedUnionProperties'}],
         },
+        // Type alias with mixed properties in return
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type MixedResult = {success: true; data: string} | {success: false; error: string};
+                route((ctx): MixedResult => ({success: true, data: 'ok', error: 'also has error'}));
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}],
+        },
+        // Type alias with unique properties from different union types
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type UserOrProduct = {userId: string; userName: string} | {productId: string; productName: string};
+                route((ctx): UserOrProduct => ({userId: '1', productId: '2'}));
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}],
+        },
+        // Type alias with multiple mixed returns in conditional
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type Status = {active: boolean; lastSeen: Date} | {active: boolean; reason: string};
+                route((ctx): Status => {
+                    if (Math.random() > 0.5) {
+                        return {active: true, lastSeen: new Date(), reason: 'mixed'};
+                    }
+                    return {active: false, lastSeen: new Date(), reason: 'also mixed'};
+                });
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}, {messageId: 'mixedUnionProperties'}],
+        },
+        // Type alias with hook and mixed properties
+        {
+            code: `
+                import { hook } from '@mionkit/router';
+                type HookData = {name: string} | {age: number};
+                hook((ctx): HookData => ({name: 'John', age: 25}));
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}],
+        },
     ],
 });

--- a/packages/eslint-plugin/src/rules/no-mixed-union-properties.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-union-properties.spec.ts
@@ -1,0 +1,124 @@
+/* ########
+ * 2024 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {RuleTester} from 'eslint';
+import rule from './no-mixed-union-properties';
+
+const ruleTester = new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('no-mixed-union-properties', rule, {
+    valid: [
+        // Return object matching single union type
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {b: number} => ({a: 'hello'}));
+            `,
+        },
+        // Return object matching single union type (second type)
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {b: number} => ({b: 123}));
+            `,
+        },
+        // Non-router function (should not be checked)
+        {
+            code: `
+                const fn = (): {a: string} | {b: number} => ({a: 'hello', b: 123});
+            `,
+        },
+        // Import from different package (should not be checked)
+        {
+            code: `
+                import { route } from 'other-package';
+                route((ctx): {a: string} | {b: number} => ({a: 'hello', b: 123}));
+            `,
+        },
+        // Union with atomic types only
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): string | number | boolean => 'hello');
+            `,
+        },
+        // Object with shared properties only (no unique properties from multiple types)
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string; b: number} | {a: string; c: boolean} => ({a: 'hello'}));
+            `,
+        },
+        // Block statement with single-type returns
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {b: number} => {
+                    if (Math.random() > 0.5) {
+                        return {a: 'hello'};
+                    }
+                    return {b: 123};
+                });
+            `,
+        },
+    ],
+    invalid: [
+        // Return object with properties from multiple union types
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {b: number} => ({a: 'hello', b: 123}));
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}],
+        },
+        // Hook with mixed properties
+        {
+            code: `
+                import { hook } from '@mionkit/router';
+                hook((ctx): {name: string} | {age: number} => ({name: 'John', age: 25}));
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}],
+        },
+        // headersHook with mixed properties
+        {
+            code: `
+                import { headersHook } from '@mionkit/router';
+                headersHook((ctx, [t]: [string]): {valid: boolean} | {userId: string} => ({valid: true, userId: '123'}));
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}],
+        },
+        // Block statement with mixed return
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {b: number} => {
+                    return {a: 'hello', b: 123};
+                });
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}],
+        },
+        // Multiple mixed returns in block statement
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {b: number} => {
+                    if (Math.random() > 0.5) {
+                        return {a: 'hello', b: 123};
+                    }
+                    return {a: 'world', b: 456};
+                });
+            `,
+            errors: [{messageId: 'mixedUnionProperties'}, {messageId: 'mixedUnionProperties'}],
+        },
+    ],
+});

--- a/packages/eslint-plugin/src/rules/no-mixed-union-properties.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-union-properties.ts
@@ -1,0 +1,234 @@
+/* ########
+ * 2024 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {TSESTree, TSESLint, AST_NODE_TYPES} from '@typescript-eslint/utils';
+
+type PropertyInfo = {name: string; isOptional: boolean};
+type UnionTypeInfo = {node: TSESTree.TypeNode; properties: PropertyInfo[]};
+
+function getObjectTypeProperties(node: TSESTree.TypeNode): PropertyInfo[] | null {
+    if (node.type === AST_NODE_TYPES.TSTypeLiteral) {
+        const props: PropertyInfo[] = [];
+        for (const member of node.members) {
+            if (member.type === AST_NODE_TYPES.TSPropertySignature && member.key.type === AST_NODE_TYPES.Identifier) {
+                props.push({name: member.key.name, isOptional: !!member.optional});
+            }
+        }
+        return props;
+    }
+    return null;
+}
+
+function getUnionObjectTypes(unionNode: TSESTree.TSUnionType): UnionTypeInfo[] {
+    const types: UnionTypeInfo[] = [];
+    for (const typeNode of unionNode.types) {
+        const props = getObjectTypeProperties(typeNode);
+        if (props && props.length > 0) {
+            types.push({node: typeNode, properties: props});
+        }
+    }
+    return types;
+}
+
+function getObjectLiteralPropertyNames(node: TSESTree.ObjectExpression): string[] {
+    const names: string[] = [];
+    for (const prop of node.properties) {
+        if (prop.type === AST_NODE_TYPES.Property && prop.key.type === AST_NODE_TYPES.Identifier) {
+            names.push(prop.key.name);
+        }
+    }
+    return names;
+}
+
+function getMatchingUnionTypes(objectProps: string[], unionTypes: UnionTypeInfo[]): number[] {
+    const matchingIndices: number[] = [];
+    for (let i = 0; i < unionTypes.length; i++) {
+        const unionPropNames = new Set(unionTypes[i].properties.map((p) => p.name));
+        if (objectProps.some((prop) => unionPropNames.has(prop))) {
+            matchingIndices.push(i);
+        }
+    }
+    return matchingIndices;
+}
+
+function getUniquePropertiesPerType(unionTypes: UnionTypeInfo[]): Map<number, Set<string>> {
+    const allProps = new Map<string, number[]>();
+    for (let i = 0; i < unionTypes.length; i++) {
+        for (const prop of unionTypes[i].properties) {
+            const existing = allProps.get(prop.name) || [];
+            existing.push(i);
+            allProps.set(prop.name, existing);
+        }
+    }
+    const uniqueProps = new Map<number, Set<string>>();
+    for (let i = 0; i < unionTypes.length; i++) {
+        const unique = new Set<string>();
+        for (const prop of unionTypes[i].properties) {
+            if ((allProps.get(prop.name) || []).length === 1) {
+                unique.add(prop.name);
+            }
+        }
+        uniqueProps.set(i, unique);
+    }
+    return uniqueProps;
+}
+
+function getReturnTypeAnnotation(
+    func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration
+): TSESTree.TSUnionType | null {
+    if (func.returnType?.typeAnnotation?.type === AST_NODE_TYPES.TSUnionType) {
+        return func.returnType.typeAnnotation;
+    }
+    return null;
+}
+
+function findReturnStatements(
+    func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration
+): TSESTree.Node[] {
+    const returns: TSESTree.Node[] = [];
+    if (
+        func.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+        func.expression &&
+        func.body.type !== AST_NODE_TYPES.BlockStatement
+    ) {
+        returns.push(func.body);
+        return returns;
+    }
+    if (func.body.type === AST_NODE_TYPES.BlockStatement) {
+        findReturnsInBlock(func.body, returns);
+    }
+    return returns;
+}
+
+function findReturnsInBlock(block: TSESTree.BlockStatement, returns: TSESTree.Node[]): void {
+    for (const statement of block.body) {
+        if (statement.type === AST_NODE_TYPES.ReturnStatement && statement.argument) {
+            returns.push(statement.argument);
+        } else if (statement.type === AST_NODE_TYPES.IfStatement) {
+            if (statement.consequent.type === AST_NODE_TYPES.BlockStatement) {
+                findReturnsInBlock(statement.consequent, returns);
+            } else if (statement.consequent.type === AST_NODE_TYPES.ReturnStatement && statement.consequent.argument) {
+                returns.push(statement.consequent.argument);
+            }
+            if (statement.alternate?.type === AST_NODE_TYPES.BlockStatement) {
+                findReturnsInBlock(statement.alternate, returns);
+            } else if (statement.alternate?.type === AST_NODE_TYPES.ReturnStatement && statement.alternate.argument) {
+                returns.push(statement.alternate.argument);
+            }
+        }
+    }
+}
+
+function getConflictDescription(objectProps: string[], unionTypes: UnionTypeInfo[], matchingIndices: number[]): string {
+    const uniqueProps = getUniquePropertiesPerType(unionTypes);
+    const conflicts: string[] = [];
+    for (const idx of matchingIndices) {
+        const unique = uniqueProps.get(idx) || new Set();
+        const matchingProps = objectProps.filter((p) => unique.has(p));
+        if (matchingProps.length > 0) {
+            conflicts.push(`'${matchingProps.join("', '")}' from type ${idx + 1}`);
+        }
+    }
+    return conflicts.join(' and ');
+}
+
+function isRouterFunction(node: TSESTree.Node, context: TSESLint.RuleContext<any, any>): boolean {
+    let current: TSESTree.Node | undefined = node;
+    while (current) {
+        if (current.type === AST_NODE_TYPES.CallExpression) {
+            return isRouterFunctionCall(current, context);
+        }
+        current = current.parent;
+    }
+    return false;
+}
+
+function isRouterFunctionCall(node: TSESTree.CallExpression, context: TSESLint.RuleContext<any, any>): boolean {
+    const routerFunctions = ['route', 'hook', 'headersHook'];
+    if (node.callee.type !== AST_NODE_TYPES.Identifier || !routerFunctions.includes(node.callee.name)) {
+        return false;
+    }
+    return isImportedFromMionRouter(node.callee.name, context);
+}
+
+function isImportedFromMionRouter(name: string, context: TSESLint.RuleContext<any, any>): boolean {
+    const sourceCode = context.sourceCode;
+    const program = sourceCode.ast;
+    for (const statement of program.body) {
+        if (statement.type === AST_NODE_TYPES.ImportDeclaration) {
+            const source = statement.source.value;
+            if (source === '@mionkit/router' || source === '@mionkit/router/') {
+                for (const specifier of statement.specifiers) {
+                    if (
+                        specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+                        specifier.imported.type === AST_NODE_TYPES.Identifier &&
+                        specifier.imported.name === name
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+function checkFunction(
+    func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration,
+    context: TSESLint.RuleContext<'mixedUnionProperties', []>
+) {
+    if (!isRouterFunction(func, context)) return;
+    const unionType = getReturnTypeAnnotation(func);
+    if (!unionType) return;
+    const unionTypes = getUnionObjectTypes(unionType);
+    if (unionTypes.length < 2) return;
+    const returnStatements = findReturnStatements(func);
+    for (const returnNode of returnStatements) {
+        if (returnNode.type !== AST_NODE_TYPES.ObjectExpression) continue;
+        const objectProps = getObjectLiteralPropertyNames(returnNode);
+        if (objectProps.length === 0) continue;
+        const matchingIndices = getMatchingUnionTypes(objectProps, unionTypes);
+        const uniqueProps = getUniquePropertiesPerType(unionTypes);
+        const typesWithUniqueMatches = matchingIndices.filter((idx) => {
+            const unique = uniqueProps.get(idx) || new Set();
+            return objectProps.some((prop) => unique.has(prop));
+        });
+        if (typesWithUniqueMatches.length > 1) {
+            const conflicts = getConflictDescription(objectProps, unionTypes, typesWithUniqueMatches);
+            context.report({node: returnNode, messageId: 'mixedUnionProperties', data: {conflicts}});
+        }
+    }
+}
+
+const rule: TSESLint.RuleModule<'mixedUnionProperties', []> = {
+    meta: {
+        type: 'problem',
+        docs: {description: 'Detect object literals with properties from multiple union types in router handlers'},
+        messages: {
+            mixedUnionProperties:
+                'Object literal has properties from multiple union types: {{conflicts}}. ' +
+                'With loose union matching, only the first matching type will be used for serialization.',
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        return {
+            ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression) {
+                checkFunction(node, context);
+            },
+            FunctionExpression(node: TSESTree.FunctionExpression) {
+                checkFunction(node, context);
+            },
+            FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+                checkFunction(node, context);
+            },
+        };
+    },
+};
+
+export default rule;

--- a/packages/eslint-plugin/src/rules/no-mixed-union-properties.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-union-properties.ts
@@ -77,12 +77,54 @@ function getUniquePropertiesPerType(unionTypes: UnionTypeInfo[]): Map<number, Se
     return uniqueProps;
 }
 
-function getReturnTypeAnnotation(
-    func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration
-): TSESTree.TSUnionType | null {
-    if (func.returnType?.typeAnnotation?.type === AST_NODE_TYPES.TSUnionType) {
-        return func.returnType.typeAnnotation;
+/**
+ * Resolves a type reference to its actual union type definition
+ */
+function resolveTypeReference(node: TSESTree.TypeNode, context: TSESLint.RuleContext<any, any>): TSESTree.TSUnionType | null {
+    if (node.type !== AST_NODE_TYPES.TSTypeReference) {
+        return null;
     }
+
+    // Get the type name
+    if (node.typeName.type !== AST_NODE_TYPES.Identifier) {
+        return null;
+    }
+
+    const typeName = node.typeName.name;
+    const sourceCode = context.sourceCode;
+    const program = sourceCode.ast;
+
+    // Find the type alias declaration
+    for (const statement of program.body) {
+        if (statement.type === AST_NODE_TYPES.TSTypeAliasDeclaration) {
+            if (statement.id.name === typeName && statement.typeAnnotation.type === AST_NODE_TYPES.TSUnionType) {
+                return statement.typeAnnotation;
+            }
+        }
+    }
+
+    return null;
+}
+
+function getReturnTypeAnnotation(
+    func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration,
+    context: TSESLint.RuleContext<any, any>
+): TSESTree.TSUnionType | null {
+    const returnType = func.returnType?.typeAnnotation;
+    if (!returnType) {
+        return null;
+    }
+
+    // Direct union type
+    if (returnType.type === AST_NODE_TYPES.TSUnionType) {
+        return returnType;
+    }
+
+    // Type reference that might resolve to a union type
+    if (returnType.type === AST_NODE_TYPES.TSTypeReference) {
+        return resolveTypeReference(returnType, context);
+    }
+
     return null;
 }
 
@@ -182,7 +224,7 @@ function checkFunction(
     context: TSESLint.RuleContext<'mixedUnionProperties', []>
 ) {
     if (!isRouterFunction(func, context)) return;
-    const unionType = getReturnTypeAnnotation(func);
+    const unionType = getReturnTypeAnnotation(func, context);
     if (!unionType) return;
     const unionTypes = getUnionObjectTypes(unionType);
     if (unionTypes.length < 2) return;

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
@@ -1,0 +1,115 @@
+/* ########
+ * 2024 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {RuleTester} from 'eslint';
+import rule from './no-unreachable-union-types';
+
+const ruleTester = new RuleTester({
+    parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('no-unreachable-union-types', rule, {
+    valid: [
+        // Union with distinct types (no overlap)
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {b: number} => ({a: 'hello'}));
+            `,
+        },
+        // Union with types that have same number of properties
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string; b: number} | {c: string; d: number} => ({a: 'hello', b: 1}));
+            `,
+        },
+        // Superset type comes BEFORE subset type (correct order)
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string; b: number} | {a: string} => ({a: 'hello', b: 1}));
+            `,
+        },
+        // Non-router function (should not be checked)
+        {
+            code: `
+                const fn = (): {a: string} | {a: string; b: number} => ({a: 'hello'});
+            `,
+        },
+        // Import from different package (should not be checked)
+        {
+            code: `
+                import { route } from 'other-package';
+                route((ctx): {a: string} | {a: string; b: number} => ({a: 'hello'}));
+            `,
+        },
+        // Union with atomic types only
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): string | number | boolean => 'hello');
+            `,
+        },
+        // Optional properties in subset don't block
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a?: string} | {a: string; b: number} => ({a: 'hello', b: 1}));
+            `,
+        },
+        // Handler type annotation with proper order
+        {
+            code: `
+                import { Handler } from '@mionkit/router';
+                const fn: Handler = (ctx): {a: string; b: number} | {a: string} => ({a: 'hello', b: 1});
+            `,
+        },
+    ],
+    invalid: [
+        // Subset type before superset type in route return
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {a: string; b: number} => ({a: 'hello'}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Subset type before superset type in hook return
+        {
+            code: `
+                import { hook } from '@mionkit/router';
+                hook((ctx): {name: string} | {name: string; age: number} => ({name: 'John'}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Subset type before superset type in headersHook return
+        {
+            code: `
+                import { headersHook } from '@mionkit/router';
+                headersHook((ctx, [token]: [string]): {valid: boolean} | {valid: boolean; userId: string} => ({valid: true}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Multiple unreachable types - {a,b} blocked by {a}, {a,b,c} blocked by both {a} and {a,b}
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string} | {a: string; b: number} | {a: string; b: number; c: boolean} => ({a: 'hello'}));
+            `,
+            errors: [
+                {messageId: 'unreachableUnionType'},
+                {messageId: 'unreachableUnionType'},
+                {messageId: 'unreachableUnionType'},
+            ],
+        },
+    ],
+});

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
@@ -186,5 +186,65 @@ ruleTester.run('no-unreachable-union-types', rule, {
             `,
             errors: [{messageId: 'unreachableUnionType'}],
         },
+        // Type alias with unreachable union in return type
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type UnreachableReturn = {a: string} | {a: string; b: number};
+                route((ctx): UnreachableReturn => ({a: 'hello'}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Type alias with unreachable union in parameter
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type UnreachableParam = {id: string} | {id: string; name: string};
+                route((ctx, data: UnreachableParam): string => data.id);
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Type alias with optional properties blocking more specific types
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type OptionalBlocking = {a?: string} | {a: string; b: number};
+                route((ctx): OptionalBlocking => ({a: 'hello', b: 1}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Type alias with mixed optional/required blocking
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type MixedBlocking = {a: string; b?: number} | {a: string; b: number};
+                route((ctx): MixedBlocking => ({a: 'hello', b: 1}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Type alias with multiple unreachable types
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                type MultipleUnreachable = {a: string} | {a: string; b: number} | {a: string; b: number; c: boolean};
+                route((ctx): MultipleUnreachable => ({a: 'hello'}));
+            `,
+            errors: [
+                {messageId: 'unreachableUnionType'},
+                {messageId: 'unreachableUnionType'},
+                {messageId: 'unreachableUnionType'},
+            ],
+        },
+        // Type alias in headersHook parameter (third parameter)
+        {
+            code: `
+                import { headersHook } from '@mionkit/router';
+                type UnreachableHeaderParam = {x: number} | {x: number; y: number};
+                headersHook((ctx, [token]: [string], data: UnreachableHeaderParam): void => {
+                    console.log(data.x);
+                });
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
     ],
 });

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
@@ -73,6 +73,41 @@ ruleTester.run('no-unreachable-union-types', rule, {
                 const fn: Handler = (ctx): {a: string; b: number} | {a: string} => ({a: 'hello', b: 1});
             `,
         },
+        // Parameters with proper union order (route)
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx, data: {a: string; b: number} | {a: string}) => ({result: 'ok'}));
+            `,
+        },
+        // Parameters with proper union order (hook)
+        {
+            code: `
+                import { hook } from '@mionkit/router';
+                hook((ctx, data: {a: string; b: number} | {a: string}) => ({result: 'ok'}));
+            `,
+        },
+        // Parameters with proper union order (headersHook)
+        {
+            code: `
+                import { headersHook } from '@mionkit/router';
+                headersHook((ctx, [token]: [string], data: {a: string; b: number} | {a: string}) => ({result: 'ok'}));
+            `,
+        },
+        // Context parameter should NOT be checked (route)
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx: {a: string} | {a: string; b: number}) => ({result: 'ok'}));
+            `,
+        },
+        // Headers parameter should NOT be checked (headersHook)
+        {
+            code: `
+                import { headersHook } from '@mionkit/router';
+                headersHook((ctx, headers: {a: string} | {a: string; b: number}) => ({result: 'ok'}));
+            `,
+        },
     ],
     invalid: [
         // Subset type before superset type in route return
@@ -124,6 +159,30 @@ ruleTester.run('no-unreachable-union-types', rule, {
             code: `
                 import { route } from '@mionkit/router';
                 route((ctx): {a: string; b?: number} | {a: string; b: number} => ({a: 'hello', b: 1}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Parameter with unreachable union type (route)
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx, data: {a: string} | {a: string; b: number}) => ({result: 'ok'}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Parameter with unreachable union type (hook)
+        {
+            code: `
+                import { hook } from '@mionkit/router';
+                hook((ctx, data: {a: string} | {a: string; b: number}) => ({result: 'ok'}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Parameter with unreachable union type (headersHook) - third parameter
+        {
+            code: `
+                import { headersHook } from '@mionkit/router';
+                headersHook((ctx, [token]: [string], data: {a: string} | {a: string; b: number}) => ({result: 'ok'}));
             `,
             errors: [{messageId: 'unreachableUnionType'}],
         },

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.spec.ts
@@ -45,7 +45,7 @@ ruleTester.run('no-unreachable-union-types', rule, {
                 const fn = (): {a: string} | {a: string; b: number} => ({a: 'hello'});
             `,
         },
-        // Import from different package (should not be checked)
+        // Import from different package (should not be checked - only @mionkit/router is checked)
         {
             code: `
                 import { route } from 'other-package';
@@ -59,11 +59,11 @@ ruleTester.run('no-unreachable-union-types', rule, {
                 route((ctx): string | number | boolean => 'hello');
             `,
         },
-        // Optional properties in subset don't block
+        // Different properties - no blocking
         {
             code: `
                 import { route } from '@mionkit/router';
-                route((ctx): {a?: string} | {a: string; b: number} => ({a: 'hello', b: 1}));
+                route((ctx): {a?: string} | {b: number; c: string} => ({b: 1, c: 'hello'}));
             `,
         },
         // Handler type annotation with proper order
@@ -110,6 +110,22 @@ ruleTester.run('no-unreachable-union-types', rule, {
                 {messageId: 'unreachableUnionType'},
                 {messageId: 'unreachableUnionType'},
             ],
+        },
+        // Optional properties block more specific types
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a?: string} | {a: string; b: number} => ({a: 'hello', b: 1}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
+        },
+        // Optional property with required property blocks more specific type
+        {
+            code: `
+                import { route } from '@mionkit/router';
+                route((ctx): {a: string; b?: number} | {a: string; b: number} => ({a: 'hello', b: 1}));
+            `,
+            errors: [{messageId: 'unreachableUnionType'}],
         },
     ],
 });

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
@@ -1,0 +1,225 @@
+/* ########
+ * 2024 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+import {TSESTree, TSESLint, AST_NODE_TYPES} from '@typescript-eslint/utils';
+
+type PropertyInfo = {
+    name: string;
+    isOptional: boolean;
+};
+
+/**
+ * Extracts property names from an object type (interface body, type literal)
+ */
+function getObjectTypeProperties(node: TSESTree.TypeNode): PropertyInfo[] | null {
+    if (node.type === AST_NODE_TYPES.TSTypeLiteral) {
+        const props: PropertyInfo[] = [];
+        for (const member of node.members) {
+            if (member.type === AST_NODE_TYPES.TSPropertySignature && member.key.type === AST_NODE_TYPES.Identifier) {
+                props.push({name: member.key.name, isOptional: !!member.optional});
+            }
+        }
+        return props;
+    }
+    return null;
+}
+
+/**
+ * Checks if typeA is a superset of typeB (typeA has all properties of typeB plus more)
+ * This means if typeB comes before typeA in a union, typeA would be unreachable.
+ * Only considers types as blocking if they have at least one REQUIRED property in common.
+ */
+function isSupersetOf(typeAProps: PropertyInfo[], typeBProps: PropertyInfo[]): boolean {
+    if (typeAProps.length <= typeBProps.length) return false;
+
+    // Get required properties from both types
+    const typeBRequired = typeBProps.filter((p) => !p.isOptional);
+
+    // If typeB has no required properties, it doesn't block typeA
+    // (all-optional types need special handling via weakTypeCheck)
+    if (typeBRequired.length === 0) return false;
+
+    // Check if all required properties of typeB exist in typeA (and are also required)
+    for (const propB of typeBRequired) {
+        const propA = typeAProps.find((p) => p.name === propB.name);
+        // If typeB has a required prop that typeA doesn't have as required, A is not a superset
+        if (!propA || propA.isOptional) return false;
+    }
+
+    // typeA has all required properties of typeB, check if it has extra required ones
+    const typeBRequiredNames = new Set(typeBRequired.map((p) => p.name));
+    const typeARequired = typeAProps.filter((p) => !p.isOptional);
+    const hasExtraRequiredProps = typeARequired.some((p) => !typeBRequiredNames.has(p.name));
+    return hasExtraRequiredProps;
+}
+
+/**
+ * Checks if a union type has interfaces where one is a superset of another
+ * and the subset comes before the superset (making the superset unreachable)
+ */
+function findUnreachableTypes(unionNode: TSESTree.TSUnionType): {unreachable: TSESTree.TypeNode; blocker: TSESTree.TypeNode}[] {
+    const issues: {unreachable: TSESTree.TypeNode; blocker: TSESTree.TypeNode}[] = [];
+    const typesWithProps: {node: TSESTree.TypeNode; props: PropertyInfo[]}[] = [];
+
+    // Collect all object types with their properties
+    for (const typeNode of unionNode.types) {
+        const props = getObjectTypeProperties(typeNode);
+        if (props && props.length > 0) {
+            typesWithProps.push({node: typeNode, props});
+        }
+    }
+
+    // For each pair of types, check if one is a superset of another
+    for (let i = 0; i < typesWithProps.length; i++) {
+        for (let j = i + 1; j < typesWithProps.length; j++) {
+            const typeA = typesWithProps[i];
+            const typeB = typesWithProps[j];
+
+            // If typeA (earlier) is a subset of typeB (later), typeB is unreachable
+            if (isSupersetOf(typeB.props, typeA.props)) {
+                issues.push({unreachable: typeB.node, blocker: typeA.node});
+            }
+        }
+    }
+
+    return issues;
+}
+
+/**
+ * Gets a readable representation of an object type for error messages
+ */
+function getTypeDescription(node: TSESTree.TypeNode): string {
+    if (node.type === AST_NODE_TYPES.TSTypeLiteral) {
+        const props = getObjectTypeProperties(node);
+        if (props) {
+            return `{${props.map((p) => (p.isOptional ? `${p.name}?` : p.name)).join(', ')}}`;
+        }
+    }
+    return 'object type';
+}
+
+/**
+ * Checks if the union type is a return type or parameter type of route/hook/headersHook
+ */
+function isRouterUnionType(node: TSESTree.TSUnionType, context: TSESLint.RuleContext<any, any>): boolean {
+    // Check if we're in a return type annotation or parameter type annotation
+    let current: TSESTree.Node | undefined = node.parent;
+    while (current) {
+        // Check if we're in a function that's used in route/hook/headersHook
+        if (
+            current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+            current.type === AST_NODE_TYPES.FunctionExpression ||
+            current.type === AST_NODE_TYPES.FunctionDeclaration
+        ) {
+            // Check if parent is a call to route/hook/headersHook
+            const parent = current.parent;
+            if (parent?.type === AST_NODE_TYPES.CallExpression) {
+                return isRouterFunctionCall(parent, context);
+            }
+        }
+        // Check if we're in a type annotation for Handler/HeaderHandler
+        if (current.type === AST_NODE_TYPES.TSTypeAnnotation) {
+            const typeAnnotationParent = current.parent;
+            if (typeAnnotationParent?.type === AST_NODE_TYPES.Identifier) {
+                const declarator = typeAnnotationParent.parent;
+                if (declarator?.type === AST_NODE_TYPES.VariableDeclarator) {
+                    // Check if the type annotation references Handler/HeaderHandler
+                    if (current.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference) {
+                        const typeName = current.typeAnnotation.typeName;
+                        if (typeName.type === AST_NODE_TYPES.Identifier) {
+                            if (
+                                (typeName.name === 'Handler' || typeName.name === 'HeaderHandler') &&
+                                isImportedFromMionRouter(typeName.name, context)
+                            ) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        current = current.parent;
+    }
+    return false;
+}
+
+/**
+ * Checks if a call expression is a route/hook/headersHook from @mionkit/router
+ */
+function isRouterFunctionCall(node: TSESTree.CallExpression, context: TSESLint.RuleContext<any, any>): boolean {
+    const routerFunctions = ['route', 'hook', 'headersHook'];
+    if (node.callee.type !== AST_NODE_TYPES.Identifier || !routerFunctions.includes(node.callee.name)) {
+        return false;
+    }
+    return isImportedFromMionRouter(node.callee.name, context);
+}
+
+/**
+ * Checks if a name is imported from @mionkit/router
+ */
+function isImportedFromMionRouter(name: string, context: TSESLint.RuleContext<any, any>): boolean {
+    const sourceCode = context.sourceCode;
+    const program = sourceCode.ast;
+
+    for (const statement of program.body) {
+        if (statement.type === AST_NODE_TYPES.ImportDeclaration) {
+            const source = statement.source.value;
+            if (source === '@mionkit/router' || source === '@mionkit/router/') {
+                for (const specifier of statement.specifiers) {
+                    if (
+                        specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+                        specifier.imported.type === AST_NODE_TYPES.Identifier &&
+                        specifier.imported.name === name
+                    ) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+const rule: TSESLint.RuleModule<'unreachableUnionType', []> = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Detect union types where one interface is unreachable because a subset type comes before it',
+        },
+        messages: {
+            unreachableUnionType:
+                'Union type {{unreachableType}} is unreachable because {{blockerType}} matches first. ' +
+                'Move the more specific type (with more properties) before the less specific one.',
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        return {
+            TSUnionType(node: TSESTree.TSUnionType) {
+                // Only check unions in router context
+                if (!isRouterUnionType(node, context)) {
+                    return;
+                }
+
+                const issues = findUnreachableTypes(node);
+                for (const issue of issues) {
+                    context.report({
+                        node: issue.unreachable,
+                        messageId: 'unreachableUnionType',
+                        data: {
+                            unreachableType: getTypeDescription(issue.unreachable),
+                            blockerType: getTypeDescription(issue.blocker),
+                        },
+                    });
+                }
+            },
+        };
+    },
+};
+
+export default rule;

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
@@ -29,32 +29,45 @@ function getObjectTypeProperties(node: TSESTree.TypeNode): PropertyInfo[] | null
 }
 
 /**
- * Checks if typeA is a superset of typeB (typeA has all properties of typeB plus more)
- * This means if typeB comes before typeA in a union, typeA would be unreachable.
- * Only considers types as blocking if they have at least one REQUIRED property in common.
+ * Checks if typeB (earlier in union) blocks typeA (later in union), making typeA unreachable.
+ *
+ * TypeB blocks TypeA when:
+ * - All properties of TypeB (required + optional) exist in TypeA
+ * - TypeA has at least as many required properties as TypeB
+ * - TypeA is more specific than TypeB (more properties OR same properties but more required)
+ *
+ * Examples:
+ * - {a: string} blocks {a: string; b: number} - TypeB has 'a' (req), TypeA has 'a' (req) + 'b' (req)
+ * - {a?: string} does NOT block {b: number; c: string} - TypeB has 'a', TypeA doesn't have 'a'
+ * - {a: string; b?: number} blocks {a: string; b: number} - same props, but TypeA has more required
+ *
+ * @param typeAProps - Properties of the later type (potentially unreachable)
+ * @param typeBProps - Properties of the earlier type (potentially blocking)
+ * @returns true if typeB blocks typeA
  */
 function isSupersetOf(typeAProps: PropertyInfo[], typeBProps: PropertyInfo[]): boolean {
-    if (typeAProps.length <= typeBProps.length) return false;
-
-    // Get required properties from both types
+    const typeARequired = typeAProps.filter((p) => !p.isOptional);
     const typeBRequired = typeBProps.filter((p) => !p.isOptional);
 
-    // If typeB has no required properties, it doesn't block typeA
-    // (all-optional types need special handling via weakTypeCheck)
-    if (typeBRequired.length === 0) return false;
+    // TypeA must have at least as many required properties as TypeB
+    if (typeARequired.length < typeBRequired.length) return false;
 
-    // Check if all required properties of typeB exist in typeA (and are also required)
-    for (const propB of typeBRequired) {
+    // TypeA must be more specific: either more properties OR same properties but more required
+    const isMoreSpecific =
+        typeAProps.length > typeBProps.length ||
+        (typeAProps.length === typeBProps.length && typeARequired.length > typeBRequired.length);
+
+    if (!isMoreSpecific) return false;
+
+    // Check if ALL properties of TypeB (required and optional) exist in TypeA
+    for (const propB of typeBProps) {
         const propA = typeAProps.find((p) => p.name === propB.name);
-        // If typeB has a required prop that typeA doesn't have as required, A is not a superset
-        if (!propA || propA.isOptional) return false;
+        // If TypeB has a prop that TypeA doesn't have, B doesn't block A
+        if (!propA) return false;
     }
 
-    // typeA has all required properties of typeB, check if it has extra required ones
-    const typeBRequiredNames = new Set(typeBRequired.map((p) => p.name));
-    const typeARequired = typeAProps.filter((p) => !p.isOptional);
-    const hasExtraRequiredProps = typeARequired.some((p) => !typeBRequiredNames.has(p.name));
-    return hasExtraRequiredProps;
+    // TypeA has all properties of TypeB and is more specific, so TypeB blocks TypeA
+    return true;
 }
 
 /**

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
@@ -317,7 +317,7 @@ const rule: TSESLint.RuleModule<'unreachableUnionType', []> = {
                 const issues = findUnreachableTypes(node);
                 for (const issue of issues) {
                     context.report({
-                        node: issue.unreachable,
+                        node: node,
                         messageId: 'unreachableUnionType',
                         data: {
                             unreachableType: getTypeDescription(issue.unreachable),
@@ -341,7 +341,7 @@ const rule: TSESLint.RuleModule<'unreachableUnionType', []> = {
                 const issues = findUnreachableTypes(unionType);
                 for (const issue of issues) {
                     context.report({
-                        node: issue.unreachable,
+                        node: node,
                         messageId: 'unreachableUnionType',
                         data: {
                             unreachableType: getTypeDescription(issue.unreachable),

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
@@ -116,6 +116,60 @@ function getTypeDescription(node: TSESTree.TypeNode): string {
 }
 
 /**
+ * Gets the router function name if the function is a handler for route/hook/headersHook
+ */
+function getRouterFunctionName(
+    func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration,
+    context: TSESLint.RuleContext<any, any>
+): string | null {
+    const parent = func.parent;
+    if (parent?.type === AST_NODE_TYPES.CallExpression) {
+        if (parent.callee.type === AST_NODE_TYPES.Identifier) {
+            const functionName = parent.callee.name;
+            if (['route', 'hook', 'headersHook'].includes(functionName) && isImportedFromMionRouter(functionName, context)) {
+                return functionName;
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Checks if the union type is in a parameter that should be checked
+ */
+function isInCheckableParameter(
+    node: TSESTree.TSUnionType,
+    func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration,
+    routerFunctionName: string
+): boolean {
+    // Find which parameter contains this union type
+    let current: TSESTree.Node | undefined = node.parent;
+    while (current && current !== func) {
+        // Check if we're in a parameter
+        if (
+            current.type === AST_NODE_TYPES.Identifier ||
+            current.type === AST_NODE_TYPES.ArrayPattern ||
+            current.type === AST_NODE_TYPES.ObjectPattern
+        ) {
+            const paramIndex = func.params.indexOf(current as TSESTree.Parameter);
+            if (paramIndex !== -1) {
+                // For route and hook: skip first parameter (context)
+                if ((routerFunctionName === 'route' || routerFunctionName === 'hook') && paramIndex >= 1) {
+                    return true;
+                }
+                // For headersHook: skip first two parameters (context and headers)
+                if (routerFunctionName === 'headersHook' && paramIndex >= 2) {
+                    return true;
+                }
+                return false;
+            }
+        }
+        current = current.parent;
+    }
+    return false;
+}
+
+/**
  * Checks if the union type is a return type or parameter type of route/hook/headersHook
  */
 function isRouterUnionType(node: TSESTree.TSUnionType, context: TSESLint.RuleContext<any, any>): boolean {
@@ -128,10 +182,16 @@ function isRouterUnionType(node: TSESTree.TSUnionType, context: TSESLint.RuleCon
             current.type === AST_NODE_TYPES.FunctionExpression ||
             current.type === AST_NODE_TYPES.FunctionDeclaration
         ) {
-            // Check if parent is a call to route/hook/headersHook
-            const parent = current.parent;
-            if (parent?.type === AST_NODE_TYPES.CallExpression) {
-                return isRouterFunctionCall(parent, context);
+            const routerFunctionName = getRouterFunctionName(current, context);
+            if (routerFunctionName) {
+                // Check if we're in the return type
+                if (current.returnType?.typeAnnotation === node || isDescendantOf(node, current.returnType?.typeAnnotation)) {
+                    return true;
+                }
+                // Check if we're in a parameter type (excluding context and headers params)
+                if (isInCheckableParameter(node, current, routerFunctionName)) {
+                    return true;
+                }
             }
         }
         // Check if we're in a type annotation for Handler/HeaderHandler
@@ -161,14 +221,16 @@ function isRouterUnionType(node: TSESTree.TSUnionType, context: TSESLint.RuleCon
 }
 
 /**
- * Checks if a call expression is a route/hook/headersHook from @mionkit/router
+ * Checks if a node is a descendant of another node
  */
-function isRouterFunctionCall(node: TSESTree.CallExpression, context: TSESLint.RuleContext<any, any>): boolean {
-    const routerFunctions = ['route', 'hook', 'headersHook'];
-    if (node.callee.type !== AST_NODE_TYPES.Identifier || !routerFunctions.includes(node.callee.name)) {
-        return false;
+function isDescendantOf(node: TSESTree.Node | undefined, ancestor: TSESTree.Node | undefined): boolean {
+    if (!node || !ancestor) return false;
+    let current: TSESTree.Node | undefined = node;
+    while (current) {
+        if (current === ancestor) return true;
+        current = current.parent;
     }
-    return isImportedFromMionRouter(node.callee.name, context);
+    return false;
 }
 
 /**

--- a/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
+++ b/packages/eslint-plugin/src/rules/no-unreachable-union-types.ts
@@ -135,10 +135,10 @@ function getRouterFunctionName(
 }
 
 /**
- * Checks if the union type is in a parameter that should be checked
+ * Checks if the union type or type reference is in a parameter that should be checked
  */
 function isInCheckableParameter(
-    node: TSESTree.TSUnionType,
+    node: TSESTree.TSUnionType | TSESTree.TSTypeReference,
     func: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | TSESTree.FunctionDeclaration,
     routerFunctionName: string
 ): boolean {
@@ -170,9 +170,12 @@ function isInCheckableParameter(
 }
 
 /**
- * Checks if the union type is a return type or parameter type of route/hook/headersHook
+ * Checks if the union type or type reference is a return type or parameter type of route/hook/headersHook
  */
-function isRouterUnionType(node: TSESTree.TSUnionType, context: TSESLint.RuleContext<any, any>): boolean {
+function isRouterUnionType(
+    node: TSESTree.TSUnionType | TSESTree.TSTypeReference,
+    context: TSESLint.RuleContext<any, any>
+): boolean {
     // Check if we're in a return type annotation or parameter type annotation
     let current: TSESTree.Node | undefined = node.parent;
     while (current) {
@@ -259,16 +262,46 @@ function isImportedFromMionRouter(name: string, context: TSESLint.RuleContext<an
     return false;
 }
 
+/**
+ * Resolves a type reference to its actual union type definition
+ */
+function resolveTypeReference(node: TSESTree.TypeNode, context: TSESLint.RuleContext<any, any>): TSESTree.TSUnionType | null {
+    if (node.type !== AST_NODE_TYPES.TSTypeReference) {
+        return null;
+    }
+
+    // Get the type name
+    if (node.typeName.type !== AST_NODE_TYPES.Identifier) {
+        return null;
+    }
+
+    const typeName = node.typeName.name;
+    const sourceCode = context.sourceCode;
+    const program = sourceCode.ast;
+
+    // Find the type alias declaration
+    for (const statement of program.body) {
+        if (statement.type === AST_NODE_TYPES.TSTypeAliasDeclaration) {
+            if (statement.id.name === typeName && statement.typeAnnotation.type === AST_NODE_TYPES.TSUnionType) {
+                return statement.typeAnnotation;
+            }
+        }
+    }
+
+    return null;
+}
+
 const rule: TSESLint.RuleModule<'unreachableUnionType', []> = {
     meta: {
         type: 'problem',
         docs: {
-            description: 'Detect union types where one interface is unreachable because a subset type comes before it',
+            description:
+                'Detect union types where one interface is unreachable at runtime when using isType function because a subset type comes before it',
         },
         messages: {
             unreachableUnionType:
-                'Union type {{unreachableType}} is unreachable because {{blockerType}} matches first. ' +
-                'Move the more specific type (with more properties) before the less specific one.',
+                'Union type {{unreachableType}} is unreachable at runtime when doing type checking because {{blockerType}} will always match first. ' +
+                'To fix this move the more specific type {{unreachableType}} first within the union, ie: {{unreachableType}} | {{blockerType}} ',
         },
         schema: [],
     },
@@ -282,6 +315,30 @@ const rule: TSESLint.RuleModule<'unreachableUnionType', []> = {
                 }
 
                 const issues = findUnreachableTypes(node);
+                for (const issue of issues) {
+                    context.report({
+                        node: issue.unreachable,
+                        messageId: 'unreachableUnionType',
+                        data: {
+                            unreachableType: getTypeDescription(issue.unreachable),
+                            blockerType: getTypeDescription(issue.blocker),
+                        },
+                    });
+                }
+            },
+            TSTypeReference(node: TSESTree.TSTypeReference) {
+                // Try to resolve the type reference to a union type
+                const unionType = resolveTypeReference(node, context);
+                if (!unionType) {
+                    return;
+                }
+
+                // Only check if this type reference is used in a router context
+                if (!isRouterUnionType(node, context)) {
+                    return;
+                }
+
+                const issues = findUnreachableTypes(unionType);
                 for (const issue of issues) {
                     context.report({
                         node: issue.unreachable,

--- a/packages/router/examples/eslint-rule-test.routes.ts
+++ b/packages/router/examples/eslint-rule-test.routes.ts
@@ -1,5 +1,8 @@
-// This file demonstrates the strong-typed-routes ESLint rule
-// The rule is disabled for this file so you can see both valid and invalid examples
+// This file demonstrates the ESLint rules for @mionkit/router
+// The rules are disabled for this file so you can see both valid and invalid examples
+/* eslint-disable @mionkit/strong-typed-routes */
+/* eslint-disable @mionkit/no-unreachable-union-types */
+/* eslint-disable @mionkit/no-mixed-union-properties */
 import {route, hook, headersHook, Handler, HeaderHandler, CallContext, HeadersList} from '@mionkit/router';
 
 // ========================================
@@ -57,8 +60,29 @@ function headersHookWithJSDoc(c: CallContext, [token]: HeadersList<['auth']>): v
     console.log(token);
 }
 
+// 6. Union types with proper order (more specific types first)
+type UserResponse = {id: string; name: string; email: string} | {id: string; name: string} | {id: string};
+route((ctx): UserResponse => ({id: '1', name: 'John', email: 'john@example.com'}));
+
+// 7. Union types in parameters with proper order
+type UserInput = {id: string; name: string; email: string} | {id: string; name: string} | {id: string};
+route((ctx, user: UserInput): string => user.id);
+
+// 8. Union types with distinct properties (no overlap)
+type Action = {type: 'create'; data: string} | {type: 'update'; id: string} | {type: 'delete'; id: string};
+route((ctx): Action => ({type: 'create', data: 'test'}));
+
+// 9. Return objects matching single union type (no mixed properties)
+type Result = {success: true; data: string} | {success: false; error: string};
+route((ctx): Result => ({success: true, data: 'ok'}));
+route((ctx): Result => ({success: false, error: 'failed'}));
+
 // ========================================
 // ❌ INVALID EXAMPLES (these SHOULD trigger ESLint errors when rule is enabled)
+// ========================================
+
+// ========================================
+// Rule: @mionkit/strong-typed-routes
 // ========================================
 
 // 1. Direct inline handlers missing types
@@ -113,12 +137,68 @@ function invalidHeadersHookJSDoc(c: CallContext, [token]): void {
 } // Missing param type
 
 // ========================================
+// Rule: @mionkit/no-unreachable-union-types
+// ========================================
+
+// 1. Unreachable union type in return (subset before superset)
+type UnreachableReturn = {a: string} | {a: string; b: number}; // Second type is unreachable
+route((ctx): UnreachableReturn => ({a: 'hello'}));
+
+// 2. Unreachable union type in parameter
+type UnreachableParam = {id: string} | {id: string; name: string}; // Second type is unreachable
+route((ctx, data: UnreachableParam): string => data.id);
+
+// 3. Optional properties blocking more specific types
+type OptionalBlocking = {a?: string} | {a: string; b: number}; // Second type is unreachable
+route((ctx): OptionalBlocking => ({a: 'hello', b: 1}));
+
+// 4. Mixed optional/required blocking
+type MixedBlocking = {a: string; b?: number} | {a: string; b: number}; // Second type is unreachable
+route((ctx): MixedBlocking => ({a: 'hello', b: 1}));
+
+// 5. Multiple unreachable types
+type MultipleUnreachable = {a: string} | {a: string; b: number} | {a: string; b: number; c: boolean};
+// Both second and third types are unreachable
+route((ctx): MultipleUnreachable => ({a: 'hello'}));
+
+// 6. Unreachable in headersHook parameter (third parameter)
+type UnreachableHeaderParam = {x: number} | {x: number; y: number}; // Second type is unreachable
+headersHook((ctx, [token]: HeadersList<['auth']>, data: UnreachableHeaderParam): void => {
+    console.log(data.x);
+});
+
+// ========================================
+// Rule: @mionkit/no-mixed-union-properties
+// ========================================
+
+// 1. Return object with properties from multiple union types
+type MixedResult = {success: true; data: string} | {success: false; error: string};
+route((ctx): MixedResult => ({success: true, data: 'ok', error: 'also has error'})); // Mixed properties
+
+// 2. Object literal with unique properties from different union types
+type UserOrProduct = {userId: string; userName: string} | {productId: string; productName: string};
+route((ctx): UserOrProduct => ({userId: '1', productId: '2'})); // Has properties from both types
+
+// 3. Multiple mixed returns in conditional
+type Status = {active: boolean; lastSeen: Date} | {active: boolean; reason: string};
+route((ctx): Status => {
+    if (Math.random() > 0.5) {
+        return {active: true, lastSeen: new Date(), reason: 'mixed'}; // Mixed properties
+    }
+    return {active: false, lastSeen: new Date(), reason: 'also mixed'}; // Mixed properties
+});
+
+// 4. Hook with mixed properties
+type HookData = {name: string} | {age: number};
+hook((ctx): HookData => ({name: 'John', age: 25})); // Mixed properties
+
+// ========================================
 // 📝 INSTRUCTIONS FOR TESTING:
 // ========================================
-// 1. Remove the first line: /* eslint-disable @mionkit/strong-typed-routes */
+// 1. Remove the eslint-disable comments at the top of the file
 // 2. Run: npx eslint packages/router/examples/eslint-rule-test.routes.ts
 // 3. You should see ESLint errors for all the "INVALID EXAMPLES" above
 // 4. The "VALID EXAMPLES" should not produce any errors
-// 5. Add the disable comment back to prevent CI failures
+// 5. Add the disable comments back to prevent CI failures
 
 export {}; // Make this a module

--- a/packages/router/examples/eslint-rule-test.routes.ts
+++ b/packages/router/examples/eslint-rule-test.routes.ts
@@ -1,8 +1,5 @@
 // This file demonstrates the ESLint rules for @mionkit/router
 // The rules are disabled for this file so you can see both valid and invalid examples
-/* eslint-disable @mionkit/strong-typed-routes */
-/* eslint-disable @mionkit/no-unreachable-union-types */
-/* eslint-disable @mionkit/no-mixed-union-properties */
 import {route, hook, headersHook, Handler, HeaderHandler, CallContext, HeadersList} from '@mionkit/router';
 
 // ========================================
@@ -168,37 +165,28 @@ headersHook((ctx, [token]: HeadersList<['auth']>, data: UnreachableHeaderParam):
 });
 
 // ========================================
-// Rule: @mionkit/no-mixed-union-properties
+// Rule: @mionkit/no-mixed-union-properties , !!RULE DISABLED AS DOES NOT ADD MUCH VALUE!!
 // ========================================
 
-// 1. Return object with properties from multiple union types
-type MixedResult = {success: true; data: string} | {success: false; error: string};
-route((ctx): MixedResult => ({success: true, data: 'ok', error: 'also has error'})); // Mixed properties
+// // 1. Return object with properties from multiple union types
+// type MixedResult = {success: true; data: string} | {success: false; error: string};
+// route((ctx): MixedResult => ({success: true, data: 'ok', error: 'also has error'})); // Mixed properties
 
-// 2. Object literal with unique properties from different union types
-type UserOrProduct = {userId: string; userName: string} | {productId: string; productName: string};
-route((ctx): UserOrProduct => ({userId: '1', productId: '2'})); // Has properties from both types
+// // 2. Object literal with unique properties from different union types
+// type UserOrProduct = {userId: string; userName: string} | {productId: string; productName: string};
+// route((ctx): UserOrProduct => ({userId: '1', productId: '2'})); // Has properties from both types
 
-// 3. Multiple mixed returns in conditional
-type Status = {active: boolean; lastSeen: Date} | {active: boolean; reason: string};
-route((ctx): Status => {
-    if (Math.random() > 0.5) {
-        return {active: true, lastSeen: new Date(), reason: 'mixed'}; // Mixed properties
-    }
-    return {active: false, lastSeen: new Date(), reason: 'also mixed'}; // Mixed properties
-});
+// // 3. Multiple mixed returns in conditional
+// type Status = {active: boolean; lastSeen: Date} | {active: boolean; reason: string};
+// route((ctx): Status => {
+//     if (Math.random() > 0.5) {
+//         return {active: true, lastSeen: new Date(), reason: 'mixed'}; // Mixed properties
+//     }
+//     return {active: false, lastSeen: new Date(), reason: 'also mixed'}; // Mixed properties
+// });
 
 // 4. Hook with mixed properties
 type HookData = {name: string} | {age: number};
 hook((ctx): HookData => ({name: 'John', age: 25})); // Mixed properties
-
-// ========================================
-// 📝 INSTRUCTIONS FOR TESTING:
-// ========================================
-// 1. Remove the eslint-disable comments at the top of the file
-// 2. Run: npx eslint packages/router/examples/eslint-rule-test.routes.ts
-// 3. You should see ESLint errors for all the "INVALID EXAMPLES" above
-// 4. The "VALID EXAMPLES" should not produce any errors
-// 5. Add the disable comments back to prevent CI failures
 
 export {}; // Make this a module

--- a/packages/router/examples/eslint-rule-test.routes.ts
+++ b/packages/router/examples/eslint-rule-test.routes.ts
@@ -164,6 +164,29 @@ headersHook((ctx, [token]: HeadersList<['auth']>, data: UnreachableHeaderParam):
     console.log(data.x);
 });
 
+// 7. Unreachable in hook parameter
+type UnreachableHookParam = {status: string} | {status: string; code: number}; // Second type is unreachable
+hook((ctx, data: UnreachableHookParam): void => {
+    console.log(data.status);
+});
+
+// 8. Multiple parameters with unreachable unions
+type UserBase = {id: string} | {id: string; email: string}; // Second type is unreachable
+type ProductBase = {sku: string} | {sku: string; price: number}; // Second type is unreachable
+route((ctx, user: UserBase, product: ProductBase): string => {
+    return `${user.id}-${product.sku}`;
+});
+
+// 9. Nested object with unreachable union in parameter
+type NestedUnreachable = {
+    data: {value: string} | {value: string; extra: number}; // Second type is unreachable
+};
+route((ctx, input: NestedUnreachable): string => input.data.value);
+
+// 10. Optional properties in parameter union
+type OptionalParamBlocking = {name?: string} | {name: string; age: number}; // Second type is unreachable
+route((ctx, person: OptionalParamBlocking): string => person.name || 'unknown');
+
 // ========================================
 // Rule: @mionkit/no-mixed-union-properties , !!RULE DISABLED AS DOES NOT ADD MUCH VALUE!!
 // ========================================

--- a/packages/run-types/src/jitCompilers/binary/toBinary.ts
+++ b/packages/run-types/src/jitCompilers/binary/toBinary.ts
@@ -339,7 +339,7 @@ export function emitToBinary(runType: BaseRunType, comp: BinaryCompiler): JitCod
                     const writeIndex = isUint16
                         ? `${sεr}.view.setUint16(${sεr}.index, ${index}, 1, (${sεr}.index += 2))`
                         : `${sεr}.view.setUint8(${sεr}.index++, ${index})`;
-                    const isTypeCode = rt.getChildIsTypeWithForbiddenProps(childRt, comp);
+                    const isTypeCode = rt.getChildIsTypeWithLooseCheck(childRt, comp);
                     return `${ifElse()} (${isTypeCode}) {${writeIndex};${encodeCode}}`;
                 });
                 return result.filter(Boolean);

--- a/packages/run-types/src/jitCompilers/json/jsonStringify.ts
+++ b/packages/run-types/src/jitCompilers/json/jsonStringify.ts
@@ -284,7 +284,7 @@ export function createStringifyCompiler(fnID: Operation) {
                     `const ${errName} = "Can not ${getOperationName()} union: item does not belong to the union"`
                 );
 
-                const isType = (unionItem) => urt.getChildIsTypeWithForbiddenProps(unionItem, comp);
+                const isType = (unionItem) => urt.getChildIsTypeWithLooseCheck(unionItem, comp);
                 const ifElse = createIfElseFn();
                 const onUnionTypes = (items: BaseRunType[]) => {
                     const result = items.map((unionItem) => {

--- a/packages/run-types/src/nodes/collection/union.spec.ts
+++ b/packages/run-types/src/nodes/collection/union.spec.ts
@@ -162,14 +162,15 @@ describe('Arr with union of types', () => {
 describe('Union Obj', () => {
     type UnionObj = {a: string; aa: boolean} | {b: number} | {c: bigint} | {d?: string};
 
-    const objA: UnionObj = {a: 'hello', b: 123, c: 1n}; // unlike typescript we don't allow mix of properties in the union
+    // With loose matching, objects with mixed properties are now allowed (first match wins)
+    const objA: UnionObj = {a: 'hello', b: 123, c: 1n}; // will match {d?: string} as first compatible (empty object matches)
     const objB: UnionObj = {a: 'world', aa: true};
     const objC: UnionObj = {c: 1n};
     const objD: UnionObj = {d: 'hello'};
     const objE: UnionObj = {};
-    const notA = {a: 'hello'}; // missing aa property
+    const notA = {a: 'hello'}; // missing aa property, but matches {d?: string}
     const notB = {b: 'hello'}; // properties of the union must be of the correct type
-    const notC = {a: 'hello', d: 'extra'}; // extra properties are not allowed in the union
+    const notC = {a: 'hello', d: 'extra'}; // now allowed with loose matching, matches {d?: string}
     const notD = {d: 123}; // properties of the union must be of the correct type
 
     const rt = runType<UnionObj>();
@@ -177,16 +178,27 @@ describe('Union Obj', () => {
     it('validate union', () => {
         const validate = rt.createJitFunction(JitFunctions.isType);
 
-        expect(validate(objA)).toBe(false); // mix of properties is not allowed in the union
+        // With loose matching, mixed properties are allowed (first match wins)
+        // objA has mixed props and matches {a: string; aa: boolean} because it has a='hello' (string)
+        // but also has b and c which don't match aa: boolean. Let's check what actually happens.
+        // Actually objA = {a: 'hello', b: 123, c: 1n} - 'a' is string but no 'aa' boolean, so first type fails
+        // {b: number} - has b: 123, matches!
+        expect(validate(objA)).toBe(true);
         expect(validate(objB)).toBe(true);
         expect(validate(objC)).toBe(true);
         expect(validate(objD)).toBe(true);
         expect(validate(objE)).toBe(true);
 
+        // notA = {a: 'hello'} doesn't match any:
+        // - {a: string; aa: boolean} - missing aa
+        // - {b: number} - no b
+        // - {c: bigint} - no c
+        // - {d?: string} - weakTypeCheck requires 'd' in object OR empty object, {a:'hello'} has neither
         expect(validate(notA)).toBe(false);
-        expect(validate(notB)).toBe(false);
-        expect(validate(notC)).toBe(false);
-        expect(validate(notD)).toBe(false);
+        expect(validate(notB)).toBe(false); // b: 'hello' doesn't match {b: number}
+        // notC = {a: 'hello', d: 'extra'} matches {d?: string} because d is present and is string
+        expect(validate(notC)).toBe(true);
+        expect(validate(notD)).toBe(false); // d: 123 doesn't match {d?: string}
         expect(validate([])).toBe(false);
     });
 
@@ -218,16 +230,18 @@ describe('Union Obj', () => {
     it('validate union + errors', () => {
         const valWithErrors = rt.createJitFunction(JitFunctions.typeErrors);
 
-        expect(valWithErrors(objA)).toEqual([{path: [], expected: 'union'}]); // mix of properties is not allowed in the union
+        // With loose matching, mixed properties are allowed (first match wins)
+        expect(valWithErrors(objA)).toEqual([]); // matches {b: number}
         expect(valWithErrors(objB)).toEqual([]);
         expect(valWithErrors(objC)).toEqual([]);
         expect(valWithErrors(objD)).toEqual([]);
         expect(valWithErrors(objE)).toEqual([]);
 
+        // notA = {a: 'hello'} doesn't match any type (weakTypeCheck for {d?: string} fails)
         expect(valWithErrors(notA)).toEqual([{path: [], expected: 'union'}]);
-        expect(valWithErrors(notB)).toEqual([{path: [], expected: 'union'}]);
-        expect(valWithErrors(notC)).toEqual([{path: [], expected: 'union'}]);
-        expect(valWithErrors(notD)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(notB)).toEqual([{path: [], expected: 'union'}]); // b: 'hello' doesn't match any type
+        expect(valWithErrors(notC)).toEqual([]); // matches {d?: string} because 'd' property is present
+        expect(valWithErrors(notD)).toEqual([{path: [], expected: 'union'}]); // d: 123 doesn't match any type
     });
 
     it('mock', async () => {
@@ -357,12 +371,13 @@ describe('Union Mixed', () => {
 
     const mixA: UnionMix = ['a', 'b', 'c'];
     const mixB: UnionMix = {a: 'hello', aa: true};
-    const mixC: UnionMix = {b: 123, c: 123n}; // typescript allow mixed properties of objects, but we don't
+    // With loose matching, objects with mixed properties now match first compatible type
+    const mixC: UnionMix = {b: 123, c: 123n}; // now matches {b: number} (first compatible match)
     const mixD: UnMixD = {d: new Date()}; // although is not a class instance, it has the same properties so is true
-    const withExtraProps = {a: 'hello', aa: true, j: 'extra'}; // extra props NOT from other union types are allowed
+    const withExtraProps = {a: 'hello', aa: true, j: 'extra'}; // extra props allowed (loose matching)
     const notMixA = [1, 'b'];
     const notMixB = {};
-    const notMixD = {a: 'hello', d: 'world'}; // expect aa property
+    const notMixD = {a: 'hello', d: 'world'}; // expect aa property, now will fail since no match
 
     const mix2A: UnMix2 = {a: true};
     const mix2B: UnMix2 = {a: 123};
@@ -378,12 +393,13 @@ describe('Union Mixed', () => {
 
         expect(validate(mixA)).toBe(true);
         expect(validate(mixB)).toBe(true);
-        expect(validate(mixC)).toBe(false); // we don't allow mixed properties in the union
+        // With loose matching, mixC {b: 123, c: 123n} matches {b: number}
+        expect(validate(mixC)).toBe(true);
         expect(validate(mixD)).toBe(true);
 
         expect(validate(notMixA)).toBe(false);
         expect(validate(notMixB)).toBe(false);
-        expect(validate(notMixD)).toBe(false);
+        expect(validate(notMixD)).toBe(false); // {a: 'hello', d: 'world'} doesn't match any type (aa is boolean not present)
     });
 
     it('validate union allows extra properties not from other union types', () => {
@@ -434,13 +450,14 @@ describe('Union mixed with index property', () => {
 
     const indexA: UnionIndex = ['a', 'b', 'c'];
     const indexB: UnionIndex = {a: 'hello', aa: true};
-    const indexC: UnionIndex = {b: 123, a: 'world'}; // typescript allow mixed properties of objects, but we don't
+    // With loose matching, mixed properties now match first compatible type
+    const indexC: UnionIndex = {b: 123, a: 'world'}; // matches {b: number} (first compatible match)
     const indexD: UnionIndex = {b: 1n, c: 2n};
     const unionWithExtra: UnionIndex = {a: 'hello', aa: true, j: 'extra'}; // allows extra props
 
     const notIndexA = [1, 'b'];
     const notIndexB = {};
-    const notIndexD = {a: 'hello', b: 123n}; // we do not allow extra properties in the union
+    const notIndexD = {a: 'hello', b: 123n}; // doesn't match any type (b is bigint, a is string)
 
     const rt = runType<UnionIndex>();
 
@@ -449,7 +466,8 @@ describe('Union mixed with index property', () => {
 
         expect(validate(indexA)).toBe(true);
         expect(validate(indexB)).toBe(true);
-        expect(validate(indexC)).toBe(false); // we don't allow mixed properties in the union
+        // With loose matching, indexC {b: 123, a: 'world'} matches {b: number}
+        expect(validate(indexC)).toBe(true);
         expect(validate(indexD)).toBe(true);
         expect(validate(unionWithExtra)).toBe(true);
 
@@ -538,8 +556,8 @@ describe('Union circular', () => {
 });
 
 describe('Union with objects containing methods', () => {
-    // unions use strict check to identify the objects in the union,
-    // but we want to ignore methods an other non serializable properties, so those does not make the object invalid
+    // With loose matching, methods and extra properties are allowed.
+    // Objects match the first compatible union type in declaration order.
 
     // Test union with objects that have methods - methods should be ignored during validation
     type UnionWithMethods =
@@ -575,13 +593,14 @@ describe('Union with objects containing methods', () => {
         getName() {
             return 'John';
         },
-        extraProp: 'extra props not from other union types are allowed',
+        extraProp: 'extra props allowed with loose matching',
     };
 
-    // Objects with mixed properties from different union types (should fail)
+    // Objects with mixed properties from different union types
+    // With loose matching, this matches the first compatible type (name: string)
     const objWithMixedProps = {
         name: 'John',
-        age: 25, // 'age' is from another union type, so this should fail
+        age: 25, // With loose matching, extra props are allowed
         getName() {
             return 'John';
         },
@@ -600,16 +619,17 @@ describe('Union with objects containing methods', () => {
         expect(validate(objWithAge)).toBe(true);
         expect(validate(objWithActive)).toBe(true);
 
-        // Objects with mixed properties from OTHER union types should fail
-        expect(validate(objWithMixedProps)).toBe(false);
+        // With loose matching, mixed properties are allowed (first match wins)
+        // objWithMixedProps has {name: 'John'} which matches {name: string; getName(): string}
+        expect(validate(objWithMixedProps)).toBe(true);
     });
 
     it('validate union allows extra properties not from other union types', () => {
         const validate = rt.createJitFunction(JitFunctions.isType);
 
-        // Extra properties that are NOT defined in any other union type are allowed.
+        // Extra properties are allowed with loose matching.
         // This enables returning objects with methods or additional data properties.
-        expect(validate(objWithExtraData)).toBe(true); // 'extraProp' is not in any union type
+        expect(validate(objWithExtraData)).toBe(true);
     });
 
     it('validate union with methods + errors', () => {
@@ -619,10 +639,10 @@ describe('Union with objects containing methods', () => {
         expect(valWithErrors(objWithName)).toEqual([]);
         expect(valWithErrors(objWithAge)).toEqual([]);
         expect(valWithErrors(objWithActive)).toEqual([]);
-        expect(valWithErrors(objWithExtraData)).toEqual([]); // extra props not from other union types are allowed
+        expect(valWithErrors(objWithExtraData)).toEqual([]);
 
-        // Invalid objects should have union errors (mixed props from different union types)
-        expect(valWithErrors(objWithMixedProps)).toEqual([{path: [], expected: 'union'}]);
+        // With loose matching, mixed props are allowed (first match wins)
+        expect(valWithErrors(objWithMixedProps)).toEqual([]);
     });
 
     it('mock union with methods', async () => {

--- a/packages/run-types/src/nodes/collection/union.spec.ts
+++ b/packages/run-types/src/nodes/collection/union.spec.ts
@@ -162,43 +162,41 @@ describe('Arr with union of types', () => {
 describe('Union Obj', () => {
     type UnionObj = {a: string; aa: boolean} | {b: number} | {c: bigint} | {d?: string};
 
-    // With loose matching, objects with mixed properties are now allowed (first match wins)
-    const objA: UnionObj = {a: 'hello', b: 123, c: 1n}; // will match {d?: string} as first compatible (empty object matches)
-    const objB: UnionObj = {a: 'world', aa: true};
-    const objC: UnionObj = {c: 1n};
-    const objD: UnionObj = {d: 'hello'};
-    const objE: UnionObj = {};
-    const notA = {a: 'hello'}; // missing aa property, but matches {d?: string}
-    const notB = {b: 'hello'}; // properties of the union must be of the correct type
-    const notC = {a: 'hello', d: 'extra'}; // now allowed with loose matching, matches {d?: string}
-    const notD = {d: 123}; // properties of the union must be of the correct type
+    // With loose matching, objects with mixed properties are allowed (first match wins)
+    const objMixedMatchesB: UnionObj = {a: 'hello', b: 123, c: 1n}; // matches {b: number} (first compatible)
+    const objMatchesA: UnionObj = {a: 'world', aa: true}; // matches {a: string; aa: boolean}
+    const objMatchesC: UnionObj = {c: 1n}; // matches {c: bigint}
+    const objMatchesD: UnionObj = {d: 'hello'}; // matches {d?: string}
+    const objEmptyMatchesD: UnionObj = {}; // matches {d?: string} (empty object allowed for all-optional)
+    const objWithExtraMatchesD = {a: 'hello', d: 'extra'}; // matches {d?: string} (has 'd' property)
+
+    // Invalid objects - don't match any union type
+    const invalidMissingAa = {a: 'hello'}; // missing 'aa', no 'b', no 'c', no 'd' (weakTypeCheck fails for {d?: string})
+    const invalidWrongTypeB = {b: 'hello'}; // 'b' must be number, not string
+    const invalidWrongTypeD = {d: 123}; // 'd' must be string, not number
 
     const rt = runType<UnionObj>();
 
     it('validate union', () => {
         const validate = rt.createJitFunction(JitFunctions.isType);
 
-        // With loose matching, mixed properties are allowed (first match wins)
-        // objA has mixed props and matches {a: string; aa: boolean} because it has a='hello' (string)
-        // but also has b and c which don't match aa: boolean. Let's check what actually happens.
-        // Actually objA = {a: 'hello', b: 123, c: 1n} - 'a' is string but no 'aa' boolean, so first type fails
-        // {b: number} - has b: 123, matches!
-        expect(validate(objA)).toBe(true);
-        expect(validate(objB)).toBe(true);
-        expect(validate(objC)).toBe(true);
-        expect(validate(objD)).toBe(true);
-        expect(validate(objE)).toBe(true);
+        // With loose matching, first compatible type wins
+        expect(validate(objMixedMatchesB)).toBe(true); // has b: 123, matches {b: number}
+        expect(validate(objMatchesA)).toBe(true);
+        expect(validate(objMatchesC)).toBe(true);
+        expect(validate(objMatchesD)).toBe(true);
+        expect(validate(objEmptyMatchesD)).toBe(true);
+        expect(validate(objWithExtraMatchesD)).toBe(true); // has 'd' property, matches {d?: string}
 
-        // notA = {a: 'hello'} doesn't match any:
+        // Invalid objects
+        // {a: 'hello'} doesn't match any:
         // - {a: string; aa: boolean} - missing aa
         // - {b: number} - no b
         // - {c: bigint} - no c
-        // - {d?: string} - weakTypeCheck requires 'd' in object OR empty object, {a:'hello'} has neither
-        expect(validate(notA)).toBe(false);
-        expect(validate(notB)).toBe(false); // b: 'hello' doesn't match {b: number}
-        // notC = {a: 'hello', d: 'extra'} matches {d?: string} because d is present and is string
-        expect(validate(notC)).toBe(true);
-        expect(validate(notD)).toBe(false); // d: 123 doesn't match {d?: string}
+        // - {d?: string} - weakTypeCheck requires 'd' in object OR empty, but has only 'a'
+        expect(validate(invalidMissingAa)).toBe(false);
+        expect(validate(invalidWrongTypeB)).toBe(false);
+        expect(validate(invalidWrongTypeD)).toBe(false);
         expect(validate([])).toBe(false);
     });
 
@@ -230,18 +228,18 @@ describe('Union Obj', () => {
     it('validate union + errors', () => {
         const valWithErrors = rt.createJitFunction(JitFunctions.typeErrors);
 
-        // With loose matching, mixed properties are allowed (first match wins)
-        expect(valWithErrors(objA)).toEqual([]); // matches {b: number}
-        expect(valWithErrors(objB)).toEqual([]);
-        expect(valWithErrors(objC)).toEqual([]);
-        expect(valWithErrors(objD)).toEqual([]);
-        expect(valWithErrors(objE)).toEqual([]);
+        // With loose matching, first compatible type wins
+        expect(valWithErrors(objMixedMatchesB)).toEqual([]); // matches {b: number}
+        expect(valWithErrors(objMatchesA)).toEqual([]);
+        expect(valWithErrors(objMatchesC)).toEqual([]);
+        expect(valWithErrors(objMatchesD)).toEqual([]);
+        expect(valWithErrors(objEmptyMatchesD)).toEqual([]);
+        expect(valWithErrors(objWithExtraMatchesD)).toEqual([]); // matches {d?: string}
 
-        // notA = {a: 'hello'} doesn't match any type (weakTypeCheck for {d?: string} fails)
-        expect(valWithErrors(notA)).toEqual([{path: [], expected: 'union'}]);
-        expect(valWithErrors(notB)).toEqual([{path: [], expected: 'union'}]); // b: 'hello' doesn't match any type
-        expect(valWithErrors(notC)).toEqual([]); // matches {d?: string} because 'd' property is present
-        expect(valWithErrors(notD)).toEqual([{path: [], expected: 'union'}]); // d: 123 doesn't match any type
+        // Invalid objects
+        expect(valWithErrors(invalidMissingAa)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(invalidWrongTypeB)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(invalidWrongTypeD)).toEqual([{path: [], expected: 'union'}]);
     });
 
     it('mock', async () => {
@@ -369,20 +367,24 @@ describe('Union Mixed', () => {
     type UnMix2 = {a: boolean} | {a: number};
     type UnMixD = UnionMix | D; // ensures unions get flattened
 
-    const mixA: UnionMix = ['a', 'b', 'c'];
-    const mixB: UnionMix = {a: 'hello', aa: true};
-    // With loose matching, objects with mixed properties now match first compatible type
-    const mixC: UnionMix = {b: 123, c: 123n}; // now matches {b: number} (first compatible match)
-    const mixD: UnMixD = {d: new Date()}; // although is not a class instance, it has the same properties so is true
-    const withExtraProps = {a: 'hello', aa: true, j: 'extra'}; // extra props allowed (loose matching)
-    const notMixA = [1, 'b'];
-    const notMixB = {};
-    const notMixD = {a: 'hello', d: 'world'}; // expect aa property, now will fail since no match
+    // Valid objects
+    const arrStrings: UnionMix = ['a', 'b', 'c'];
+    const objMatchesA: UnionMix = {a: 'hello', aa: true};
+    // With loose matching, objects with mixed properties match first compatible type
+    const objMixedMatchesB: UnionMix = {b: 123, c: 123n}; // matches {b: number} (first compatible)
+    const objMatchesD: UnMixD = {d: new Date()}; // matches class D (same properties)
+    const objWithExtraProps = {a: 'hello', aa: true, j: 'extra'}; // extra props allowed (loose matching)
 
-    const mix2A: UnMix2 = {a: true};
-    const mix2B: UnMix2 = {a: 123};
-    const notMix2A = {a: 'hello'};
-    const notMix2B = {};
+    // Invalid objects
+    const invalidMixedArray = [1, 'b']; // mixed types in array don't match any array type
+    const invalidEmptyObj = {}; // no matching properties
+    const invalidMissingAa = {a: 'hello', d: 'world'}; // missing 'aa' for {a, aa}, no match
+
+    // UnMix2: 'a' property is merged into union prop, accepts both boolean and number
+    const objABoolean: UnMix2 = {a: true};
+    const objANumber: UnMix2 = {a: 123};
+    const invalidAString = {a: 'hello'}; // 'a' must be boolean or number
+    const invalidEmpty = {}; // missing 'a' property
 
     const rt = runType<UnionMix>();
     const rt2 = runType<UnMix2>();
@@ -391,45 +393,45 @@ describe('Union Mixed', () => {
     it('validate union', () => {
         const validate = rtD.createJitFunction(JitFunctions.isType);
 
-        expect(validate(mixA)).toBe(true);
-        expect(validate(mixB)).toBe(true);
-        // With loose matching, mixC {b: 123, c: 123n} matches {b: number}
-        expect(validate(mixC)).toBe(true);
-        expect(validate(mixD)).toBe(true);
+        expect(validate(arrStrings)).toBe(true);
+        expect(validate(objMatchesA)).toBe(true);
+        // With loose matching, {b: 123, c: 123n} matches {b: number}
+        expect(validate(objMixedMatchesB)).toBe(true);
+        expect(validate(objMatchesD)).toBe(true);
 
-        expect(validate(notMixA)).toBe(false);
-        expect(validate(notMixB)).toBe(false);
-        expect(validate(notMixD)).toBe(false); // {a: 'hello', d: 'world'} doesn't match any type (aa is boolean not present)
+        expect(validate(invalidMixedArray)).toBe(false);
+        expect(validate(invalidEmptyObj)).toBe(false);
+        expect(validate(invalidMissingAa)).toBe(false);
     });
 
     it('validate union allows extra properties not from other union types', () => {
         // Extra properties that are NOT defined in any other union type are allowed.
         // This enables returning objects with methods or additional data properties.
         const validate = rtD.createJitFunction(JitFunctions.isType);
-        expect(validate(withExtraProps)).toBe(true); // 'j' is not in any union type, so it's allowed
+        expect(validate(objWithExtraProps)).toBe(true); // 'j' is not in any union type, so it's allowed
     });
 
     // for UnMix2 the 'a' property is merged into a single union prop, so 'a' accepts both boolean and number
     it('validate union with merged properties', () => {
         const validate = rt2.createJitFunction(JitFunctions.isType);
 
-        expect(validate(mix2A)).toBe(true);
-        expect(validate(mix2B)).toBe(true);
+        expect(validate(objABoolean)).toBe(true);
+        expect(validate(objANumber)).toBe(true);
 
-        expect(validate(notMix2A)).toBe(false);
-        expect(validate(notMix2B)).toBe(false);
+        expect(validate(invalidAString)).toBe(false);
+        expect(validate(invalidEmpty)).toBe(false);
     });
 
     // validation for Unions does not return info about the path as we can't know which type of the union the user was trying to use.
     it('validate union + errors', () => {
         const valWithErrors = rt.createJitFunction(JitFunctions.typeErrors);
 
-        expect(valWithErrors(mixA)).toEqual([]);
-        expect(valWithErrors(mixB)).toEqual([]);
-        expect(valWithErrors(withExtraProps)).toEqual([]); // extra props not from other union types are allowed
+        expect(valWithErrors(arrStrings)).toEqual([]);
+        expect(valWithErrors(objMatchesA)).toEqual([]);
+        expect(valWithErrors(objWithExtraProps)).toEqual([]); // extra props allowed
 
-        expect(valWithErrors(notMixA)).toEqual([{path: [], expected: 'union'}]);
-        expect(valWithErrors(notMixB)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(invalidMixedArray)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(invalidEmptyObj)).toEqual([{path: [], expected: 'union'}]);
     });
 
     it('mock', async () => {
@@ -448,45 +450,47 @@ describe('Union mixed with index property', () => {
         | {a: string; [key: string]: string}
         | {[key: string]: bigint; b: bigint};
 
-    const indexA: UnionIndex = ['a', 'b', 'c'];
-    const indexB: UnionIndex = {a: 'hello', aa: true};
-    // With loose matching, mixed properties now match first compatible type
-    const indexC: UnionIndex = {b: 123, a: 'world'}; // matches {b: number} (first compatible match)
-    const indexD: UnionIndex = {b: 1n, c: 2n};
-    const unionWithExtra: UnionIndex = {a: 'hello', aa: true, j: 'extra'}; // allows extra props
+    // Valid objects
+    const arrStrings: UnionIndex = ['a', 'b', 'c'];
+    const objMatchesAWithAa: UnionIndex = {a: 'hello', aa: true};
+    // With loose matching, mixed properties match first compatible type
+    const objMixedMatchesB: UnionIndex = {b: 123, a: 'world'}; // matches {b: number} (first compatible)
+    const objBigintIndex: UnionIndex = {b: 1n, c: 2n};
+    const objWithExtraProps: UnionIndex = {a: 'hello', aa: true, j: 'extra'}; // extra props allowed
 
-    const notIndexA = [1, 'b'];
-    const notIndexB = {};
-    const notIndexD = {a: 'hello', b: 123n}; // doesn't match any type (b is bigint, a is string)
+    // Invalid objects
+    const invalidMixedArray = [1, 'b']; // mixed types don't match any array type
+    const invalidEmptyObj = {}; // no matching properties
+    const invalidMixedTypes = {a: 'hello', b: 123n}; // doesn't match any type
 
     const rt = runType<UnionIndex>();
 
     it('validate union', () => {
         const validate = rt.createJitFunction(JitFunctions.isType);
 
-        expect(validate(indexA)).toBe(true);
-        expect(validate(indexB)).toBe(true);
-        // With loose matching, indexC {b: 123, a: 'world'} matches {b: number}
-        expect(validate(indexC)).toBe(true);
-        expect(validate(indexD)).toBe(true);
-        expect(validate(unionWithExtra)).toBe(true);
+        expect(validate(arrStrings)).toBe(true);
+        expect(validate(objMatchesAWithAa)).toBe(true);
+        // With loose matching, {b: 123, a: 'world'} matches {b: number}
+        expect(validate(objMixedMatchesB)).toBe(true);
+        expect(validate(objBigintIndex)).toBe(true);
+        expect(validate(objWithExtraProps)).toBe(true);
 
-        expect(validate(notIndexA)).toBe(false);
-        expect(validate(notIndexB)).toBe(false);
-        expect(validate(notIndexD)).toBe(false);
+        expect(validate(invalidMixedArray)).toBe(false);
+        expect(validate(invalidEmptyObj)).toBe(false);
+        expect(validate(invalidMixedTypes)).toBe(false);
     });
 
     it('validate union + errors', () => {
         const valWithErrors = rt.createJitFunction(JitFunctions.typeErrors);
 
-        expect(valWithErrors(indexA)).toEqual([]);
-        expect(valWithErrors(indexB)).toEqual([]);
-        expect(valWithErrors(indexD)).toEqual([]);
-        expect(valWithErrors(unionWithExtra)).toEqual([]);
+        expect(valWithErrors(arrStrings)).toEqual([]);
+        expect(valWithErrors(objMatchesAWithAa)).toEqual([]);
+        expect(valWithErrors(objBigintIndex)).toEqual([]);
+        expect(valWithErrors(objWithExtraProps)).toEqual([]);
 
-        expect(valWithErrors(notIndexA)).toEqual([{path: [], expected: 'union'}]);
-        expect(valWithErrors(notIndexB)).toEqual([{path: [], expected: 'union'}]);
-        expect(valWithErrors(notIndexD)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(invalidMixedArray)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(invalidEmptyObj)).toEqual([{path: [], expected: 'union'}]);
+        expect(valWithErrors(invalidMixedTypes)).toEqual([{path: [], expected: 'union'}]);
     });
 });
 

--- a/packages/run-types/src/nodes/collection/union.ts
+++ b/packages/run-types/src/nodes/collection/union.ts
@@ -46,13 +46,14 @@ export class UnionRunType extends CollectionRunType<TypeUnion> {
     }
 
     /**
-     * Unlike typescript unions can not have properties from two types,
-     * this is because at runtime we need to identify the original object in the union.
-     * This allows objects to have extra properties (like methods) as long as they don't have
-     * properties that belong to other union members, enabling unambiguous type identification.
+     * Returns isType check for a union child with loose matching.
+     * Uses first-match strategy: returns first matching type in declaration order.
+     * For all-optional types (weak types), ensures at least one property matches or is empty object.
+     * Note: Use ESLint rules @mionkit/no-unreachable-union-types and @mionkit/no-mixed-union-properties
+     * to detect overlapping union types at compile time.
      * @see union.spec.ts 'Union Obj' and 'Union Mixed' test suites for examples.
      */
-    getChildIsTypeWithForbiddenProps(rt: BaseRunType, comp: JitFnCompiler): string {
+    getChildIsTypeWithLooseCheck(rt: BaseRunType, comp: JitFnCompiler): string {
         const isTypeCode = comp.compileIsType(rt, 'E').code || '';
         const isTypeWithProperties =
             isInterfaceRunType(rt) || isClassRunType(rt) || isObjectLiteralRunType(rt) || isIntersectionRunType(rt);
@@ -60,35 +61,9 @@ export class UnionRunType extends CollectionRunType<TypeUnion> {
         const props = rt.getJitChildren(comp);
         const hasIndexProperty = props.some((prop) => prop.src.kind === ReflectionKind.indexSignature);
         if (hasIndexProperty) return isTypeCode;
-        // Get all object types in the union
-        const {objectTypes} = this.getUnionChildren(comp);
         const isAllOptional = rt.areAllChildrenOptional(props);
-        // If there are no other object types, no need to check forbidden props
-        if (objectTypes.length === 1 && !isAllOptional) return isTypeCode;
-        // Get property names of this type
-        const thisTypeProps = new Set<string | number>();
-        for (const prop of props) {
-            const name = (prop as PropertyRunType).getPropertyName();
-            thisTypeProps.add(name);
-        }
-        // Collect property names from OTHER object types that are NOT in this type
-        const forbiddenPropNames = new Set<string | number>();
-        for (const otherRt of objectTypes) {
-            if (otherRt === rt) continue;
-            const otherProps = otherRt.getJitChildren(comp);
-            // If any other type has an index signature, fall back to strict checking
-            const otherHasIndex = otherProps.some((p) => p.src.kind === ReflectionKind.indexSignature);
-            if (otherHasIndex) continue;
-            for (const prop of otherProps) {
-                const name = (prop as PropertyRunType).getPropertyName();
-                if (name !== undefined && !thisTypeProps.has(name)) {
-                    forbiddenPropNames.add(name);
-                }
-            }
-        }
         // For all-optional types (weak types), TypeScript requires at least one matching property
         // or an empty object. This prevents {c: 'hello'} from matching {a?: string; b?: string}
-        let weakTypeCheck = '';
         if (isAllOptional && props.length > 0) {
             // Must have at least one of this type's own props OR be empty
             const hasOwnPropCheck = props.map((p) => {
@@ -96,33 +71,24 @@ export class UnionRunType extends CollectionRunType<TypeUnion> {
                 return `(${toLiteral(name)} in ${comp.vλl})`;
             });
             hasOwnPropCheck.push(`Object.keys(${comp.vλl}).length === 0`);
-            weakTypeCheck = `(${hasOwnPropCheck.join(' || ')})`;
+            const weakTypeCheck = `(${hasOwnPropCheck.join(' || ')})`;
+            return `(${isTypeCode} && ${weakTypeCheck})`;
         }
-        if (forbiddenPropNames.size === 0 && !weakTypeCheck) return isTypeCode;
-        // Generate code to check that none of the forbidden props exist
-        const checks: string[] = [isTypeCode];
-        if (forbiddenPropNames.size > 0) {
-            const forbiddenCheck = Array.from(forbiddenPropNames)
-                .map((p) => `!(${toLiteral(p)} in ${comp.vλl})`)
-                .join(' && ');
-            checks.push(forbiddenCheck);
-        }
-        if (weakTypeCheck) checks.push(weakTypeCheck);
-        return `(${checks.join(' && ')})`;
+        return isTypeCode;
     }
 
     /**
-     * Uses forbidden props approach: Only check for properties from OTHER union types.
-     * This allows objects to have extra properties (like methods) as long as they don't have
-     * properties that belong to other union members, enabling unambiguous type identification.
+     * Loose union matching: returns first matching type in declaration order.
+     * Objects with properties from multiple union types will match the first compatible type.
+     * Use ESLint rules to detect overlapping types at compile time.
      */
     emitIsType(comp: JitFnCompiler): JitCode {
         this.checkNonSkipTypes(comp);
         const {simpleItems, objectTypes} = this.getUnionChildren(comp);
-        const items = simpleItems.map((rt) => this.getChildIsTypeWithForbiddenProps(rt, comp));
+        const items = simpleItems.map((rt) => this.getChildIsTypeWithLooseCheck(rt, comp));
         const checkItems = items.filter(Boolean).join(' || ');
         if (!objectTypes.length) return {code: `(${checkItems})`, type: 'E'};
-        const objItems = objectTypes.map((rt) => this.getChildIsTypeWithForbiddenProps(rt, comp));
+        const objItems = objectTypes.map((rt) => this.getChildIsTypeWithLooseCheck(rt, comp));
         const objCode = objItems.filter(Boolean).join(' || ');
         const checkObjs = `(typeof ${comp.vλl} === 'object' && ${comp.vλl} !== null && (${objCode}))`;
         return {code: `(${[checkItems, checkObjs].filter(Boolean).join(' || ')})`, type: 'E'};
@@ -161,7 +127,7 @@ export class UnionRunType extends CollectionRunType<TypeUnion> {
                 // item encoded before reassigning varName to [i, item]
                 const index = this.getUnionItemIndex(comp, childRt);
                 const tupleEncode = needsTupleEncoding ? `${comp.vλl} = [${index}, ${comp.vλl}]` : '/*noop*/';
-                const isTypeCode = this.getChildIsTypeWithForbiddenProps(childRt, comp);
+                const isTypeCode = this.getChildIsTypeWithLooseCheck(childRt, comp);
                 return `${ifElse()} (${isTypeCode}) {${encodeCode} ${tupleEncode}}`;
             });
             return result.filter(Boolean);


### PR DESCRIPTION
## Summary

This PR changes union type validation from strict runtime checking to loose matching (first-match wins), while adding ESLint rules to detect potential issues at compile time.

## Motivation

The previous approach used `getChildIsTypeWithForbiddenProps` to do expensive runtime checks ensuring objects don't have properties from multiple union types. This was costly at runtime. Instead, we now:

1. Use loose matching - return first compatible type in declaration order
2. Detect potential issues at compile time via ESLint rules

## Changes

### `@mionkit/run-types`

- **Renamed** `getChildIsTypeWithForbiddenProps` → `getChildIsTypeWithLooseCheck`
- **Removed** expensive forbidden props checking at runtime
- **Kept** `weakTypeCheck` for all-optional interfaces (prevents `{c: 'hello'}` from matching `{a?: string; b?: string}`)
- **Updated** tests to reflect new loose matching behavior
- **Renamed** test variables for clarity (e.g., `notC` → `objWithExtraMatchesD`)

### `@mionkit/eslint-plugin`

Added two new ESLint rules:

#### `@mionkit/no-unreachable-union-types` (error)
Detects union types where one interface is unreachable because a subset type comes before it.

```typescript
// ❌ Bad - {a: string; b: number} is unreachable
route((ctx): {a: string} | {a: string; b: number} => ({a: 'hello'}));

// ✅ Good - more specific type first
route((ctx): {a: string; b: number} | {a: string} => ({a: 'hello', b: 1}));
```

#### `@mionkit/no-mixed-union-properties` (warn)
Detects object literals returned from router handlers that have properties from multiple union types.

```typescript
// ⚠️ Warning - has properties from both union types
route((ctx): {a: string} | {b: number} => ({a: 'hello', b: 123}));
```

## Breaking Changes

Union types now use first-match strategy. Objects with properties from multiple union types will match the first compatible type. Use the new ESLint rules to detect overlapping unions at compile time.

## Testing

- All `run-types` tests pass (799 passed, 21 skipped)
- All `eslint-plugin` tests pass (84 passed)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author