### PR TITLE
Replace allowNonRegistryProtocols with blockExoticSubdeps in pnpm config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,12 +38,16 @@ minimumReleaseAgeExclude: []
 ignoreScripts: true
 sideEffectsCache: false
 
-# ── Block non-registry sources ───────────────────────────
-# Refuse git/github/file/http specifiers from dependencies.
-# (workspace:* is exempt — it's the workspace protocol, not external.)
-allowNonRegistryProtocols: false
+# ── Block exotic transitive sources ───────────────────────
+# pnpm 11 defaults this to true; setting explicitly for clarity. Direct
+# dependencies may declare any source; all TRANSITIVE deps must resolve
+# from a trusted source: configured registry, workspace links, local file
+# paths, or the node/bun/deno mirrors. pnpm has no per-package allowlist
+# for direct-dep sources — PR review covers that surface.
+# (workspace:* is always exempt — it's the workspace protocol, not external.)
+blockExoticSubdeps: true
 
-# ── Strict peer / hoisting ───────────────────────────────
+# ── Strict peer / hoisting ────────────────────────────────
 strictPeerDependencies: true
 autoInstallPeers: false
 # Use npm-like flat hoisting so transitive deps (esbuild, etc.) remain

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -4,12 +4,12 @@ packages: []
 
 # ── Build-script allowlist ───────────────────────────────
 # pnpm 11 blocks every dependency install/postinstall script by default.
-# Only the packages listed below with `true` may run them. Verified minimum
-# required for `nuxt dev` and `nuxt generate` to function — every other
-# package with install hooks (esbuild, sharp, @parcel/watcher, unrs-resolver,
-# vue-demi) was tested and is NOT needed: their binaries either ship
-# pre-built via optional platform-specific deps (esbuild), or the
-# package falls back to a JS implementation at runtime.
+# Only packages set to `true` here may run them. Verified minimum required
+# for `nuxt dev` and `nuxt generate` to function — every other package with
+# install hooks (esbuild, sharp, @parcel/watcher, unrs-resolver, vue-demi)
+# was tested and is NOT needed: their binaries either ship pre-built via
+# optional platform-specific deps (esbuild), or the package falls back to
+# a JS implementation at runtime.
 # Add a new entry only after confirming a real failure without it.
 allowBuilds:
   better-sqlite3: true     # native sqlite binary — @nuxt/content fails to load without it
@@ -23,7 +23,7 @@ allowBuilds:
 preferFrozenLockfile: true
 verifyStoreIntegrity: true
 
-# ── Version pinning ──────────────────────────────────────
+# ── Version pinning ────────────────────────────────────
 # Empty savePrefix means exact pinning (replaces legacy save-exact=true).
 savePrefix: ''
 resolutionMode: highest
@@ -43,8 +43,12 @@ minimumReleaseAgeExclude: []
 # Allowlist-based: only packages set to `true` in `allowBuilds` run scripts.
 # (Equivalent to the root's `ignoreScripts: true` + allowlist combo.)
 
-# ── Block non-registry sources ───────────────────────────
-allowNonRegistryProtocols: false
+# ── Block exotic transitive sources ───────────────────────
+# pnpm 11 defaults this to true; setting explicitly for clarity. Direct
+# dependencies may declare any source; all TRANSITIVE deps must resolve
+# from a trusted source. pnpm has no per-package allowlist for direct-dep
+# sources — PR review covers that surface.
+blockExoticSubdeps: true
 
 # ── Peer / hoisting ──────────────────────────────────────
 strictPeerDependencies: false


### PR DESCRIPTION
## Summary
Updated pnpm workspace configuration to use the newer `blockExoticSubdeps` setting in place of the deprecated `allowNonRegistryProtocols` option, aligning with pnpm 11 defaults and improving clarity around dependency source restrictions.

## Key Changes
- Replaced `allowNonRegistryProtocols: false` with `blockExoticSubdeps: true` in both `pnpm-workspace.yaml` and `website/pnpm-workspace.yaml`
- Expanded and clarified configuration comments to explain the security model:
  - Direct dependencies may use any source (subject to PR review)
  - All transitive dependencies must resolve from trusted sources (registry, workspace links, local paths, or node/bun/deno mirrors)
  - Workspace protocol (`workspace:*`) remains exempt as an internal mechanism
- Minor formatting improvements to comment section headers for consistency

## Implementation Details
The change reflects pnpm 11's explicit default behavior. The new `blockExoticSubdeps` setting provides clearer semantics than the negatively-phrased `allowNonRegistryProtocols`, making the security intent more obvious. The expanded comments document the rationale: direct dependency source vetting happens through PR review, while transitive dependency sources are enforced at the tool level.

https://claude.ai/code/session_0179pdSS7EP4WrAytnAVEuwb