### PR TITLE
docs(todos): upstream CompiledFnArgs fix landed; record the mion cleanup

### DIFF
--- a/docs/todos/upstream-compiledfnargs-type-lie.md
+++ b/docs/todos/upstream-compiledfnargs-type-lie.md
@@ -1,72 +1,96 @@
 # Upstream: `CompiledFnArgs` cannot describe its own values
 
-**Status:** todo — file against `ts-run-types`, not fixable in mion
-**Type:** upstream bug report
+**Status:** todo — upstream half FIXED, mion half blocked on a release
+**Type:** upstream bug report → now a mion cleanup
 **Created:** 2026-07-27
+**Updated:** 2026-08-01 — upstream fix landed as
+[MionKit/ts-run-types#308](https://github.com/MionKit/ts-run-types/pull/308)
 **Found while:** deleting `rtResolver.ts` ([../done/rtresolver-removal.md](../done/rtresolver-removal.md))
 
-## The bug
+## The bug (as filed, and correct on `@ts-runtypes/core` 0.11.0)
 
-`@ts-runtypes/core` 0.11.0, `packages/ts-runtypes/src/runtypes/types.ts:142-147`:
+`CompiledFnData` types **both** `args` and `defaultParamValues` as `CompiledFnArgs`
+(all-string). `args` genuinely is all-strings. `defaultParamValues` is not, for any family —
+`{vλl: undefined}`, `{vλl: undefined, pλth: [], εrr: []}`, `{vλl: undefined, θpts: {}}`,
+`{vλl: undefined, sεr: undefined}`, `{vλl: undefined, dεs: undefined}` — each laundered through
+an `as unknown as CompiledFnArgs` cast. `familyMeta` is the only writer of either field, so 100%
+of entries carry a `defaultParamValues` the declared type rejects.
 
-```ts
-export type CompiledFnArgs = {
-  vλl: string;
-  [key: string]: string;
-};
+Two walls for a consumer that builds codecs over the wire form (mion ships these to the browser):
+
+1. **Validation.** `createValidateFn<CompiledFnData>()` rejects every real entry — the required
+   `vλl` slot holds `undefined`, not a string.
+2. **Serialization.** The `sj` JIT stringifier compiled from `CompiledFnData` has no
+   undefined-guard on a required property, so it emits the literal text `"vλl":undefined` —
+   syntactically invalid JSON. The receiver's `JSON.parse` throws on every entry.
+
+## What upstream actually did — NOT either fix we suggested
+
+We proposed (1) widen `defaultParamValues` to `unknown` values, or (2) drop both fields as
+derivable from `familyTag`. **Both were wrong**, and the reason matters for mion:
+
+`defaultParamValues` is consumed when a receiver rebuilds the function via `new Function(...)`,
+which is exactly why it was typed as strings. The Go emitter's `ArgSpec` is the authority:
+
+```go
+// Key is the conceptual slot ("vλl", "pλth", "εrr"); Name is the JS identifier
+// in the emitted signature; Default is the JS-source default expression
+// (empty for no default).
+type ArgSpec struct{ Key, Name, Default string }
 ```
 
-`CompiledFnData` types **both** `args` and `defaultParamValues` as `CompiledFnArgs`. `args` genuinely
-is all-strings. **`defaultParamValues` is not, for any family.** `entryTuple.ts:462-468`:
+Both tables are **JS source fragments**, describing the emitted
+`function verr_<hash>(v, pth=[], er=[])`. So `CompiledFnArgs` was correct all along — the JS
+mirror in `entryTuple.ts` had drifted to storing real runtime values where source text belongs.
 
-```ts
-const valueDefaults  = () => ({vλl: undefined}) as unknown as CompiledFnArgs;
-const errorDefaults  = () => ({vλl: undefined, pλth: [], εrr: []}) as unknown as CompiledFnArgs;
-```
+Upstream therefore **kept the type** and corrected the values:
 
-…plus `{vλl: undefined, θpts: {}}` (huk), `{vλl: undefined, sεr: undefined}` (tb),
-`{vλl: undefined, dεs: undefined}` (fb). Every one goes through an `as unknown as CompiledFnArgs`
-cast — the author knew the value violates the type.
+| family | `args` (identifiers) | `defaultParamValues` (source text) |
+| --- | --- | --- |
+| value-shaped (`val`, `pj`, `rj`, `cj`, `ces`, `fmt`, …) | `{vλl:'v'}` | `{vλl:''}` |
+| error-shaped (`verr`, `uke`) | `{vλl:'v', pλth:'pth', εrr:'er'}` | `{vλl:'', pλth:'[]', εrr:'[]'}` |
+| `huk` | `{vλl:'v', θpts:'opts'}` | `{vλl:'', θpts:'{}'}` |
+| `tb` | `{vλl:'v', sεr:'Ser'}` | `{vλl:'', sεr:''}` |
+| `fb` | `{vλl:'ret', dεs:'Des'}` | `{vλl:'', dεs:''}` |
 
-`familyMeta` (`entryTuple.ts:481-525`) is the only writer of either field anywhere in the package, so
-this is not an edge case: **100% of entries have a `defaultParamValues` that the declared type
-rejects.**
+An empty string means "this parameter takes no default", mirroring Go's convention. No type was
+widened, no field removed.
 
-## Why it matters to a consumer
+## Consequences for mion
 
-`CompiledFnData` is publicly exported (`index.ts:27`) and documented as the closure-free **wire**
-form. Upstream never builds a validator, encoder or decoder over it, so nothing internally notices.
-A consumer that does — mion ships these to the browser — hits two walls:
+**Our note that "nothing reads these values, so the loss is inert" was wrong in principle.**
+They are not derivable bookkeeping — they are the default expressions a client needs to
+reconstruct a signature. Today nothing on our client side reads them (we restore through `code`
+via `buildFactoryFromCode`), so no outage was caused, but the field is meaningful and must be
+forwarded verbatim once available.
 
-1. **Validation.** `createValidateFn<CompiledFnData>()` emits `typeof v === 'string'` for the
-   required `vλl` with no undefined-guard, and applies the index-signature check to every own
-   enumerable key. `undefined`, `[]` and `{}` all fail.
-2. **Serialization, which is worse.** The JSON stringifier compiled from `CompiledFnData` has no
-   undefined-guard on a non-optional property either, so it emits the literal text
-   `"vλl":undefined` — **syntactically invalid JSON**. The receiver's `JSON.parse` throws. Not a
-   degradation: a total outage of any route that ships these.
+Two things about `toWireArgs`
+([`packages/router/src/lib/remoteMethods.ts`](../../packages/router/src/lib/remoteMethods.ts)),
+in the order they bite:
 
-So a consumer cannot forward the values it is handed, and has to launder them.
-
-## What mion does meanwhile
-
-`toWireArgs` in `packages/router/src/lib/remoteMethods.ts` drops non-string entries from
-`defaultParamValues` before serialization. The loss is inert — nothing on either side ever reads
-these fields (upstream restores through `code` alone, via `buildFactoryFromCode`), and they are pure
-functions of `familyTag`, so they carry no per-entry information. But it is a workaround for a type
-that should not have needed one, and it will silently keep working even if upstream later starts
-putting meaningful data there.
-
-## Suggested fixes (upstream)
-
-1. **Split the type.** Keep `args: CompiledFnArgs` and give defaults their own:
-   `defaultParamValues: {vλl?: unknown; [key: string]: unknown}`. Honest, minimal, unblocks
-   consumers.
-2. **Drop both from `CompiledFnData` entirely.** They are derivable from `familyTag` via
-   `familyMeta`; exposing that table as a lookup would let consumers reconstruct them bit-identically
-   with zero wire bytes, and removes the question at the root. Larger change, better end state.
+1. **On the current pin (0.11.0) it ships wrong data.** Non-string values are dropped, so
+   `pλth: []` and `εrr: []` vanish; then `if (!('vλl' in out)) out.vλl = 'v'` injects the
+   *identifier* `'v'` into a table of *default expressions*. Every error-shaped entry goes over
+   the wire as `defaultParamValues: {vλl: 'v'}` — three slots reduced to one, and that one
+   semantically wrong. Inert only because nothing reads it.
+2. **After the upgrade it becomes an identity no-op.** Every value is a string, so the filter
+   copies all of them and the `vλl` fallback is unreachable. Dead weight, plus a fallback that
+   would inject a wrong value if it ever fired again.
 
 ## Done when
 
-- Filed in the `ts-run-types` repo with the repro above.
-- When it ships: delete `toWireArgs` and let the real values through (or stop sending the fields).
+- [x] Filed in the `ts-run-types` repo with the repro above.
+- [x] Upstream fix shipped ([ts-run-types#308](https://github.com/MionKit/ts-run-types/pull/308)):
+      the five drifted values corrected, all five `as unknown as CompiledFnArgs` casts removed,
+      and the source-text contract documented on the type so it cannot drift again.
+- [ ] **Blocked on a release.** `@ts-runtypes/core` is pinned to `0.11.0` in `client`, `core`,
+      `drizze`, `examples` and `router`; the fix is on `main`, unreleased. Bump all five pins to
+      the first release that contains it.
+- [ ] Delete `toWireArgs` and pass `comp.defaultParamValues` through unchanged (spread it like
+      `args` already is: `defaultParamValues: {...comp.defaultParamValues}`). Drop its long
+      explanatory comment with it.
+- [ ] Add a round-trip assertion so this cannot regress silently: a metadata-route payload must
+      survive `JSON.parse(JSON.stringify(…))` with **every** `defaultParamValues` slot intact.
+      Assert on slot presence, not `toEqual` — `JSON.stringify` silently drops undefined-valued
+      keys and `toEqual` treats a missing key and an undefined one as equal, so a naive
+      round-trip assertion passes even when the bug is present.


### PR DESCRIPTION
Docs only. Updates the existing `docs/todos/upstream-compiledfnargs-type-lie.md` now that the upstream half is fixed in [MionKit/ts-run-types#308](https://github.com/MionKit/ts-run-types/pull/308).

I updated the existing todo rather than filing a new one — it already tracked exactly this, and its "Done when" was *"when it ships: delete `toWireArgs`"*.

## Upstream did NOT take either fix we proposed, and the reason matters

We suggested (1) widen `defaultParamValues` to `unknown` values, or (2) drop both fields as derivable from `familyTag`. Both were wrong.

`defaultParamValues` is consumed when a receiver rebuilds the function via `new Function(...)` — which is precisely why it was typed as strings. The Go emitter's `ArgSpec` says so outright:

```go
// Key is the conceptual slot ("vλl", "pλth", "εrr"); Name is the JS identifier
// in the emitted signature; Default is the JS-source default expression
// (empty for no default).
type ArgSpec struct{ Key, Name, Default string }
```

Both tables are **JS source fragments**, describing the emitted `function verr_<hash>(v, pth=[], er=[])`. So `CompiledFnArgs` was correct all along — the JS mirror in `entryTuple.ts` had drifted to storing real runtime values where source text belongs. Upstream kept the type and corrected the values (`{vλl:'', pλth:'[]', εrr:'[]'}` and friends), deleted all five `as unknown as` casts, and documented the contract.

## Which corrects one of our own claims

Our todo said *"nothing reads these values, so the loss is inert"* and called them derivable bookkeeping. **That was wrong in principle.** They're the default expressions a client needs to reconstruct a signature. No outage resulted — our client restores through `code` via `buildFactoryFromCode` — but the field is meaningful and must be forwarded verbatim.

## What `toWireArgs` does, in the order it bites

1. **On the current pin (0.11.0) it ships wrong data.** Non-string values are dropped, so `pλth: []` and `εrr: []` vanish; then `if (!('vλl' in out)) out.vλl = 'v'` injects the *identifier* `'v'` into a table of *default expressions*. Every error-shaped entry goes over the wire as `defaultParamValues: {vλl: 'v'}` — three slots reduced to one, and that one semantically wrong.
2. **After the upgrade it becomes an identity no-op.** Every value is a string, so the filter copies all of them and the `vλl` fallback is unreachable.

## Blocked on a release

`@ts-runtypes/core` is pinned to `0.11.0` in `client`, `core`, `drizze`, `examples` and `router`. The fix is on ts-run-types `main`, unreleased — so nothing is actionable in code yet. The todo records the follow-up: bump the five pins, delete `toWireArgs`, spread `defaultParamValues` through like `args` already is, and add a round-trip assertion.

One trap noted in the todo for whoever writes that assertion: `JSON.stringify` silently drops undefined-valued keys and `toEqual` treats a missing key and an undefined one as equal, so a naive round-trip check passes *even with the bug present*. Assert on slot presence instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnD2KeUxrXbuKRcUrE9zje

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnD2KeUxrXbuKRcUrE9zje)_