### PR TITLE
feat(client)!: split fatal and middleFn errors into separate tuple slots

### DIFF
--- a/docs/done/client-error-dispatch-contract.md
+++ b/docs/done/client-error-dispatch-contract.md
@@ -1,6 +1,11 @@
 # Client error dispatch: define the contract, then make the runtime obey it
 
 **Status:** done — implemented 2026-08-21 on `claude/client-transport-error-types-u2hd0j`
+(**revised 2026-08-22**: middleFn errors were separated back OUT of the single unexpected slot into
+their own typed `middleFnErrors` record — the tuple is `[result, error, fatal, middleFnResults,
+middleFnErrors]`. The single-slot fold silently dropped information: several middleFns can fail at
+once, and a middleFn failure can coexist with a fatal error, but one slot can hold only one error.
+The contract below is updated to the 5-tuple; the fatal slot keeps only what NOBODY declared.)
 (runtime + tests: `feat(client)!: dispatch errors per the contract`; examples and website docs in
 the two follow-up commits on the same branch).
 **Type:** bug (several) + public API change
@@ -25,17 +30,18 @@ failure is reachable at runtime but unreachable through the public types.
 This spec (a) states the intended contract, (b) lists the defects that violate it, (c) plans the
 fix, and (d) specifies the tests that pin each rule.
 
-The headline API change: **slot 2 becomes a single `unexpected` error, and the `middleFnsErrors`
-record leaves the tuple.** Only the route's own declared errors (and `ValidationError`) are
-strongly typed; _everything_ else — a middleFn's error, a transport failure, a platform error, an
-undeclared throw — is, from the route caller's point of view, unexpected, and lands untyped in one
-slot. MiddleFn errors keep their strongly typed channel: the prefill `onError` listeners.
+The headline API change: **the tuple gains a `fatal` slot at index 2.** Declared responses stay
+strongly typed in their own slots — the route's errors in slot 1, each middleFn's errors by name in
+slot 4 — and everything _nobody_ declared (transport, platform, framework, undeclared throws, and
+errors for middleFns that were not part of the request) lands untyped in `fatal`. MiddleFn errors
+additionally keep their strongly typed listener channel (`onError`, now registrable without
+prefill).
 
 ```ts
 // before
 const [result, error, middleFnResults, middleFnErrors] = await routes.users.getById(id).call();
 // after
-const [result, error, unexpected, middleFnResults] = await routes.users.getById(id).call();
+const [result, error, fatal, middleFnResults, middleFnErrors] = await routes.users.getById(id).call();
 ```
 
 `routesFlow` gets the same slot, request-scoped:
@@ -47,13 +53,13 @@ const [[user, order], [userErr, orderErr], middleFnResults, middleFnErrors] = aw
   routes.orders.getById('9'),
 ]).call();
 // after
-const [[user, order], [userErr, orderErr], unexpected, middleFnResults] = await routesFlow([
+const [[user, order], [userErr, orderErr], fatal, middleFnResults, middleFnErrors] = await routesFlow([
   routes.users.getById('1'),
   routes.orders.getById('9'),
 ]).call();
 ```
 
-Same arity, **different meaning at indexes 2 and 3** — see Breaking changes.
+Arity 4 → 5, `fatal` inserted at index 2 — see Breaking changes.
 
 ## How errors flow today (measured, not inferred)
 
@@ -121,7 +127,7 @@ places on the wire:
 > other executables. thrown Errors are **not strongly typed** and are all serialized/deserialized as
 > `RpcError<string>`.
 
-That is precisely the `unexpected` slot's type: _not strongly typed_, `RpcError<string>`. (The
+That is precisely the `fatal` slot's type: _not strongly typed_, `RpcError<string>`. (The
 client even names the concept already: the function that receives the split is called
 `unwrapUnexpectedErrors`.)
 
@@ -151,7 +157,7 @@ The split matters in two places under the new contract:
 
 **One carve-out.** Server-side `validation-error` is _thrown_
 (`dispatch.ts:187`, `:207`, `:220`) but is by design part of the expected union — `ValidationError`
-is an explicit member of `HandlerErrors`. So the classification rule is "thrown ⇒ unexpected,
+is an explicit member of `HandlerErrors`. So the classification rule is "thrown ⇒ fatal,
 **except** `validation-error`". The cleaner alternative — making the server _return_ validation
 errors instead of throwing — is a larger change to how the execution chain short-circuits and is
 deliberately out of scope here; the carve-out is one condition in one function.
@@ -160,92 +166,84 @@ deliberately out of scope here; the carve-out is one condition in one function.
 
 ### Slots
 
-Only the route's declared response is strongly typed. Everything the route did not declare —
-including another subrequest's declared error — is `unexpected` from the caller's point of view.
+Only declared responses are strongly typed: the route's in slots 0–1, each middleFn's in slots
+3–4. Everything **nobody** declared is `fatal`.
 
 ```ts
-type Result<RouteSuccess, RouteError, MiddleFnsResults> = [
+type Result<RouteSuccess, RouteError, MiddleFnsResults, MiddleFnsErrors> = [
   RouteSuccess | undefined, // 0 result — what the route returned
   RouteError | undefined, // 1 error — the route's DECLARED errors | ValidationError (CLOSED)
-  UnexpectedError | undefined, // 2 unexpected — a middleFn error or a fatal/unknown error (OPEN)
-  MiddleFnsResults | undefined, // 3 middleFn results
+  FatalError | undefined, // 2 fatal — anything NOBODY declared (OPEN)
+  MiddleFnsResults | undefined, // 3 middleFn results, by name
+  MiddleFnsErrors | undefined, // 4 middleFn DECLARED errors | ValidationError, by name (typed)
 ];
 
-/** any error that is not part of the route's declared response: a middleFn's error (typed access
- *  via its prefill onError listener), transport, platform, framework, or an undeclared throw.
- *  Open by nature — the code can be anything. */
-type UnexpectedError = RpcError<string>;
+/** any error that is not part of a declared response: transport, platform, framework, an
+ *  undeclared throw (route or middleFn), or an error for a middleFn that was not part of the
+ *  request. Open by nature — the code can be anything. */
+type FatalError = RpcError<string>;
 ```
 
-There is **no `middleFnsErrors` slot**. A middleFn's errors have exactly two outlets: its
-`onError` listener (the strongly typed channel, per-middleFn) and the shared `unexpected` slot
-(untyped). This is deliberate: keeping a typed per-middleFn error record in every route's return
-type re-imports the union-widening problem this spec exists to avoid — only the route's declared
-response stays strongly typed — and the listener is the typed API for middleFn concerns.
+The `middleFnErrors` record is **typed per middleFn** (`{[K in keyof H]?: MiddleFnError<H[K]>}`)
+and holds one slot per middleFn — several middleFns failing, or a middleFn failing while the route
+throws, loses **no information** (this is why the earlier revision's single shared slot was
+reverted). A middleFn's declared errors therefore have two outlets: its slot in the record and its
+`onError` listener (registrable without prefill — `events()`/`onError` on the subrequest). A
+middleFn's **thrown/undeclared** error cannot appear in its typed record slot: it is fatal.
 
-**Consequence to own: inline middleFns lose their typed record.** Today the record is genuinely
-typed per middleFn (`{[K in keyof H]?: MiddleFnError<H[K]>}`, `types.ts:183`) and examples narrow
-on it (`middleFnErrors.auth.type === 'not-authorized'`, `client.ts` example `:100`). But `onError`
-listeners are only reachable through `prefill()` (`subRequest.ts:49` is the sole `TypedEvent`
-constructor call) — so a middleFn passed inline via `call({middleFns: {auth}})` currently has **no
-listener**, and once the record is gone its errors are only visible untyped in slot 2. The fix is
-small and this spec includes it (plan step 6b): expose the middleFn's `TypedEvent` without
-prefilling, so `auth.onError('not-authorized', …)` works before passing it inline. Dispatch already
-supports it — `processMiddleFnsResponses` fires the registry by subrequest id for _every_ middleFn
-in the request, prefilled or not (`client.ts:148`); only registration is gated on `prefill()`.
-
-`routesFlow` mirrors it, with **one** unexpected slot rather than an array or record — the flow
-shares one transport, one platform, one middleFn chain:
+`routesFlow` mirrors it, with **one** fatal slot — the flow shares one transport, one platform,
+one middleFn chain:
 
 ```ts
 type WorkflowResult<Routes, MiddleFns> = [
   WorkflowRouteResults<Routes>, // 0 per-route results
   WorkflowRouteErrors<Routes>, // 1 per-route DECLARED errors (each index closed)
-  UnexpectedError | undefined, // 2 unexpected — request-scoped, ONE slot
-  MiddleFnsResults | undefined, // 3 middleFn results
+  FatalError | undefined, // 2 fatal — request-scoped, ONE slot
+  MiddleFnsResults | undefined, // 3 middleFn results, by name
+  MiddleFnsErrors | undefined, // 4 middleFn DECLARED errors, by name
 ];
 ```
 
 From the caller's side:
 
 ```ts
-const [[user, order], [userErr, orderErr], unexpected] = await routesFlow([
+const [[user, order], [userErr, orderErr], fatal] = await routesFlow([
   routes.users.getById('1'),
   routes.orders.getById('9'),
 ]).call();
-if (unexpected) retryLater(); // one check covers transport, platform, middleFns, undeclared throws
+if (fatal) retryLater(); // one check covers transport, platform, framework, undeclared throws
 ```
 
 ### Dispatch rules
 
-| #   | error                                                                           | goes to                                                                                                       |
-| --- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| R1  | route returned its own declared error                                           | slot 1 (that route's index in a flow)                                                                         |
-| R2  | param validation failed for a route (client- or server-side)                    | slot 1 (that route's index)                                                                                   |
-| R3  | middleFn returned its own declared error, or its params failed validation       | its `onError` listener (typed) **and** slot 2 (untyped)                                                       |
-| R4  | anything thrown / undeclared — transport, platform, framework, undeclared throw | slot 2 only; **no** listener fires                                                                            |
-| R5  | route produced a result                                                         | slot 0 keeps it, whatever else failed                                                                         |
-| R6  | an error the route did not declare                                              | **never** appears in slot 1                                                                                   |
-| R7  | more than one non-route error exists                                            | slot 2 holds the **first in execution order**; every middleFn's declared error still reaches its own listener |
+| #   | error                                                                                                                                  | goes to                                                                                             |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| R1  | route returned its own declared error                                                                                                  | slot 1 (that route's index in a flow)                                                               |
+| R2  | param validation failed for a route (client- or server-side)                                                                           | slot 1 (that route's index)                                                                         |
+| R3  | middleFn returned its own declared error, or its params failed validation                                                              | slot 4 under its name (typed) **and** its `onError` listener (typed)                                |
+| R4  | anything thrown / undeclared — transport, platform, framework, an undeclared throw, or an error for a middleFn not part of the request | slot 2 (`fatal`) only; **no** listener fires. Several fatals: the **first in execution order** wins |
+| R5  | route produced a result                                                                                                                | slot 0 keeps it, whatever else failed                                                               |
+| R6  | an error the route did not declare                                                                                                     | **never** appears in slot 1                                                                         |
 
-R7 exists because slot 2 is a single value. In practice multiple candidates are rare: the server
-short-circuits the chain at the first error (`dispatch.ts:79`), a transport failure means no server
-errors at all, and a platform error precludes body errors — the realistic overlap is a `runOnError`
-executable failing after an earlier error. "First in execution order" is the error that actually
-aborted the chain, which is the one the caller needs.
+The first-in-execution-order rule inside R4 exists because slot 2 is a single value, and applies
+only among genuinely fatal errors. In practice multiple candidates are rare: the server
+short-circuits the chain at the first thrown error (`dispatch.ts:79`), a transport failure means no
+server errors at all, and a platform error precludes body errors.
 
-R4 covers what today scatters across three places: the route slot (single call),
+R4 covers what previously scattered across three places: the route slot (single call),
 `middleFnsErrors['mion-routes-flow']` (flow), and `middleFnsErrors['mion@methodsMetadata']`
-(internal route ids leaking into a user-facing record).
+(internal route ids leaking into a user-facing record). Internal ids can no longer leak: an error
+keyed to an id that is not a middleFn of the request is fatal, never a record entry.
 
-Note R5 means **result and error slots can both be populated** in the same tuple — a flow where one
-route succeeds and another fails, or a single call where the route succeeds and a middleFn fails.
-The client's job is correct per-slot assignment. Callers may use the shorthand
+Note R3/R5 mean **several slots can be populated at once** — a flow where one route succeeds and
+another fails, a route succeeding while a middleFn fails, or a middleFn failing while the route
+throws (each error keeps its own slot). The client's job is correct per-slot assignment. Callers
+may use the shorthand
 
 ```ts
 if (result) …
 else if (error) …
-else 'unexpected error, try again later'
+else 'fatal error, try again later'
 ```
 
 but that is a caller's choice, **not an invariant the client guarantees**, and no test should
@@ -261,7 +259,7 @@ Each is a violation of a rule above; each gets a failing test written first.
 - **D2 — a foreign error hijacks the typed route slot (violates R6).** `findSubRequestError`
   returns the **first error in the map** when nothing is keyed to the route. Measured: a middleFn's
   `session-expired` in the route slot, typed as the route's own union. Under the contract that
-  error belongs in slot 2 (R3) — same reachability, honest type.
+  error belongs in its own `middleFnErrors` slot (R3) — same reachability, honest type.
 - **D3 — single-route and routesFlow disagree.** The flow branch of `buildResult` has no such
   fallback. Same failure, different slot, depending on call shape. The contract removes the
   fallback entirely, so both converge.
@@ -270,7 +268,7 @@ Each is a violation of a rule above; each gets a failing test written first.
 - **D5 — the declared union cannot express undeclared errors, forcing casts.** Symptom that started
   this: `packages/examples/src/client/cancellation-timeout.ts` ships an `as string` cast because
   `error?.type === 'request-timeout'` does not compile (`TS2367`, union is
-  `'validation-error' | undefined`). The `unexpected` slot removes the need for the cast _and_
+  `'validation-error' | undefined`). The `fatal` slot removes the need for the cast _and_
   keeps slot 1 closed.
 - **D6 — `validation-error` carries two different payload shapes.** `ValidationError` is declared
   `RpcError<'validation-error', {typeErrors: RunTypeError[]}>`. The server honours it
@@ -279,18 +277,19 @@ Each is a violation of a rule above; each gets a failing test written first.
   client-side — the common case, since `validateParams` defaults to `true`. Sole consumer of the
   bad shape is `request.ts:184`, backing the public `typeErrors()` API.
 - **D7 — internal route ids leak into the user-facing middleFn errors record.** Measured:
-  `middleFnsErrors['mion@methodsMetadata']` on a platform error. Removing the record from the tuple
-  eliminates the leak surface entirely; under R4 these errors become the `unexpected` slot.
+  `middleFnsErrors['mion@methodsMetadata']` on a platform error. Under R4 an error keyed to
+  anything that is not a middleFn of the request is fatal — the record only ever carries the
+  middleFns the caller knows about.
 - **D8 — `UnknownErrorHandler` is dead.** `types.ts:105` declares and exports it; a repo-wide grep
   finds no reader. It is the vestige of the untyped channel this spec finally builds. Delete it
-  (its role is now the `unexpected` slot, not a handler).
+  (its role is now the `fatal` slot, not a handler).
 
 ## Implementation plan
 
 1. **Preserve the wire distinction.** `lib/serializer.ts` `unwrapUnexpectedErrors` must stop
    flattening. Return the `@thrownErrors` map to the caller alongside the body instead of
    `Object.assign`-ing it into the root. Platform errors keep their existing special case but are
-   classified as unexpected rather than fanned out to every subrequest (kills D7's cause).
+   classified as fatal rather than fanned out to every subrequest (kills D7's cause).
 2. **Classify on the way in.** `request.ts` keeps errors keyed by subrequest id but tags each as
    `returned` or `thrown`:
    - server body entry → returned, keyed by id
@@ -299,30 +298,30 @@ Each is a violation of a rule above; each gets a failing test written first.
    - client transport error (timeout, abort, fetch failure, serialization, header extraction) →
      thrown, request-scoped. **Stop keying these to `this.requestId`** — that is what made them
      indistinguishable from the route's own errors.
-3. **Distribute per the contract.** Rewrite `buildResult`: no `findSubRequestError` fallback, no
-   middleFn errors record at all, result slot preserved independently of the error slots.
+3. **Distribute per the contract.** Rewrite `buildResult`: no `findSubRequestError` fallback,
+   result slot preserved independently of the error slots.
    - slot 1 ← the route's id, `returned` only
-   - slot 2 ← first (execution order, R7) of: the route's `thrown` error, any middleFn's error
-     (returned or thrown), any request-scoped error
+   - slot 4 ← each request middleFn's `returned` error, under its record name
+   - slot 2 ← first (execution order) of: any middleFn's `thrown` error, the route's `thrown`
+     error, any request-scoped error, any error keyed to an id that is not part of the request
+     (middleFns restored from prefill while a record was passed are merged into the record under
+     their id, so their results/errors are never dropped)
    - Single-route and flow branches share the same rules.
-4. **Reshape the tuple.** `Result` keeps arity 4 but index 2 becomes `UnexpectedError | undefined`
-   and index 3 becomes the middleFn **results**. The `MiddleFnsErrors` type parameter and the
-   record disappear from `Result` (`types.ts:15`), `WorkflowResult` (`types.ts:31`), the
-   `RouteSubRequest.call` overloads (`types.ts:171` builds `{[K in keyof H]?: MiddleFnError<H[K]>}`
-   today), `RoutesFlowBuilder.call`, and `routesFlow()`'s result padding. `MiddleFnError<H>` itself
-   stays — the listener typing still needs it.
+4. **Reshape the tuple.** `Result` and `WorkflowResult` gain `FatalError | undefined` at index 2;
+   the middleFn results and typed errors records shift to indexes 3 and 4. The
+   `RouteSubRequest.call` overloads, `RoutesFlowBuilder.call` and `routesFlow()`'s result padding
+   follow.
 5. **Keep slot 1 closed.** `HandlerErrors` stays `declared | ValidationError`. No widening — that
    was the earlier proposal and it is explicitly rejected: it dilutes route typing, and with the
-   `unexpected` slot it is unnecessary.
+   `fatal` slot it is unnecessary.
 6. **Scope the listeners.** `processMiddleFnsResponses` fires `onError` only for a middleFn's
-   _returned_ (declared) errors, matching `TypedEvent<S, E>`'s declared `E`. The listener is now
-   the **only** typed channel for middleFn errors — pin that in tests, since the record that used
-   to duplicate it is gone.
+   _returned_ (declared) errors, matching `TypedEvent<S, E>`'s declared `E`. Fatals never fire
+   listeners.
    **6b — listeners without prefill.** Expose the middleFn subrequest's `TypedEvent` so inline
-   middleFns can register typed handlers without prefilling (today `prefill()` is the only path to
-   one, `subRequest.ts:49`). Registration is the only missing piece — dispatch is already id-keyed
-   for every middleFn in the request. Without 6b, inline middleFns would have no typed error
-   channel at all after the record is removed.
+   middleFns can register typed handlers without prefilling (previously `prefill()` was the only
+   path to one). Registration was the only missing piece — dispatch is already id-keyed for every
+   middleFn in the request. Landed as `events()`/`onError`/`offError`/`onSuccess`/`offSuccess` on
+   `MiddlewareSubRequest`.
 7. **Fix D6.** `lib/validation.ts:73` → `errorData: {typeErrors: errors}`; `request.ts:184` reads
    `.errorData?.typeErrors ?? []`. Own commit.
 8. **Delete D8.** Remove `UnknownErrorHandler`.
@@ -337,10 +336,10 @@ Written **first**, failing, one per rule. Client suite unless noted.
 - **T1 (R1)** route returns its declared error → slot 1 holds it; slots 0 and 2 `undefined`.
 - **T2 (R2)** route params invalid → slot 1 holds `validation-error`; slot 2 `undefined`.
 - **T3 (R5+R3, pins D1)** route succeeds while a middleFn fails → **slot 0 holds the route
-  result**, slot 1 `undefined`, slot 2 holds the middleFn error, listener fires. This is the
-  regression test for the discarded-result bug.
-- **T4 (R6, pins D2)** middleFn returns its declared error → slot 1 stays `undefined`, slot 2
-  holds the error. Asserts the error does **not** appear in the typed route slot.
+  result**, slot 1 and 2 `undefined`, slot 4 holds the middleFn error under its name, listener
+  fires. This is the regression test for the discarded-result bug.
+- **T4 (R6, pins D2)** middleFn returns its declared error → slot 1 stays `undefined`, slot 4
+  holds the error. Asserts the error does **not** appear in the typed route slot nor in `fatal`.
 - **T5 (R4)** timeout → slot 2 holds `request-timeout`; slots 0 and 1 `undefined`.
 - **T6 (R4)** abort → slot 2 holds `request-aborted`.
 - **T7 (R4)** platform error (oversized payload) → slot 2 only. Replaces the current
@@ -358,24 +357,24 @@ Written **first**, failing, one per rule. Client suite unless noted.
   route's value in slot 0 at its own index; slot 2 `undefined`.
 - **T11 (R4, pins D4)** flow timeout → slot 2 holds `request-timeout`; per-route slots all
   `undefined`.
-- **T12 (R3)** flow + failing middleFn → slot 2 holds the middleFn error, listener fires,
-  per-route error slots `undefined`.
+- **T12 (R3)** flow + failing middleFn → slot 4 holds the middleFn error under its name, listener
+  fires, per-route error slots and `fatal` `undefined`.
 - **T13** single-route and flow agree: the same failure yields the same slot in both shapes.
 
 ### Listener tests
 
-- **T14 (R3)** middleFn's declared error → listener fires **and** slot 2 is populated (both
-  channels; updates the "two ways" claim in `1.error-handling.md:56` — the record is gone, the
-  second way is now slot 2).
+- **T14 (R3)** middleFn's declared error → listener fires **and** its `middleFnErrors` slot is
+  populated (both channels, matching the "two ways" claim in `1.error-handling.md`).
 - **T15 (R4)** transport failure → **no** listener fires, even one registered for that code.
 - **T15b (6b)** an **inline** (non-prefilled) middleFn with a registered `onError` → the listener
   fires with the typed error when that middleFn fails.
 - **T16 (D7)** platform error → slot 2 holds it; no internal id (`mion@methodsMetadata`) is
-  observable anywhere in the tuple.
-- **T17 (R7)** an error plus a failing `runOnError` middleFn → slot 2 holds the first in execution
-  order; **both** listeners' typed errors still reach their own `onError`. Needs a test-server
-  fixture with a `runOnError` middleFn that fails; if the test server cannot express one, say so in
-  the PR and pin R7 with the closest reachable scenario instead of dropping it silently.
+  observable anywhere in the tuple (slots 3 and 4 both empty).
+- **T17** a failing `runOnError` middleFn plus a route that throws → **no information is lost**:
+  slot 4 holds the middleFn's declared error under its name, `fatal` holds the route's undeclared
+  throw, and the middleFn's listener still fires. (This is the scenario that killed the
+  single-shared-slot revision.) Uses the test-server `audit` (`runOnError`) middleFn and the
+  `throwsUnexpectedly` route.
 
 ### Payload test
 
@@ -388,15 +387,16 @@ The examples package is the only `tsc` gate in CI (`.github/workflows/pull-reque
 `check-types-examples`), and there is no `expectTypeOf`/vitest-typecheck setup — so type assertions
 live in a compiled example:
 
-- **T19** `unexpected.type === 'request-timeout'` compiles with **no cast** (this is D5's
+- **T19** `fatal.type === 'request-timeout'` compiles with **no cast** (this is D5's
   done-when).
 - **T20** slot 1 stays closed: `error.type === 'request-timeout'` is a compile error, asserted with
   `@ts-expect-error` (precedent: `_homepage/home-client.ts:25`).
 - **T21** an exhaustive `switch` over slot 1 ending in `const _n: never = error` compiles.
 - **T22** declared payloads survive narrowing (`error.errorData?.until` typed, unknown fields
   rejected) and `ValidationError` keeps `ValidationErrorData` rather than collapsing to `any`.
-- **T23** slot 3 is the middleFn **results** record; the old errors record is not addressable
-  (`@ts-expect-error` on the removed shape).
+- **T23** slot 4 is the typed middleFn **errors** record: a declared code narrows
+  (`middleFnErrors.auth.type === 'not-authorized'` gives typed `errorData`), and a name that was
+  not passed to the call is a compile error (`@ts-expect-error`).
 
 ## Website docs
 
@@ -405,14 +405,14 @@ updated ahead of the implementation without documenting behaviour that does not 
 below lands in the same PR as the change.
 
 - **[`website/content/3.client/1.error-handling.md`](../../website/content/3.client/1.error-handling.md)**
-  - "The Result Pattern" section lists the 4 tuple elements — rewrite for the new meaning of
-    indexes 2 and 3, describing each slot's guarantee (closed vs open) rather than just naming it.
-  - Add a section documenting the dispatch rules (the R1–R7 table, in prose) — this is the piece
+  - "The Result Pattern" section — rewrite for the 5 slots, describing each slot's guarantee
+    (closed vs open) rather than just naming it.
+  - Add a section documenting the dispatch rules (the R1–R6 table, in prose) — this is the piece
     that has never been written down and is the root of the whole problem.
-  - The "two ways to read a middleFn error" passage: the two ways are now the typed `onError`
-    listener and the untyped `unexpected` slot (T14 pins it).
+  - The "two ways to read a middleFn error" passage: the typed `onError` listener and the typed
+    `middleFnErrors` record (T14 pins it).
   - Type Reference: the `Result` entry is a `code-import` over the
-    `// type-result-start/end` markers, so it follows automatically; add an `UnexpectedError` entry
+    `// type-result-start/end` markers, so it follows automatically; add a `FatalError` entry
     with new markers.
 - **[`website/content/3.client/0.client-overview.md`](../../website/content/3.client/0.client-overview.md)**
   - The features list and two prose passages name the tuple's elements explicitly — update.
@@ -421,19 +421,18 @@ below lands in the same PR as the change.
   - Names `middleFnsErrors` in its flow description — update to the new slots.
 - **[`website/content/3.client/4.cancellation-timeouts.md`](../../website/content/3.client/4.cancellation-timeouts.md)**
   - Prose says aborted/timed-out requests "return an error with `type === 'request-aborted'`" —
-    correct but now it is the **unexpected** slot; say so.
+    correct but now it is the **fatal** slot; say so.
 - **Examples** (each is code-imported by the pages above, and each is a CI-gated typecheck):
   - `cancellation-timeout.ts` — drop the `as string` cast and its explanatory comment; read
-    `unexpected` instead. This file is D5's acceptance criterion.
+    `fatal` instead. This file is D5's acceptance criterion.
   - `cancellation-abort-signal.ts`, `cancellation-global-abort.ts` — their
     `// error.type === 'request-aborted'` trailing comments are comments _because_ the real code did
-    not compile. Promote them to real narrowing on `unexpected`.
+    not compile. Promote them to real narrowing on `fatal`.
   - Verified readers of the errors record (grep 2026-08-21): `client.ts`, `client-usage.ts`,
     `client-using-middleFns.ts`, `client-prefill-middleFns.ts`, `handling-errors.ts`,
-    `workflow-vs-single.ts`, `workflow-with-middleFns.ts` — each moves its record read to a typed
-    listener (6b) or to `unexpected`. Every other client example destructures the tuple
-    positionally and must move to the new slot meanings. Audit with
-    `grep -rn "\.call(" packages/examples/src/client`.
+    `workflow-vs-single.ts`, `workflow-with-middleFns.ts` — their record reads stay valid (the
+    record moved to index 4); every client example destructures the tuple positionally and moves
+    to the new slot order. Audit with `grep -rn "\.call(" packages/examples/src/client`.
   - New `client-error-slots.ts` carrying T19–T23, code-imported into the new dispatch-rules
     section.
 - Run `pnpm run check-code-imports` — a dangling marker renders an error placeholder on the site
@@ -441,17 +440,16 @@ below lands in the same PR as the change.
 
 ## Breaking changes
 
-- **Tuple arity stays 4 but indexes 2 and 3 change meaning**: index 2 was the middleFn results
-  record, now `unexpected`; index 3 was the middleFn errors record, now the middleFn results.
-  This is _more_ dangerous than an arity change — old positional destructuring still compiles
-  wherever the record types overlap structurally — so the release notes must lead with it, and T23
-  makes the old shape a compile error where possible.
-- **The middleFn errors record is gone from the public API.** Callers that read
-  `middleFnErrors.session` move to an `onError` listener (typed — available without prefill once
-  6b lands) or the `unexpected` slot (untyped).
+- **Tuple arity 4 → 5**, with `fatal` inserted at index 2: the middleFn results and errors records
+  shift to indexes 3 and 4. Positional destructuring past index 1 breaks. Appending `fatal` at the
+  end would be non-breaking but puts the most important error slot last; on 0.x the insert is
+  worth it. The release notes must lead with it.
 - **Errors move between slots.** A middleFn's declared error no longer appears in the route slot; a
-  transport/platform error moves from the route slot to `unexpected`. Callers reading only slot 1
-  will see `undefined` where they previously saw an error — they must read `unexpected`.
+  transport/platform error moves from the route slot to `fatal`. Callers reading only slot 1 will
+  see `undefined` where they previously saw an error — they must read `fatal` and/or
+  `middleFnErrors`.
+- **An error for a middleFn that was not part of the request is now fatal**, not a raw-id entry in
+  the record.
 - **A successful route result now survives a middleFn failure** (D1). Callers using `if (!result)`
   as a proxy for "something failed" need to check the error slots instead.
 - Versions are lerna-unified with `forcePublish` (`lerna.json`), so no `package.json` edits; this is
@@ -459,13 +457,14 @@ below lands in the same PR as the change.
 
 ## Done when
 
-- Every rule R1–R7 has a passing test, and each of D1–D8 has a test that fails before the fix.
+- Every rule R1–R6 has a passing test, and each of D1–D8 has a test that fails before the fix.
 - `cancellation-timeout.ts` compiles with no cast and no explanatory comment.
 - Slot 1's union is unchanged (`declared | ValidationError`) and a transport code in it is still a
   compile error.
-- No error the route did not declare ever appears in slot 1.
-- The middleFn errors record is gone: no internal mion route id, and no key at all, is reachable
-  through the tuple — `middleFnsErrors['mion-routes-flow']` no longer exists anywhere.
+- No error the route did not declare ever appears in slot 1; no error nobody declared ever appears
+  in slot 4.
+- No internal mion route id is reachable through the tuple — `middleFnsErrors['mion-routes-flow']`
+  and `middleFnsErrors['mion@methodsMetadata']` no longer exist anywhere.
 - The dispatch rules are documented on the website, not just in this spec.
 - Full suite + `pnpm run lint` + `pnpm run format` + `pnpm run check-code-imports` +
   `pnpm run check-types-examples` green.

--- a/packages/client/src/client.spec.ts
+++ b/packages/client/src/client.spec.ts
@@ -107,13 +107,13 @@ describe('client', () => {
         const {routes, middleFns} = initClient<MyApi>({baseURL});
         const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-        const [greeting, error, unexpected, middleFnResults] = await routes.sayHello(someUser).call({
+        const [greeting, error, fatal, middleFnResults] = await routes.sayHello(someUser).call({
             middleFns: {auth: middleFns.auth(authHeaders)},
         });
 
         expect(greeting).toEqual(`Hello John Doe`); // Test server returns: Hello ${user.name} ${user.surname}
         expect(error).toBeUndefined();
-        expect(unexpected).toBeUndefined();
+        expect(fatal).toBeUndefined();
         expect(middleFnResults).toBeDefined();
     });
 
@@ -121,13 +121,13 @@ describe('client', () => {
         const {routes, middleFns} = initClient<MyApi>({baseURL});
         const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-        const [greeting, routeError, unexpected] = await routes.sayHello(someUser).call({
+        const [greeting, routeError, fatal] = await routes.sayHello(someUser).call({
             middleFns: {auth: middleFns.auth(authHeaders)},
         });
 
         expect(greeting).toEqual(`Hello John Doe`); // Test server returns: Hello ${user.name} ${user.surname}
         expect(routeError).toBeUndefined();
-        expect(unexpected).toBeUndefined();
+        expect(fatal).toBeUndefined();
     });
 
     it('return error in result if a route call fails', async () => {
@@ -171,16 +171,16 @@ describe('client', () => {
 
         request.removePrefill();
 
-        const [, routeError, unexpected] = await routes.sayHello(someUser).call();
+        const [, routeError, fatal] = await routes.sayHello(someUser).call();
 
         // After removing prefill, the auth middleFn is not sent, so the server returns a headers
         // validation error for auth. It is not the route's declared error, so it lands in the
-        // unexpected slot, never in the route's typed error slot.
+        // fatal slot, never in the route's typed error slot.
         expect(routeError).toBeUndefined();
-        expect(unexpected).toBeDefined();
-        expect(isRpcError(unexpected)).toBe(true);
-        expect(unexpected?.['mion@isΣrrθr']).toBe(true);
-        expect(unexpected?.publicMessage).toContain('auth');
+        expect(fatal).toBeDefined();
+        expect(isRpcError(fatal)).toBe(true);
+        expect(fatal?.['mion@isΣrrθr']).toBe(true);
+        expect(fatal?.publicMessage).toContain('auth');
     });
 
     // ========== Result Pattern Tests (using call() with prefilled auth) ==========
@@ -442,12 +442,12 @@ describe('client', () => {
             middleFns.auth(authHeaders).prefill();
 
             // call() should return both route result AND middleFn results in the 4-tuple
-            const [greeting, routeError, unexpected, middleFnResults] = await routes.sayHello(someUser).call();
+            const [greeting, routeError, fatal, middleFnResults] = await routes.sayHello(someUser).call();
 
             // Route should succeed
             expect(greeting).toBe('Hello John Doe');
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
 
             // MiddleFn results should be available in the 4-tuple (from prefilled middleFns)
             expect(middleFnResults).toBeDefined();
@@ -462,7 +462,7 @@ describe('client', () => {
             await middleFns.auth(authHeaders).removePrefill();
         });
 
-        it('call() with prefilled middleFns should surface the middleFn error in the unexpected slot AND trigger TypedEvent error handlers', async () => {
+        it('call() with prefilled middleFns should surface the middleFn error in middleFnErrors AND trigger TypedEvent error handlers', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
@@ -481,12 +481,13 @@ describe('client', () => {
             // Prefill auth middleFn
             middleFns.auth(authHeaders).prefill();
 
-            // the middleFn error is not the route's declared error -> unexpected slot (untyped)
-            const [, routeError, unexpected] = await routes.sayHello(someUser).call();
+            // a middleFn's DECLARED error lands in the middleFnErrors record, never in the
+            // route's typed slot and never in the fatal slot
+            const [, routeError, fatal, , middleFnErrors] = await routes.sayHello(someUser).call();
 
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected?.type).toBe('session-expired');
+            expect(fatal).toBeUndefined();
+            expect(middleFnErrors?.session?.type).toBe('session-expired');
 
             // TypedEvent error handler should ALSO have been called
             expect(typedEventErrorCalled).toBe(true);
@@ -518,14 +519,14 @@ describe('client', () => {
             middleFns.auth(authHeaders).prefill();
 
             // Call a route that always fails - middleFns still execute and succeed, but route returns error
-            const [result, routeError, unexpected, middleFnResults] = await routes.alwaysFails(someUser).call();
+            const [result, routeError, fatal, middleFnResults] = await routes.alwaysFails(someUser).call();
 
-            // Route should fail with its DECLARED error in the typed slot; nothing is unexpected
+            // Route should fail with its DECLARED error in the typed slot; nothing is fatal
             expect(result).toBeUndefined();
             expect(routeError).toBeDefined();
             expect(routeError?.type).toBe('unknown-error');
             expect(routeError?.publicMessage).toBe('Something fails');
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
 
             // MiddleFn results should be available (middleFns succeeded even though route failed)
             expect(middleFnResults).toBeDefined();
@@ -549,13 +550,13 @@ describe('client', () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-            const [greeting, routeError, unexpected, middleFnResults] = await routes.sayHello(someUser).call({
+            const [greeting, routeError, fatal, middleFnResults] = await routes.sayHello(someUser).call({
                 middleFns: {auth: middleFns.auth(authHeaders)},
             });
 
             expect(greeting).toBe('Hello John Doe');
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
             expect(middleFnResults).toBeDefined();
         });
 
@@ -563,7 +564,7 @@ describe('client', () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-            const [greeting, routeError, unexpected, middleFnResults] = await routes.sayHello(someUser).call({
+            const [greeting, routeError, fatal, middleFnResults] = await routes.sayHello(someUser).call({
                 middleFns: {
                     auth: middleFns.auth(authHeaders),
                     session: middleFns.session('valid-token'),
@@ -572,7 +573,7 @@ describe('client', () => {
 
             expect(greeting).toBe('Hello John Doe');
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
             expect(middleFnResults?.session).toBeDefined();
             expect(middleFnResults?.session?.userId).toBe('user-123');
         });
@@ -590,21 +591,23 @@ describe('client', () => {
             expect(routeError?.type).toBe('unknown-error');
         });
 
-        it('call({middleFns}) should surface a middleFn failure in the unexpected slot', async () => {
+        it('call({middleFns}) should surface a middleFn failure in middleFnErrors under its name', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-            const [, routeError, unexpected] = await routes.sayHello(someUser).call({
+            const [, routeError, fatal, , middleFnErrors] = await routes.sayHello(someUser).call({
                 middleFns: {
                     auth: middleFns.auth(authHeaders),
                     session: middleFns.session('expired'), // This will fail
                 },
             });
 
-            // A middleFn error is not the route's declared error: unexpected slot, never the typed route slot
+            // A middleFn's DECLARED error: its own slot in middleFnErrors, never the typed route slot,
+            // and not fatal (it was declared by somebody)
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected?.type).toBe('session-expired');
+            expect(fatal).toBeUndefined();
+            expect(middleFnErrors?.session?.type).toBe('session-expired');
+            expect(middleFnErrors?.auth).toBeUndefined();
         });
 
         it('call({middleFns}) should never throw', async () => {
@@ -630,18 +633,18 @@ describe('client', () => {
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
             // Session middleFn with expired token will fail
-            const [result, routeError, unexpected] = await routes.sayHello(someUser).call({
+            const [result, routeError, fatal, , middleFnErrors] = await routes.sayHello(someUser).call({
                 middleFns: {
                     auth: middleFns.auth(authHeaders),
                     session: middleFns.session('expired'),
                 },
             });
 
-            // The middleFn failure lands in the unexpected slot; whatever result the route produced
-            // is preserved in slot 0 (never masked by another subrequest's error)
+            // The middleFn failure lands in its own middleFnErrors slot; whatever result the route
+            // produced is preserved in slot 0 (never masked by another subrequest's error)
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected?.type).toBe('session-expired');
+            expect(fatal).toBeUndefined();
+            expect(middleFnErrors?.session?.type).toBe('session-expired');
             if (result !== undefined) expect(result).toBe('Hello John Doe');
         });
 
@@ -665,7 +668,7 @@ describe('client', () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-            const [greeting, routeError, unexpected, middleFnResults] = await routes.sayHello(someUser).call({
+            const [greeting, routeError, fatal, middleFnResults] = await routes.sayHello(someUser).call({
                 middleFns: {
                     auth: middleFns.auth(authHeaders),
                     session: middleFns.session('valid-token'),
@@ -674,7 +677,7 @@ describe('client', () => {
 
             expect(greeting).toBe('Hello John Doe');
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
             expect(middleFnResults?.session).toBeDefined();
         });
 
@@ -725,15 +728,15 @@ describe('client', () => {
             // We need to bypass TypeScript type checking to send wrong type
             const wrongParams = 'not-a-number' as unknown as number;
 
-            const [result, routeError, unexpected] = await routes.calculateAge(wrongParams).call({
+            const [result, routeError, fatal] = await routes.calculateAge(wrongParams).call({
                 middleFns: {auth: middleFns.auth(authHeaders)},
             });
 
-            // ValidationError is part of the route's expected union: slot 1, not the unexpected slot
+            // ValidationError is part of the route's expected union: slot 1, not the fatal slot
             expect(result).toBeUndefined();
             expect(routeError).toBeDefined();
             expect(routeError?.type).toBe('validation-error');
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
 
         it('validation error for wrong object structure lands in the typed route error slot', async () => {
@@ -743,14 +746,14 @@ describe('client', () => {
             // Send an object with wrong structure (missing surname)
             const wrongUser = {name: 'John'} as unknown as {name: string; surname: string};
 
-            const [result, routeError, unexpected] = await routes.sayHello(wrongUser).call({
+            const [result, routeError, fatal] = await routes.sayHello(wrongUser).call({
                 middleFns: {auth: middleFns.auth(authHeaders)},
             });
 
             expect(result).toBeUndefined();
             expect(routeError).toBeDefined();
             expect(routeError?.type).toBe('validation-error');
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
 
         it('validation error lands in the typed route error slot for call() with prefilled middleFns', async () => {
@@ -763,12 +766,12 @@ describe('client', () => {
             // Send wrong param type
             const wrongParams = 'not-a-number' as unknown as number;
 
-            const [result, routeError, unexpected, middleFnResults] = await routes.calculateAge(wrongParams).call();
+            const [result, routeError, fatal, middleFnResults] = await routes.calculateAge(wrongParams).call();
 
             expect(result).toBeUndefined();
             expect(routeError).toBeDefined();
             expect(routeError?.type).toBe('validation-error');
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
             // middleFn results record is always present in the 4-tuple
             expect(middleFnResults).toBeDefined();
 
@@ -1006,11 +1009,11 @@ describe('client', () => {
         it('call() without auth should fail in optimistic mode (auth required by server)', async () => {
             const {routes} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
 
-            // the missing auth middleFn's error is not the route's declared error -> unexpected slot
-            const [, routeError, unexpected] = await routes.sayHello(someUser).call();
+            // the missing auth middleFn's error is not the route's declared error -> fatal slot
+            const [, routeError, fatal] = await routes.sayHello(someUser).call();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(isRpcError(unexpected)).toBe(true);
+            expect(fatal).toBeDefined();
+            expect(isRpcError(fatal)).toBe(true);
         });
 
         it('removing prefill should cause subsequent optimistic calls to fail', async () => {
@@ -1026,10 +1029,10 @@ describe('client', () => {
             // Remove prefill
             middleFns.auth(authHeaders).removePrefill();
 
-            // Call should now fail (no auth) -> the auth error lands in the unexpected slot
-            const [, , unexpected2] = await routes.sayHello(someUser).call();
-            expect(unexpected2).toBeDefined();
-            expect(isRpcError(unexpected2)).toBe(true);
+            // Call should now fail (no auth) -> the auth error lands in the fatal slot
+            const [, , fatal2] = await routes.sayHello(someUser).call();
+            expect(fatal2).toBeDefined();
+            expect(isRpcError(fatal2)).toBe(true);
         });
 
         it('optimistic mode with simple types should work without retry (no auth required route)', async () => {
@@ -1084,11 +1087,11 @@ describe('client', () => {
             middleFns.auth(authHeaders).prefill();
 
             const signal = AbortSignal.abort();
-            const [result, routeError, unexpected] = await routes.sleep(5000).call({signal});
+            const [result, routeError, fatal] = await routes.sleep(5000).call({signal});
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected!.type).toBe('request-aborted');
+            expect(fatal).toBeDefined();
+            expect(fatal!.type).toBe('request-aborted');
 
             middleFns.auth(authHeaders).removePrefill();
         });
@@ -1103,12 +1106,12 @@ describe('client', () => {
             const promise = routes.sleep(5000).call({signal: controller.signal});
             setTimeout(() => controller.abort(), 50);
 
-            const [result, routeError, unexpected] = await promise;
+            const [result, routeError, fatal] = await promise;
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(isRpcError(unexpected)).toBe(true);
-            expect(unexpected!.type).toBe('request-aborted');
+            expect(fatal).toBeDefined();
+            expect(isRpcError(fatal)).toBe(true);
+            expect(fatal!.type).toBe('request-aborted');
 
             middleFns.auth(authHeaders).removePrefill();
         });
@@ -1119,12 +1122,12 @@ describe('client', () => {
             middleFns.auth(authHeaders).prefill();
 
             // sleep(5000) ensures the request outlasts the 100ms timeout
-            const [result, routeError, unexpected] = await routes.sleep(5000).call({timeout: 100});
+            const [result, routeError, fatal] = await routes.sleep(5000).call({timeout: 100});
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(isRpcError(unexpected)).toBe(true);
-            expect(unexpected!.type).toBe('request-timeout');
+            expect(fatal).toBeDefined();
+            expect(isRpcError(fatal)).toBe(true);
+            expect(fatal!.type).toBe('request-timeout');
 
             middleFns.auth(authHeaders).removePrefill();
         });
@@ -1134,11 +1137,11 @@ describe('client', () => {
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
             middleFns.auth(authHeaders).prefill();
 
-            const [result, routeError, unexpected] = await routes.sleep(5000).call();
+            const [result, routeError, fatal] = await routes.sleep(5000).call();
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected!.type).toBe('request-timeout');
+            expect(fatal).toBeDefined();
+            expect(fatal!.type).toBe('request-timeout');
 
             middleFns.auth(authHeaders).removePrefill();
         });
@@ -1149,10 +1152,10 @@ describe('client', () => {
             middleFns.auth(authHeaders).prefill();
 
             // Client has 30s default, but per-request 100ms should take effect
-            const [result, , unexpected] = await routes.sleep(5000).call({timeout: 100});
+            const [result, , fatal] = await routes.sleep(5000).call({timeout: 100});
             expect(result).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected!.type).toBe('request-timeout');
+            expect(fatal).toBeDefined();
+            expect(fatal!.type).toBe('request-timeout');
 
             middleFns.auth(authHeaders).removePrefill();
         });
@@ -1166,12 +1169,12 @@ describe('client', () => {
             const p2 = routes.sleep(5000).call();
             setTimeout(() => client.abort(), 50);
 
-            const [, , unexpected1] = await p1;
-            const [, , unexpected2] = await p2;
-            expect(unexpected1).toBeDefined();
-            expect(unexpected1!.type).toBe('request-aborted');
-            expect(unexpected2).toBeDefined();
-            expect(unexpected2!.type).toBe('request-aborted');
+            const [, , fatal1] = await p1;
+            const [, , fatal2] = await p2;
+            expect(fatal1).toBeDefined();
+            expect(fatal1!.type).toBe('request-aborted');
+            expect(fatal2).toBeDefined();
+            expect(fatal2!.type).toBe('request-aborted');
 
             middleFns.auth(authHeaders).removePrefill();
         });
@@ -1198,9 +1201,9 @@ describe('client', () => {
             const p1 = routes.sleep(5000).call();
             setTimeout(() => client.destroy(), 50);
 
-            const [, , unexpected] = await p1;
-            expect(unexpected).toBeDefined();
-            expect(unexpected!.type).toBe('request-aborted');
+            const [, , fatal] = await p1;
+            expect(fatal).toBeDefined();
+            expect(fatal!.type).toBe('request-aborted');
         });
 
         it('cancellation works with middleFns in call setup', async () => {
@@ -1208,14 +1211,14 @@ describe('client', () => {
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
             const signal = AbortSignal.abort();
-            const [result, routeError, unexpected] = await routes.sleep(5000).call({
+            const [result, routeError, fatal] = await routes.sleep(5000).call({
                 middleFns: {auth: middleFns.auth(authHeaders)},
                 signal,
             });
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected!.type).toBe('request-aborted');
+            expect(fatal).toBeDefined();
+            expect(fatal!.type).toBe('request-aborted');
         });
 
         it('cancellation works with routesFlow', async () => {
@@ -1226,12 +1229,12 @@ describe('client', () => {
             const {routesFlow} = await import('./routesFlow.ts');
             const signal = AbortSignal.abort();
 
-            const [, errors, unexpected] = await routesFlow([routes.sleep(5000), routes.utils.sumTwo(5)]).call({signal});
+            const [, errors, fatal] = await routesFlow([routes.sleep(5000), routes.utils.sumTwo(5)]).call({signal});
 
-            // The abort is request-scoped: ONE unexpected error, per-route slots stay empty
+            // The abort is request-scoped: ONE fatal error, per-route slots stay empty
             expect(errors).toEqual([undefined, undefined]);
-            expect(unexpected).toBeDefined();
-            expect(unexpected!.type).toBe('request-aborted');
+            expect(fatal).toBeDefined();
+            expect(fatal!.type).toBe('request-aborted');
 
             middleFns.auth(authHeaders).removePrefill();
         });
@@ -1240,7 +1243,7 @@ describe('client', () => {
     // ========== Platform Error Dispatch Tests ==========
     // A "platform error" is set by the platform adapter (e.g. payload too large) BEFORE the router
     // ever runs. It is request-scoped and nobody's declared response, so the client's contract
-    // (dispatch rules R4/R6) is to surface it ONCE, in the unexpected slot — never in the route's
+    // (dispatch rules R4/R6) is to surface it ONCE, in the fatal slot — never in the route's
     // typed error slot, never in per-route flow slots, and never keyed to a middleFn. This describe
     // block locks in that single-slot contract (it deliberately reverses the previous fan-out-to-
     // every-slot behaviour).
@@ -1250,23 +1253,23 @@ describe('client', () => {
         // a 'request-payload-too-large' platform error returned by the platform adapter.
         const HUGE_PAYLOAD = 'x'.repeat(300_000);
 
-        it('platform error appears in the unexpected slot on a single route call', async () => {
+        it('platform error appears in the fatal slot on a single route call', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
             middleFns.auth(authHeaders).prefill();
 
-            const [result, routeError, unexpected] = await routes.getRequestInfo(HUGE_PAYLOAD).call();
+            const [result, routeError, fatal] = await routes.getRequestInfo(HUGE_PAYLOAD).call();
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(isRpcError(unexpected)).toBe(true);
-            expect(unexpected?.type).toBe('request-payload-too-large');
+            expect(fatal).toBeDefined();
+            expect(isRpcError(fatal)).toBe(true);
+            expect(fatal?.type).toBe('request-payload-too-large');
 
             await middleFns.auth(authHeaders).removePrefill();
         });
 
-        it('platform error in a routesFlow is ONE unexpected error, not one per route', async () => {
+        it('platform error in a routesFlow is ONE fatal error, not one per route', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
             middleFns.auth(authHeaders).prefill();
@@ -1274,16 +1277,16 @@ describe('client', () => {
             const {routesFlow} = await import('./routesFlow.ts');
             // Mix the oversized-payload route with a normal one — the request-scoped platform error
             // must not leak into any route's positional slot
-            const [results, errors, unexpected] = await routesFlow([
+            const [results, errors, fatal] = await routesFlow([
                 routes.getRequestInfo(HUGE_PAYLOAD),
                 routes.utils.sumTwo(5),
             ]).call();
 
             expect(results).toEqual([undefined, undefined]);
             expect(errors).toEqual([undefined, undefined]);
-            expect(unexpected).toBeDefined();
-            expect(isRpcError(unexpected)).toBe(true);
-            expect(unexpected?.type).toBe('request-payload-too-large');
+            expect(fatal).toBeDefined();
+            expect(isRpcError(fatal)).toBe(true);
+            expect(fatal?.type).toBe('request-payload-too-large');
 
             await middleFns.auth(authHeaders).removePrefill();
         });
@@ -1292,15 +1295,16 @@ describe('client', () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-            const [result, routeError, unexpected, middleFnResults] = await routes.getRequestInfo(HUGE_PAYLOAD).call({
+            const [result, routeError, fatal, middleFnResults, middleFnErrors] = await routes.getRequestInfo(HUGE_PAYLOAD).call({
                 middleFns: {auth: middleFns.auth(authHeaders)},
             });
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected?.type).toBe('request-payload-too-large');
+            expect(fatal).toBeDefined();
+            expect(fatal?.type).toBe('request-payload-too-large');
             expect(middleFnResults).toEqual({});
+            expect(middleFnErrors).toEqual({});
         });
     });
 });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -117,7 +117,7 @@ export class MionClient {
             return this.buildResult(
                 routeSubRequest,
                 workflowSubRequests,
-                middleFnsRecord || allMiddleFns,
+                this.mergeMiddleFns(middleFnsRecord, allMiddleFns),
                 undefined,
                 request.thrownErrorIds
             );
@@ -128,11 +128,24 @@ export class MionClient {
             return this.buildResult(
                 routeSubRequest,
                 workflowSubRequests,
-                middleFnsRecord || allMiddleFns,
+                this.mergeMiddleFns(middleFnsRecord, allMiddleFns),
                 errors,
                 request.thrownErrorIds
             );
         }
+    }
+
+    /** Named record entries keep their names; middleFns that took part in the request but are not in the
+     * record (restored prefills) are added under their id, so their results/errors are never dropped */
+    private mergeMiddleFns(
+        middleFnsRecord: Record<string, MiddlewareSubRequest<any>> | undefined,
+        allMiddleFns: MiddlewareSubRequest<any>[]
+    ): Record<string, MiddlewareSubRequest<any>> | MiddlewareSubRequest<any>[] {
+        if (!middleFnsRecord) return allMiddleFns;
+        const recordIds = new Set(Object.values(middleFnsRecord).map((middleFn) => middleFn.id));
+        const merged: Record<string, MiddlewareSubRequest<any>> = {...middleFnsRecord};
+        for (const middleFn of allMiddleFns) if (!recordIds.has(middleFn.id)) merged[middleFn.id] = middleFn;
+        return merged;
     }
 
     /** Get route IDs from single route or routesFlow routes */
@@ -174,11 +187,13 @@ export class MionClient {
         }
     }
 
-    /** Build the result 4-tuple [result, error, unexpected, middleFnResults] per the dispatch contract:
+    /** Build the result 5-tuple [result, error, fatal, middleFnResults, middleFnErrors] per the dispatch contract:
      * - slot 1 gets ONLY the route's own declared errors | ValidationError (thrown route errors do not qualify)
-     * - slot 2 (unexpected) gets everything the route did not declare: middleFn errors, the route's own
-     *   thrown errors, and request-scoped transport/platform/framework errors. When several exist it holds
-     *   the first in execution order (middleFns run before the route)
+     * - slot 4 gets each middleFn's DECLARED errors | ValidationError, keyed by name - one entry per middleFn,
+     *   so no information is lost when several fail
+     * - slot 2 (fatal) gets what NOBODY declared: a thrown/undeclared error (route or middleFn), request-scoped
+     *   transport/platform/framework errors, and errors for middleFns that were not part of this request. When
+     *   several exist it holds the first in execution order (middleFns run before the route)
      * - slot 0 keeps the route result whatever else failed; no error ever crosses into another slot */
     private buildResult<Routes extends RouteSubRequest<any>[], H extends Record<string, MiddlewareSubRequest<any>>>(
         routeSubRequest: RouteSubRequest<any> | undefined,
@@ -216,7 +231,8 @@ export class MionClient {
         routeIds.forEach((id) => processedIds.add(id));
 
         // middleFns can be a named record (from callWithMiddleFns/routesFlow) or an array (from executeCall)
-        let unexpectedPart: RpcError<string> | undefined;
+        const middleFnsErrors = {} as Record<string, any>;
+        let fatalPart: RpcError<string> | undefined;
         const middleFnEntries: [string, MiddlewareSubRequest<any>][] = Array.isArray(middleFns)
             ? middleFns.map((middleFn) => [middleFn.id, middleFn])
             : Object.entries(middleFns);
@@ -224,31 +240,37 @@ export class MionClient {
             processedIds.add(middleFn.id);
             if (middleFn.resolvedValue !== undefined) middleFnsResults[name] = middleFn.resolvedValue;
             const middleFnError = errors?.get(middleFn.id);
-            if (middleFnError && unexpectedPart === undefined) unexpectedPart = middleFnError;
+            if (!middleFnError) continue;
+            if (thrownErrorIds.has(middleFn.id)) {
+                // a middleFn's thrown/undeclared error is fatal - its typed record cannot carry it
+                if (fatalPart === undefined) fatalPart = middleFnError;
+            } else {
+                middleFnsErrors[name] = middleFnError;
+            }
         }
 
-        if (errors && unexpectedPart === undefined) {
+        if (errors && fatalPart === undefined) {
             // the route's own thrown/undeclared error
             for (const id of routeIds) {
                 const routeThrownError = errors.get(id);
                 if (routeThrownError && thrownErrorIds.has(id)) {
-                    unexpectedPart = routeThrownError;
+                    fatalPart = routeThrownError;
                     break;
                 }
             }
         }
-        if (errors && unexpectedPart === undefined) {
-            // request-scoped errors (transport, platform, framework) and errors from ids outside this
-            // request (restored prefilled middleFns, foreign response entries)
+        if (errors && fatalPart === undefined) {
+            // request-scoped errors (transport, platform, framework) and errors keyed to ids that were
+            // not part of this request (e.g. a required middleFn the caller never sent)
             for (const [id, error] of errors) {
                 if (!processedIds.has(id)) {
-                    unexpectedPart = error;
+                    fatalPart = error;
                     break;
                 }
             }
         }
 
-        return [routeResultPart, routeErrorPart, unexpectedPart, middleFnsResults] as any;
+        return [routeResultPart, routeErrorPart, fatalPart, middleFnsResults, middleFnsErrors] as any;
     }
 
     typeErrors<List extends SubRequest<any>[]>(...subRequest: List): Promise<RunTypeError[]> {

--- a/packages/client/src/errorDispatch.spec.ts
+++ b/packages/client/src/errorDispatch.spec.ts
@@ -8,14 +8,14 @@
 /**
  * Contract tests for the client error dispatch rules (docs spec: client-error-dispatch-contract).
  *
- * The result tuple is [result, error, unexpected, middleFnResults]:
+ * The result tuple is [result, error, fatal, middleFnResults, middleFnErrors]:
  * - R1 route returned its own declared error            -> slot 1 (that route's index in a flow)
  * - R2 param validation failed for a route              -> slot 1 (client- or server-side)
- * - R3 middleFn declared error / validation error       -> its onError listener AND slot 2
- * - R4 anything thrown / undeclared                     -> slot 2 only, NO listener fires
+ * - R3 middleFn declared error / validation error       -> slot 4 under its name AND its onError listener
+ * - R4 anything thrown / undeclared, or an error for a  -> slot 2 (fatal) only, NO listener fires;
+ *      middleFn that was not part of the request           several fatals: first in execution order
  * - R5 route produced a result                          -> slot 0 keeps it, whatever else failed
  * - R6 an error the route did not declare               -> never appears in slot 1
- * - R7 several non-route errors                         -> slot 2 holds the first in execution order
  */
 
 import {describe, it, expect} from 'vitest';
@@ -37,41 +37,41 @@ describe('client error dispatch contract', () => {
     describe('single route calls', () => {
         it('T1 (R1): route returns its declared error -> slot 1 only', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [result, routeError, unexpected] = await routes.alwaysFails(someUser).call({
+            const [result, routeError, fatal] = await routes.alwaysFails(someUser).call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))},
             });
 
             expect(result).toBeUndefined();
             expect(routeError?.type).toBe('unknown-error');
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
 
         it('T2 (R2): route param validation fails client-side -> slot 1 holds validation-error', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [result, routeError, unexpected] = await routes.calculateAge('nope' as unknown as number).call({
+            const [result, routeError, fatal] = await routes.calculateAge('nope' as unknown as number).call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))},
             });
 
             expect(result).toBeUndefined();
             expect(routeError?.type).toBe('validation-error');
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
 
         it('T2b (R2): route param validation fails server-side -> still slot 1 (thrown carve-out)', async () => {
             // validation-error is thrown server-side but is part of every route's expected union
             const {routes, middleFns} = initClient<MyApi>({baseURL, validateParams: false});
-            const [result, routeError, unexpected] = await routes.calculateAge('nope' as unknown as number).call({
+            const [result, routeError, fatal] = await routes.calculateAge('nope' as unknown as number).call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))},
             });
 
             expect(result).toBeUndefined();
             expect(routeError?.type).toBe('validation-error');
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
 
         it('T3 (R5, pins the masking bug): route succeeds while a middleFn fails -> slot 0 keeps the result', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [result, routeError, unexpected] = await routes.sayHello(someUser).call({
+            const [result, routeError, fatal, , middleFnErrors] = await routes.sayHello(someUser).call({
                 middleFns: {
                     auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN')),
                     session: middleFns.session('expired'),
@@ -82,12 +82,13 @@ describe('client error dispatch contract', () => {
             // so the caller must see the result even though the session middleFn failed
             expect(result).toBe('Hello John Doe');
             expect(routeError).toBeUndefined();
-            expect(unexpected?.type).toBe('session-expired');
+            expect(fatal).toBeUndefined();
+            expect(middleFnErrors?.session?.type).toBe('session-expired');
         });
 
         it('T4 (R6, pins the hijack bug): a middleFn error never appears in the typed route slot', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [, routeError, unexpected] = await routes.sayHello(someUser).call({
+            const [, routeError, fatal, , middleFnErrors] = await routes.sayHello(someUser).call({
                 middleFns: {
                     auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN')),
                     session: middleFns.session('expired'),
@@ -95,72 +96,73 @@ describe('client error dispatch contract', () => {
             });
 
             expect(routeError).toBeUndefined();
-            expect(unexpected?.type).toBe('session-expired');
+            expect(fatal).toBeUndefined();
+            expect(middleFnErrors?.session?.type).toBe('session-expired');
         });
 
         it('T5 (R4): timeout -> slot 2 holds request-timeout; slots 0 and 1 stay empty', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             middleFns.auth(createAuthHeaders('XWYZ-TOKEN')).prefill();
 
-            const [result, routeError, unexpected] = await routes.sleep(5000).call({timeout: 100});
+            const [result, routeError, fatal] = await routes.sleep(5000).call({timeout: 100});
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected?.type).toBe('request-timeout');
+            expect(fatal?.type).toBe('request-timeout');
 
             await middleFns.auth(createAuthHeaders('XWYZ-TOKEN')).removePrefill();
         });
 
         it('T6 (R4): abort -> slot 2 holds request-aborted', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [result, routeError, unexpected] = await routes.sleep(5000).call({
+            const [result, routeError, fatal] = await routes.sleep(5000).call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))},
                 signal: AbortSignal.abort(),
             });
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected?.type).toBe('request-aborted');
+            expect(fatal?.type).toBe('request-aborted');
         });
 
         it('T7 (R4): platform error -> slot 2 only', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [result, routeError, unexpected, middleFnResults] = await routes.getRequestInfo('x'.repeat(300_000)).call({
+            const [result, routeError, fatal, middleFnResults] = await routes.getRequestInfo('x'.repeat(300_000)).call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))},
             });
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected?.type).toBe('request-payload-too-large');
+            expect(fatal?.type).toBe('request-payload-too-large');
             expect(middleFnResults).toEqual({});
         });
 
         it('T8 (R4): unreachable server -> slot 2 holds the wrapped network failure', async () => {
             const {routes} = initClient<MyApi>({baseURL: 'http://127.0.0.1:59987'});
-            const [result, routeError, unexpected] = await routes.calculateAge(1990).call();
+            const [result, routeError, fatal] = await routes.calculateAge(1990).call();
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(isRpcError(unexpected)).toBe(true);
+            expect(fatal).toBeDefined();
+            expect(isRpcError(fatal)).toBe(true);
         });
 
         it('T9 (R4): route THROWS an undeclared error server-side -> slot 2, never slot 1', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [result, routeError, unexpected] = await routes.throwsUnexpectedly('boom').call({
+            const [result, routeError, fatal] = await routes.throwsUnexpectedly('boom').call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))},
             });
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            expect(unexpected?.type).toBe('db-connection-lost');
+            expect(fatal?.type).toBe('db-connection-lost');
         });
     });
 
     describe('routesFlow calls', () => {
         it('T10 (R1): one route fails, another succeeds -> each stays in its own index; slot 2 empty', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
-            const [[failResult, sum], [failError, sumError], unexpected] = await routesFlow([
+            const [[failResult, sum], [failError, sumError], fatal] = await routesFlow([
                 routes.alwaysFails(someUser),
                 routes.utils.sumTwo(5),
             ]).call({middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))}});
@@ -169,36 +171,37 @@ describe('client error dispatch contract', () => {
             expect(failError?.type).toBe('unknown-error');
             expect(sum).toBe(7);
             expect(sumError).toBeUndefined();
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
 
-        it('T11 (R4, pins the unreachable-fatal bug): flow timeout -> ONE request-scoped unexpected error', async () => {
+        it('T11 (R4, pins the unreachable-fatal bug): flow timeout -> ONE request-scoped fatal error', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             middleFns.auth(createAuthHeaders('XWYZ-TOKEN')).prefill();
 
-            const [results, errors, unexpected] = await routesFlow([routes.sleep(5000), routes.utils.sumTwo(5)]).call({
+            const [results, errors, fatal] = await routesFlow([routes.sleep(5000), routes.utils.sumTwo(5)]).call({
                 timeout: 100,
             });
 
             expect(results).toEqual([undefined, undefined]);
             expect(errors).toEqual([undefined, undefined]);
-            expect(unexpected?.type).toBe('request-timeout');
+            expect(fatal?.type).toBe('request-timeout');
 
             await middleFns.auth(createAuthHeaders('XWYZ-TOKEN')).removePrefill();
         });
 
-        it('T12 (R3): flow + failing middleFn -> slot 2 + listener; per-route slots stay empty', async () => {
+        it('T12 (R3): flow + failing middleFn -> its middleFnErrors slot + listener; per-route slots stay empty', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             let listenerError: any;
             const session = middleFns.session('expired');
             session.onError('session-expired', (error) => (listenerError = error));
 
-            const [, [greetingError], unexpected] = await routesFlow([routes.sayHello(someUser)]).call({
+            const [, [greetingError], fatal, , middleFnErrors] = await routesFlow([routes.sayHello(someUser)]).call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN')), session},
             });
 
             expect(greetingError).toBeUndefined();
-            expect(unexpected?.type).toBe('session-expired');
+            expect(fatal).toBeUndefined();
+            expect(middleFnErrors?.session?.type).toBe('session-expired');
             expect(listenerError?.type).toBe('session-expired');
         });
 
@@ -217,7 +220,7 @@ describe('client error dispatch contract', () => {
     });
 
     describe('listeners', () => {
-        it('T14 (R3): a middleFn declared error reaches BOTH its listener and slot 2', async () => {
+        it('T14 (R3): a middleFn declared error reaches BOTH its listener and its middleFnErrors slot', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             let listenerError: any;
             middleFns
@@ -226,10 +229,11 @@ describe('client error dispatch contract', () => {
                 .onError('session-expired', (error) => (listenerError = error));
             middleFns.auth(createAuthHeaders('XWYZ-TOKEN')).prefill();
 
-            const [, routeError, unexpected] = await routes.sayHello(someUser).call();
+            const [, routeError, fatal, , middleFnErrors] = await routes.sayHello(someUser).call();
 
             expect(routeError).toBeUndefined();
-            expect(unexpected?.type).toBe('session-expired');
+            expect(fatal).toBeUndefined();
+            expect(middleFnErrors?.session?.type).toBe('session-expired');
             expect(listenerError?.type).toBe('session-expired');
 
             await middleFns.session('expired').removePrefill();
@@ -242,12 +246,12 @@ describe('client error dispatch contract', () => {
             const session = middleFns.session('valid-token');
             (session as any).onError('request-timeout', () => (listenerFired = true));
 
-            const [, , unexpected] = await routes.sleep(5000).call({
+            const [, , fatal] = await routes.sleep(5000).call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN')), session},
                 timeout: 100,
             });
 
-            expect(unexpected?.type).toBe('request-timeout');
+            expect(fatal?.type).toBe('request-timeout');
             expect(listenerFired).toBe(false);
         });
 
@@ -270,28 +274,31 @@ describe('client error dispatch contract', () => {
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN'))},
             });
 
-            const [, , unexpected, middleFnResults] = result;
-            expect(unexpected?.type).toBe('request-payload-too-large');
+            const [, , fatal, middleFnResults, middleFnErrors] = result;
+            expect(fatal?.type).toBe('request-payload-too-large');
             expect(Object.keys(middleFnResults ?? {})).toEqual([]);
-            expect(JSON.stringify(Object.keys(result[3] ?? {}))).not.toContain('mion@');
+            expect(Object.keys(middleFnErrors ?? {})).toEqual([]);
+            expect(JSON.stringify([...Object.keys(result[3] ?? {}), ...Object.keys(result[4] ?? {})])).not.toContain('mion@');
         });
 
-        it('T17 (R7): several non-route errors -> slot 2 holds the first in execution order, every listener still fires', async () => {
+        it('T17: a failing middleFn AND a throwing route lose NO information - each error keeps its slot', async () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             let auditListenerError: any;
             const audit = middleFns.audit(true);
             audit.onError('audit-failed', (error) => (auditListenerError = error));
 
-            // the audit middleFn (runOnError) fails BEFORE the route throws its own undeclared error
-            const [result, routeError, unexpected] = await routes.throwsUnexpectedly('boom').call({
+            // the audit middleFn (runOnError) fails with its DECLARED error and the route throws
+            // an undeclared one - separating the slots means BOTH stay visible
+            const [result, routeError, fatal, , middleFnErrors] = await routes.throwsUnexpectedly('boom').call({
                 middleFns: {auth: middleFns.auth(createAuthHeaders('XWYZ-TOKEN')), audit},
             });
 
             expect(result).toBeUndefined();
             expect(routeError).toBeUndefined();
-            // first error in execution order wins the single slot (middleFns run before the route)
-            expect(unexpected?.type).toBe('audit-failed');
-            // the declared middleFn error still reaches its own typed listener
+            // the undeclared route throw is the fatal error
+            expect(fatal?.type).toBe('db-connection-lost');
+            // the declared middleFn error keeps its own slot AND reaches its typed listener
+            expect(middleFnErrors?.audit?.type).toBe('audit-failed');
             expect(auditListenerError?.type).toBe('audit-failed');
         });
     });

--- a/packages/client/src/lib/validationErrors.spec.ts
+++ b/packages/client/src/lib/validationErrors.spec.ts
@@ -137,16 +137,16 @@ describe('client-side validation errors', () => {
     });
 
     describe('middleFn validation errors', () => {
-        it('missing required auth header surfaces in the unexpected slot, not the route slot', async () => {
+        it('missing required auth header surfaces in the fatal slot, not the route slot', async () => {
             const {routes} = initClient<MyApi>({baseURL});
 
             // Call without required auth middleFn - the auth validation error is not the route's
-            // declared error, so it lands in the unexpected slot
-            const [, routeError, unexpected] = await routes.sayHello({name: 'John', surname: 'Doe'}).call();
+            // declared error, so it lands in the fatal slot
+            const [, routeError, fatal] = await routes.sayHello({name: 'John', surname: 'Doe'}).call();
 
             expect(routeError).toBeUndefined();
-            expect(unexpected).toBeDefined();
-            expect(unexpected?.type).toBe('validation-error');
+            expect(fatal).toBeDefined();
+            expect(fatal?.type).toBe('validation-error');
         });
     });
 });

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -232,12 +232,12 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
         if (!(MION_ROUTES.platformError in deserialized)) return false;
         const platformError = deserialized[MION_ROUTES.platformError];
         Object.values(this.subRequestList).forEach((methodMeta) => (methodMeta.isResolved = true));
-        this.setUnexpectedError(CLIENT_REQUEST_ERROR_ID, platformError as RpcError<string>, errors);
+        this.setFatalError(CLIENT_REQUEST_ERROR_ID, platformError as RpcError<string>, errors);
         return true;
     }
 
-    /** Records an error as unexpected (thrown/undeclared) in the errors map */
-    private setUnexpectedError(id: string, error: RpcError<string>, errors: RequestErrors): void {
+    /** Records an error as fatal (thrown/undeclared) in the errors map */
+    private setFatalError(id: string, error: RpcError<string>, errors: RequestErrors): void {
         errors.set(id, error);
         this.thrownErrorIds.add(id);
     }
@@ -273,7 +273,7 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
         Object.entries(deserialized).forEach(([id, value]) => {
             if (id === MION_ROUTES.thrownErrors) return;
             // an error for an id this request never asked for is nobody's declared response
-            if (!(id in this.subRequestList) && isRpcError(value)) this.setUnexpectedError(id, value, errors);
+            if (!(id in this.subRequestList) && isRpcError(value)) this.setFatalError(id, value, errors);
         });
     }
 
@@ -284,7 +284,7 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
         const reason = this.signal?.aborted ? this.signal.reason : undefined;
         if (reason instanceof DOMException) {
             if (reason.name === 'TimeoutError') {
-                this.setUnexpectedError(
+                this.setFatalError(
                     CLIENT_REQUEST_ERROR_ID,
                     new RpcError({
                         type: 'request-timeout',
@@ -296,7 +296,7 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
                 return;
             }
             if (reason.name === 'AbortError') {
-                this.setUnexpectedError(
+                this.setFatalError(
                     CLIENT_REQUEST_ERROR_ID,
                     new RpcError({
                         type: 'request-aborted',
@@ -309,11 +309,11 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
             }
         }
         if (isRpcError(error)) {
-            this.setUnexpectedError(CLIENT_REQUEST_ERROR_ID, error, errors);
+            this.setFatalError(CLIENT_REQUEST_ERROR_ID, error, errors);
             return;
         }
         const message = error?.message ? `${stageMessage}: ${error.message}` : `${stageMessage}: Unknown Error`;
-        this.setUnexpectedError(
+        this.setFatalError(
             CLIENT_REQUEST_ERROR_ID,
             new RpcError({
                 type: error?.name || 'unknown-error',
@@ -340,7 +340,7 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
         const methodMeta = routesCache.getMetadata(this.requestId);
         if (!methodMeta) {
             if (errors) {
-                this.setUnexpectedError(
+                this.setFatalError(
                     this.requestId,
                     new RpcError({
                         type: 'route-metadata-not-found',
@@ -377,7 +377,7 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
             const methodMeta = routesCache.getMetadata(routeSubRequest.id);
             if (!methodMeta) {
                 if (errors) {
-                    this.setUnexpectedError(
+                    this.setFatalError(
                         routeSubRequest.id,
                         new RpcError({
                             type: 'route-metadata-not-found',

--- a/packages/client/src/routesFlow.spec.ts
+++ b/packages/client/src/routesFlow.spec.ts
@@ -74,13 +74,13 @@ describe('routesFlow', () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-            const [[greeting], [greetingError], unexpected] = await routesFlow([routes.sayHello(someUser)]).call({
+            const [[greeting], [greetingError], fatal] = await routesFlow([routes.sayHello(someUser)]).call({
                 middleFns: {auth: middleFns.auth(authHeaders)},
             });
 
             expect(greeting).toEqual('Hello John Doe');
             expect(greetingError).toBeUndefined();
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
 
         it('should handle route errors in routesFlow', async () => {
@@ -136,7 +136,7 @@ describe('routesFlow', () => {
             const {routes, middleFns} = initClient<MyApi>({baseURL});
             const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
-            const [[greeting, age], [greetingError, ageError], unexpected] = await routes
+            const [[greeting, age], [greetingError, ageError], fatal] = await routes
                 .sayHello(someUser)
                 .call({otherRoutes: [routes.calculateAge(1990)], middleFns: {auth: middleFns.auth(authHeaders)}});
 
@@ -144,7 +144,7 @@ describe('routesFlow', () => {
             expect(age).toEqual(new Date().getFullYear() - 1990);
             expect(greetingError).toBeUndefined();
             expect(ageError).toBeUndefined();
-            expect(unexpected).toBeUndefined();
+            expect(fatal).toBeUndefined();
         });
     });
 
@@ -370,15 +370,15 @@ describe('serverMapFrom e2e in routesFlow', () => {
         const authHeaders = createAuthHeaders('XWYZ-TOKEN');
 
         const customer = routes.getCustomerById(42);
-        const [[customerData, prefs], [customerError, prefsError], unexpected] = await routesFlow([
+        const [[customerData, prefs], [customerError, prefsError], fatal] = await routesFlow([
             customer,
             routes.getPreferencesById(serverMapFrom<typeof customer, number>(customer, 'nonexistentMapper').asArg()),
         ]).call({middleFns: {auth: middleFns.auth(authHeaders)}});
 
         // the whole flow is rejected while building the chain (routesFlow-mapping-missing-pure-fn
         // server-side) — nothing executes. The failure is nobody's declared response, so it
-        // surfaces once in the unexpected slot, never in the per-route typed slots.
-        expect(unexpected ?? prefsError ?? customerError).toBeTruthy();
+        // surfaces once in the fatal slot, never in the per-route typed slots.
+        expect(fatal ?? prefsError ?? customerError).toBeTruthy();
         expect(prefs).toBeUndefined();
         expect(customerData).toBeUndefined();
     });

--- a/packages/client/src/routesFlow.ts
+++ b/packages/client/src/routesFlow.ts
@@ -45,7 +45,7 @@ export function routesFlow<Routes extends RouteSubRequest<any>[]>(routeSubReques
     return {
         async call(setup?: {middleFns?: Record<string, MiddlewareSubRequest<any>>; signal?: AbortSignal; timeout?: number}) {
             const middleFns = setup?.middleFns ?? {};
-            const [results, errors, unexpected, middleFnResults] = await client.execute(
+            const [results, errors, fatal, middleFnResults, middleFnErrors] = await client.execute(
                 undefined,
                 routeSubRequests as any,
                 middleFns as any,
@@ -54,7 +54,7 @@ export function routesFlow<Routes extends RouteSubRequest<any>[]>(routeSubReques
             );
             const emptyResults = routeSubRequests.map(() => undefined);
             const emptyErrors = routeSubRequests.map(() => undefined);
-            return [results ?? emptyResults, errors ?? emptyErrors, unexpected, middleFnResults] as any;
+            return [results ?? emptyResults, errors ?? emptyErrors, fatal, middleFnResults, middleFnErrors] as any;
         },
     };
 }

--- a/packages/client/src/subRequest.ts
+++ b/packages/client/src/subRequest.ts
@@ -105,7 +105,7 @@ export class MionSubRequest<S = any, E extends RpcError<string, any> = any>
         timeout?: number
     ): Promise<any> {
         const allRoutes = [this as unknown as RouteSubRequest<any>, ...otherRoutes];
-        const [results, errors, unexpected, mfR] = await this.client.execute(
+        const [results, errors, fatal, mfR, mfE] = await this.client.execute(
             undefined,
             allRoutes,
             middleFns ?? {},
@@ -114,7 +114,7 @@ export class MionSubRequest<S = any, E extends RpcError<string, any> = any>
         );
         const emptyResults = allRoutes.map(() => undefined);
         const emptyErrors = allRoutes.map(() => undefined);
-        return [results ?? emptyResults, errors ?? emptyErrors, unexpected, mfR];
+        return [results ?? emptyResults, errors ?? emptyErrors, fatal, mfR, mfE];
     }
 
     /** Validates parameters and returns type errors */

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -10,21 +10,27 @@ import type {CoreRouterOptions, Prettify, RunTypeError, SerializerMode, Validati
 import type {PublicHeadersFn, PublicMiddleFn, RemoteApi, PublicRoute} from '@mionjs/router';
 import type {TypedEvent} from './lib/typedEvent.ts';
 
-// type-unexpected-error-start
-/** Any error not declared by the route: a middleFn's error, transport, platform, framework, or an
- * undeclared throw. Open by nature, the code can be anything. Typed access to a middleFn's declared
- * errors is via its onError listeners. **/
-export type UnexpectedError = RpcError<string>;
-// type-unexpected-error-end
+// type-fatal-error-start
+/** Any error that is not part of a declared response: transport, platform, framework, or an
+ * undeclared throw (a middleFn's DECLARED errors are not fatal - they land in the middleFnErrors
+ * record and its onError listeners). Open by nature, the code can be anything. **/
+export type FatalError = RpcError<string>;
+// type-fatal-error-end
 
 // type-result-start
-/** Result type for call() - 4-tuple pattern:
- * [routeResult, routeError (declared | ValidationError), unexpected, middleFnResults] **/
-export type Result<RouteSuccess, RouteError, MiddleFnsResults extends Record<string, unknown> = Record<string, unknown>> = [
+/** Result type for call() - 5-tuple pattern:
+ * [routeResult, routeError (declared | ValidationError), fatal, middleFnResults, middleFnErrors] **/
+export type Result<
+    RouteSuccess,
+    RouteError,
+    MiddleFnsResults extends Record<string, unknown> = Record<string, unknown>,
+    MiddleFnsErrors extends Record<string, unknown> = Record<string, RpcError<string, unknown>>,
+> = [
     RouteSuccess | undefined,
     RouteError | undefined,
-    UnexpectedError | undefined,
+    FatalError | undefined,
     MiddleFnsResults | undefined,
+    MiddleFnsErrors | undefined,
 ];
 // type-result-end
 
@@ -35,16 +41,17 @@ export type MiddleFnSuccess<H> = H extends MiddlewareSubRequest<infer PH> ? Hand
 export type MiddleFnError<H> = H extends MiddlewareSubRequest<infer PH> ? Simplify<HandlerErrors<PH>> : never;
 
 // type-routesFlow-result-start
-/** Result type for routesFlow() function - 4-tuple pattern:
- * [routeResults[], routeErrors[] (declared | ValidationError), unexpected (request-scoped, ONE slot), middleFnResults] **/
+/** Result type for routesFlow() function - 5-tuple pattern:
+ * [routeResults[], routeErrors[] (declared | ValidationError), fatal (request-scoped, ONE slot), middleFnResults, middleFnErrors] **/
 export type WorkflowResult<
     Routes extends RouteSubRequest<any>[],
     MiddleFns extends Record<string, MiddlewareSubRequest<any>> = Record<string, MiddlewareSubRequest<any>>,
 > = [
     WorkflowRouteResults<Routes>,
     WorkflowRouteErrors<Routes>,
-    UnexpectedError | undefined,
+    FatalError | undefined,
     {[K in keyof MiddleFns]?: MiddleFnSuccess<MiddleFns[K]>} | undefined,
+    {[K in keyof MiddleFns]?: MiddleFnError<MiddleFns[K]>} | undefined,
 ];
 // type-routesFlow-result-end
 
@@ -166,7 +173,7 @@ export interface RouteSubRequest<PH extends PublicHandler> extends SubRequest<PH
     /** Validates Route's parameters and returns type errors */
     typeErrors: () => Promise<RunTypeError[]>;
 
-    /** Calls a remote route and returns a Result 4-tuple */
+    /** Calls a remote route and returns a Result 5-tuple */
     call(setup?: {
         middleFns?: never;
         otherRoutes?: never;
@@ -180,7 +187,14 @@ export interface RouteSubRequest<PH extends PublicHandler> extends SubRequest<PH
         otherRoutes?: never;
         signal?: AbortSignal;
         timeout?: number;
-    }): Promise<Result<HandlerSuccessResponse<PH>, Simplify<HandlerErrors<PH>>, {[K in keyof H]?: MiddleFnSuccess<H[K]>}>>;
+    }): Promise<
+        Result<
+            HandlerSuccessResponse<PH>,
+            Simplify<HandlerErrors<PH>>,
+            {[K in keyof H]?: MiddleFnSuccess<H[K]>},
+            {[K in keyof H]?: MiddleFnError<H[K]>}
+        >
+    >;
 
     /** Calls this route with other routes in a single HTTP request */
     call<

--- a/packages/examples/src/client/cancellation-abort-signal.ts
+++ b/packages/examples/src/client/cancellation-abort-signal.ts
@@ -12,7 +12,7 @@ const resultPromise = routes.users.sayHello({id: '1', name: 'John', surname: 'Do
 // cancel the request (e.g. on component unmount or user action)
 controller.abort();
 
-const [result, , unexpected] = await resultPromise;
-if (unexpected?.type === 'request-aborted') {
+const [result, , fatal] = await resultPromise;
+if (fatal?.type === 'request-aborted') {
     console.log('Request was canceled');
 }

--- a/packages/examples/src/client/cancellation-client-timeout.ts
+++ b/packages/examples/src/client/cancellation-client-timeout.ts
@@ -10,6 +10,6 @@ const {routes} = initClient<MyApi>({
 // uses the 10s default timeout
 const [r1] = await routes.users.sayHello({id: '1', name: 'John', surname: 'Doe'}).call();
 
-// overrides to 2s for this specific call; a timeout surfaces in the unexpected slot
+// overrides to 2s for this specific call; a timeout surfaces in the fatal slot
 const [r2, , timeoutErr] = await routes.users.sayHello({id: '1', name: 'John', surname: 'Doe'}).call({timeout: 2000});
 if (timeoutErr?.type === 'request-timeout') console.log('too slow');

--- a/packages/examples/src/client/cancellation-global-abort.ts
+++ b/packages/examples/src/client/cancellation-global-abort.ts
@@ -10,11 +10,11 @@ const p2 = routes.utils.sum(5, 2).call();
 // cancel ALL in-flight requests (e.g. user navigated away)
 client.abort();
 
-// both surface 'request-aborted' in the unexpected slot
-const [, , unexpected1] = await p1;
-const [, , unexpected2] = await p2;
-if (unexpected1?.type === 'request-aborted') console.log('first request canceled');
-if (unexpected2?.type === 'request-aborted') console.log('second request canceled');
+// both surface 'request-aborted' in the fatal slot
+const [, , fatal1] = await p1;
+const [, , fatal2] = await p2;
+if (fatal1?.type === 'request-aborted') console.log('first request canceled');
+if (fatal2?.type === 'request-aborted') console.log('second request canceled');
 
 // new requests work normally after abort
 const [greeting] = await routes.users.sayHello({id: '1', name: 'John', surname: 'Doe'}).call();

--- a/packages/examples/src/client/cancellation-timeout.ts
+++ b/packages/examples/src/client/cancellation-timeout.ts
@@ -4,10 +4,10 @@ import type {MyApi} from './server.routes.ts';
 const {routes} = initClient<MyApi>({baseURL: 'http://localhost:3000'});
 
 // this request will fail if it takes longer than 5 seconds
-const [result, error, unexpected] = await routes.users.sayHello({id: '1', name: 'John', surname: 'Doe'}).call({timeout: 5000});
+const [result, error, fatal] = await routes.users.sayHello({id: '1', name: 'John', surname: 'Doe'}).call({timeout: 5000});
 
 // transport failures are never part of the route's typed error union: they land in the
-// unexpected slot, which is an open RpcError<string>
-if (unexpected?.type === 'request-timeout') {
+// fatal slot, which is an open RpcError<string>
+if (fatal?.type === 'request-timeout') {
     console.log('Request took too long');
 }

--- a/packages/examples/src/client/cancellation-with-middleFns.ts
+++ b/packages/examples/src/client/cancellation-with-middleFns.ts
@@ -7,7 +7,7 @@ const {routes, middleFns} = initClient<MyApi>({baseURL: 'http://localhost:3000'}
 const controller = new AbortController();
 
 // cancellation works with middleFns
-const [result, error, unexpected, mfResults] = await routes.users.sayHello({id: '1', name: 'John', surname: 'Doe'}).call({
+const [result, error, fatal, mfResults, mfErrors] = await routes.users.sayHello({id: '1', name: 'John', surname: 'Doe'}).call({
     middleFns: {auth: middleFns.auth(new HeadersSubset({Authorization: 'myToken-XYZ'}))},
     timeout: 5000,
     signal: controller.signal,

--- a/packages/examples/src/client/client-error-slots.ts
+++ b/packages/examples/src/client/client-error-slots.ts
@@ -1,17 +1,18 @@
 import {initClient} from '@mionjs/client';
-import type {UnexpectedError} from '@mionjs/client';
+import type {FatalError} from '@mionjs/client';
 import type {MyApi} from './server.routes.ts';
 
-const {routes} = initClient<MyApi>({baseURL: 'http://localhost:3000'});
+const {routes, middleFns} = initClient<MyApi>({baseURL: 'http://localhost:3000'});
 
-// The result tuple is [result, error, unexpected, middleFnResults]:
+// The result tuple is [result, error, fatal, middleFnResults, middleFnErrors]:
 // - slot 1 (error) is the route's DECLARED errors | ValidationError - a CLOSED, strongly typed union
-// - slot 2 (unexpected) is anything the route did not declare - an OPEN RpcError<string>
-const [user, error, unexpected] = await routes.users.getById('USER-123').call();
+// - slot 2 (fatal) is anything NOBODY declared - an OPEN RpcError<string>
+// - slot 4 (middleFnErrors) is each middleFn's DECLARED errors, strongly typed by name
+const [user, error, fatal] = await routes.users.getById('USER-123').call();
 
 // slot 2 is open: transport/framework codes narrow with NO cast
-if (unexpected?.type === 'request-timeout') console.log('took too long');
-if (unexpected?.type === 'request-aborted') console.log('canceled');
+if (fatal?.type === 'request-timeout') console.log('took too long');
+if (fatal?.type === 'request-aborted') console.log('canceled');
 
 // slot 1 stays CLOSED: a transport code can never be part of the route's typed union
 // @ts-expect-error -- shown on purpose; the assertion fails the build if this ever stops erroring
@@ -40,9 +41,17 @@ if (user === undefined && error) {
 if (error?.type === 'user-not-found') console.log(error.errorData?.bogus);
 
 // slot 2's type is exported for signatures
-const lastFailure: UnexpectedError | undefined = unexpected;
+const lastFailure: FatalError | undefined = fatal;
 console.log(lastFailure?.publicMessage);
 
-// slot 2 is the unexpected error, NOT the middleFn record the old tuple kept there
-// @ts-expect-error -- an RpcError has no per-middleFn keys
-console.log(unexpected?.auth);
+// slot 4 is a typed record keyed by the names YOU passed - each middleFn's declared errors narrow
+const [, , , , middleFnErrors] = await routes.users.getById('USER-123').call({
+    middleFns: {auth: middleFns.auth({headers: {Authorization: 'Bearer token'}}, true)},
+});
+if (middleFnErrors?.auth?.type === 'not-authorized') {
+    // errorData is strongly typed as NotAuthorizedData
+    console.log('auth failed:', middleFnErrors.auth.errorData?.reason);
+}
+// only the middleFn names you passed exist on the record
+// @ts-expect-error -- no middleFn named `bogus` was passed to this call
+console.log(middleFnErrors?.bogus);

--- a/packages/examples/src/client/client-prefill-middleFns.ts
+++ b/packages/examples/src/client/client-prefill-middleFns.ts
@@ -22,16 +22,19 @@ middleFns
         redirectToLogin();
     });
 
-// call() returns a 4-tuple: [result, error, unexpected, middleFnResults]
-// A middleFn error reaches BOTH channels: its typed onError handler (above) and the
-// `unexpected` slot (an untyped RpcError<string>)
-const [sum, error, unexpected, middleFnResults] = await routes.utils.sum(5, 2).call();
+// call() returns a 5-tuple: [result, error, fatal, middleFnResults, middleFnErrors]
+// A middleFn's declared error reaches BOTH channels: its typed onError handler (above)
+// and its own slot in the middleFnErrors record
+const [sum, error, fatal, middleFnResults, middleFnErrors] = await routes.utils.sum(5, 2).call();
 
-if (unexpected) {
-    console.log('Something the route did not declare failed:', unexpected.publicMessage);
+if (middleFnErrors?.auth) {
+    console.log('Auth error from tuple:', middleFnErrors.auth.publicMessage);
 }
 if (middleFnResults?.auth) {
     console.log('Session from tuple:', middleFnResults.auth);
+}
+if (fatal) {
+    console.log('Fatal (nobody declared it):', fatal.publicMessage);
 }
 if (!error) {
     console.log(sum); // 7

--- a/packages/examples/src/client/client-usage.ts
+++ b/packages/examples/src/client/client-usage.ts
@@ -7,22 +7,23 @@ import type {MyApi} from './server.routes.ts';
 const {routes, middleFns} = initClient<MyApi>({baseURL: 'http://localhost:3000'});
 
 // calls sumTwo route in the server using call with middleFns API
-// Returns 4-tuple: [routeResult, routeError, unexpected, middleFnResults]
-const [sumResult, sumError, unexpected, middleFnResults] = await routes.utils.sum(5, 2).call({
+// Returns 5-tuple: [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
+const [sumResult, sumError, fatal, middleFnResults, middleFnErrors] = await routes.utils.sum(5, 2).call({
     middleFns: {
         auth: middleFns.auth(new HeadersSubset({Authorization: 'myToken-XYZ'})),
     },
 });
 console.log(sumResult); // 7
 console.log(sumError); // undefined (the route's DECLARED errors | ValidationError)
-console.log(unexpected); // undefined (anything the route did not declare: middleFn or fatal errors)
+console.log(fatal); // undefined (transport, platform, framework, or an undeclared throw)
 console.log(middleFnResults); // { auth: ... }
+console.log(middleFnErrors); // {} (each middleFn's DECLARED errors, by name)
 
 // prefills the token for any future requests, value is stored in localStorage
 middleFns.auth(new HeadersSubset({Authorization: 'myToken-XYZ'})).prefill();
 
 // calls sumTwo route in the server (auth is prefilled, so call() works)
-// Returns 4-tuple: [routeResult, routeError, unexpected, middleFnsResults]
+// Returns 5-tuple: [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
 const [sumTwoResponse, sumTwoError] = await routes.utils.sum(5, 2).call();
 if (!sumTwoError) {
     console.log(sumTwoResponse); // 7

--- a/packages/examples/src/client/client-using-middleFns.ts
+++ b/packages/examples/src/client/client-using-middleFns.ts
@@ -5,15 +5,15 @@ import {HeadersSubset} from '@mionjs/core';
 const {routes, middleFns} = initClient<MyApi>({baseURL: 'http://localhost:3000'});
 
 // calls route with auth middleFn
-// Returns 4-tuple: [routeResult, routeError, unexpected, middleFnResults]
-const [user, routeError, unexpected, middleFnResults] = await routes.users.getById('123').call({
+// Returns 5-tuple: [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
+const [user, routeError, fatal, middleFnResults, middleFnErrors] = await routes.users.getById('123').call({
     middleFns: {
         auth: middleFns.auth(new HeadersSubset({Authorization: 'myToken-XYZ'})),
     },
 });
 
-// routeError is the route's DECLARED errors; a failing middleFn (e.g. auth) surfaces in `unexpected`
-if (routeError || unexpected) {
+// routeError is the route's DECLARED errors; each middleFn's declared errors arrive by name
+if (routeError || fatal || middleFnErrors?.auth) {
     console.log('Something failed');
 } else {
     console.log(user); // User object

--- a/packages/examples/src/client/client.ts
+++ b/packages/examples/src/client/client.ts
@@ -47,7 +47,7 @@ middleFns
 
 // ========== Example 1: Route with strongly-typed errorData ==========
 // getById returns User | RpcError<'user-not-found', UserNotFoundData>
-// call() returns 4-tuple: [routeResult, routeError, unexpected, middleFnsResults]
+// call() returns 5-tuple: [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
 const [user1, error1] = await routes.users.getById('USER-123').call();
 if (error1 && error1.type === 'user-not-found') {
     // error1.errorData is strongly typed as UserNotFoundData!
@@ -81,13 +81,12 @@ console.log(result); // Hello John Doe
 
 // ========== Example 5: Using call() with middleFns for per-request middleFns ==========
 // Use call({middleFns: {...}}) when you need to pass middleFns for a SINGLE request
-// Returns 4-tuple: [routeResult, routeError, unexpected, middleFnsResults]
+// Returns 5-tuple: [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
 
 // Create a middleFn with temporary credentials for this specific request
 const tempAuthHeaders: HeadersSubset<'Authorization'> = {headers: {Authorization: 'Bearer temp-token-ABC'}};
 
-// STRONGLY TYPED access to a middleFn's errors is via its onError handlers,
-// which register without prefilling (persistent, keyed by the middleFn id)
+// onError handlers register without prefilling (persistent, keyed by the middleFn id)
 const tempAuth = middleFns.auth(tempAuthHeaders, true);
 tempAuth.onError('not-authorized', (error) => {
     // error.errorData is strongly typed as NotAuthorizedData!
@@ -96,8 +95,8 @@ tempAuth.onError('not-authorized', (error) => {
     }
 });
 
-// call({middleFns: {...}}) takes a record of middleFns and returns a typed 4-tuple
-const [user4, routeError4, unexpected4, middleFnResults4] = await routes.users.getById('USER-123').call({
+// call({middleFns: {...}}) takes a record of middleFns and returns a typed 5-tuple
+const [user4, routeError4, fatal4, middleFnResults4, middleFnErrors4] = await routes.users.getById('USER-123').call({
     middleFns: {
         auth: tempAuth,
     },
@@ -106,35 +105,38 @@ const [user4, routeError4, unexpected4, middleFnResults4] = await routes.users.g
 if (routeError4?.type === 'user-not-found') {
     console.log('User not found:', routeError4.errorData?.requestedId);
 }
-// Anything the route did not declare (a middleFn error, transport, platform...) lands here, untyped
-if (unexpected4) {
-    console.log('Request failed:', unexpected4.type, unexpected4.publicMessage);
+// Each middleFn's DECLARED errors arrive by name, strongly typed - same data the handler above got
+if (middleFnErrors4?.auth?.type === 'not-authorized') {
+    console.log('Auth failed:', middleFnErrors4.auth.errorData?.reason);
+}
+// Anything NOBODY declared (transport, platform, an undeclared throw) lands here, untyped
+if (fatal4) {
+    console.log('Request failed:', fatal4.type, fatal4.publicMessage);
 }
 // Access success data
 if (user4) console.log('Found user:', user4.name);
 if (middleFnResults4?.auth) console.log('Authenticated as:', middleFnResults4.auth.userId);
 
 // ========== Example 6: Multiple MiddleFns with call({middleFns: {...}}) ==========
-// Pass multiple middleFns in the record - each gets its own typed result
-const [user5, , unexpected5, middleFnResults5] = await routes.users.getById('USER-123').call({
+// Pass multiple middleFns in the record - each gets its own typed result AND its own error slot
+const [user5, , , middleFnResults5, middleFnErrors5] = await routes.users.getById('USER-123').call({
     middleFns: {
         auth: middleFns.auth(tempAuthHeaders),
         // session: middleFns.session('session-token'), // If you have a session middleFn
     },
 });
-// The first failing middleFn surfaces in the unexpected slot; use onError handlers (see
-// Example 5) when you need each middleFn's errors independently and strongly typed
-if (unexpected5) {
-    console.log('Request failed:', unexpected5.publicMessage);
+// Handle each middleFn's errors independently - nothing is dropped when several fail
+if (middleFnErrors5?.auth) {
+    console.log('Auth failed:', middleFnErrors5.auth.publicMessage);
 }
 // Access success data
 if (user5) console.log('User:', user5.name);
 console.log(middleFnResults5); // { auth: ... }
 
 // ========== Example 7: Using call() with async/await (recommended) ==========
-// call() returns 4-tuple: [routeResult, routeError, unexpected, middleFnsResults]
+// call() returns 5-tuple: [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
 // This is the standard pattern for all route calls
-// call() never throws - returns a 4-tuple
+// call() never throws - returns a 5-tuple
 // Partial destructuring still works for backward compatibility
 const [user6, error6] = await routes.users.getById('USER-999').call();
 if (error6) {

--- a/packages/examples/src/client/handling-errors.ts
+++ b/packages/examples/src/client/handling-errors.ts
@@ -7,33 +7,34 @@ import {isRpcError} from '@mionjs/core';
 const {routes, middleFns} = initClient<MyApi>({baseURL: 'http://localhost:3000'});
 
 // ========== Result pattern (never throws) ==========
-// call() always returns a 4-tuple, never throws
-// [routeResult, routeError, unexpected, middleFnsResults]
+// call() always returns a 5-tuple, never throws
+// [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
 // - routeError: the route's DECLARED errors | ValidationError (strongly typed, CLOSED union)
-// - unexpected: anything the route did not declare - a middleFn error, transport,
-//   platform or an undeclared throw (untyped RpcError<string>, OPEN)
+// - fatal: anything NOBODY declared - transport, platform, framework, an undeclared throw,
+//   or an error for a middleFn that was not part of the request (untyped RpcError<string>, OPEN)
+// - middleFnErrors: each middleFn's DECLARED errors, by name (strongly typed)
 
 // calls sayHello route in the server
-const [sayHello, error, unexpected] = await routes.users.sayHello({id: '123', name: 'John', surname: 'Doe'}).call();
+const [sayHello, error, fatal] = await routes.users.sayHello({id: '123', name: 'John', surname: 'Doe'}).call();
 
 if (error) {
     // the route's own declared error or a validation error for its params
     console.log(error.type);
-} else if (unexpected) {
-    // in this case the request has failed because the authorization middleFn is missing:
-    // that is not the route's error, so it surfaces here
-    console.log(unexpected); // { type: 'validation-error', message: `Invalid params for Route or MiddleFn 'auth'.`}
+} else if (fatal) {
+    // in this case the request has failed because the authorization middleFn was never sent:
+    // an error for a middleFn that is not part of the request is fatal
+    console.log(fatal); // { type: 'validation-error', message: `Invalid params for Route or MiddleFn 'auth'.`}
 
-    if (isRpcError(unexpected)) {
+    if (isRpcError(fatal)) {
         // ... handle the error as required
     }
 } else {
     console.log(sayHello); // Hello John Doe
 }
 
-// ========== Full 4-tuple with middleFns ==========
-// call({middleFns: {...}}) returns [routeResult, routeError, unexpected, middleFnsResults]
-const [greeting, routeError, unexpectedError, middleFnResults] = await routes.users
+// ========== Full 5-tuple with middleFns ==========
+// call({middleFns: {...}}) returns [routeResult, routeError, fatal, middleFnResults, middleFnErrors]
+const [greeting, routeError, fatalError, middleFnResults, middleFnErrors] = await routes.users
     .sayHello({id: '123', name: 'John', surname: 'Doe'})
     .call({
         middleFns: {
@@ -43,11 +44,16 @@ const [greeting, routeError, unexpectedError, middleFnResults] = await routes.us
 
 if (routeError) {
     console.log('Route failed:', routeError.type);
-} else if (unexpectedError) {
-    // a middleFn failure (e.g. auth) or any undeclared error lands here
-    console.log('Request failed:', unexpectedError.type);
+} else if (fatalError) {
+    // transport, platform or any undeclared error lands here
+    console.log('Request failed:', fatalError.type);
 } else {
     console.log(greeting); // Hello John Doe
+}
+
+// Each middleFn's declared errors arrive by name, strongly typed
+if (middleFnErrors?.auth) {
+    console.log('Auth middleFn failed:', middleFnErrors.auth.type);
 }
 
 // Access middleFn results

--- a/packages/examples/src/client/workflow-vs-single.ts
+++ b/packages/examples/src/client/workflow-vs-single.ts
@@ -7,7 +7,7 @@ const {routes} = initClient<MyApi>({baseURL: 'http://localhost:3000'});
 // SINGLE ROUTE CALL - call()
 // ============================================
 // Result and error are the direct types from the route
-// Returns: [result, error, unexpected, middleFnResults]
+// Returns: [result, error, fatal, middleFnResults, middleFnErrors]
 const [user, error] = await routes.users.getById('USER-123').call();
 
 // `user` is User | undefined
@@ -24,7 +24,7 @@ if (error) {
 // ROUTES_FLOW - Multiple routes in one request
 // ============================================
 // Results and errors are ARRAYS in the same order as the routes
-// Returns: [[results...], [errors...], unexpected, middleFnResults]
+// Returns: [[results...], [errors...], fatal, middleFnResults, middleFnErrors]
 const [[user2, order], [userError, orderError]] = await routesFlow([
     routes.users.getById('USER-123'),
     routes.orders.getById('ORDER-1'),

--- a/packages/examples/src/client/workflow-with-middleFns.ts
+++ b/packages/examples/src/client/workflow-with-middleFns.ts
@@ -7,14 +7,17 @@ const {routes, middleFns} = initClient<MyApi>({baseURL: 'http://localhost:3000'}
 const authHeaders = new HeadersSubset({Authorization: 'my-token'});
 
 // Execute routesFlow with explicit middleFns
-const [[sum, user], [sumError, userError], unexpected, middleFnResults] = await routesFlow([
+const [[sum, user], [sumError, userError], fatal, middleFnResults, middleFnErrors] = await routesFlow([
     routes.utils.sum(5, 2),
     routes.users.getById('USER-123'),
 ]).call({middleFns: {auth: middleFns.auth(authHeaders)}});
 
-// A failing middleFn (or any other undeclared error) surfaces once, in the unexpected slot
-if (unexpected) {
-    console.log('Request failed:', unexpected.publicMessage);
+// Each middleFn's declared errors arrive by name; anything undeclared surfaces once as fatal
+if (middleFnErrors?.auth) {
+    console.log('Auth failed:', middleFnErrors.auth.publicMessage);
+}
+if (fatal) {
+    console.log('Request failed:', fatal.publicMessage);
 }
 
 // Handle route results

--- a/website/content/3.client/0.client-overview.md
+++ b/website/content/3.client/0.client-overview.md
@@ -8,7 +8,7 @@ toc: false
 
 - ✅ Strongly typed APIs with autocompletion and static type checking.
 - ✅ Fully typed list of remote methods with its parameters and return values.
-- ✅ Result pattern with 4-tuple `[routeResult, routeError, unexpected, middleFnResults]` - never throws, always returns.
+- ✅ Result pattern with 5-tuple `[routeResult, routeError, fatal, middleFnResults, middleFnErrors]` - never throws, always returns.
 - ✅ Automatic Validation and Serialization out of the box.
 - ✅ Local Validation (no need to make a server request to validate parameters)
 - ✅ Prefill request data to persist across multiple calls.
@@ -31,10 +31,11 @@ The `routes` and `middleFns` objects returned from `initClient` contain all remo
 If a middleFn is not public (does not expect any parameters and can't return data) then it is not included within the `middleFns` object.
 
 Calling routes in the client generates a `RouteSubRequest`. We use the `call()` method to perform the remote call.
-The `call()` method returns a 4-tuple `[routeResult, routeError, unexpected, middleFnResults]` - it **never throws**.
-`routeError` is the route's **declared** errors `| ValidationError` (strongly typed); anything the route did
-not declare — a middleFn error, a timeout, a platform failure, an undeclared throw — surfaces once in the
-untyped `unexpected` slot. See [Error Handling](/client/error-handling) for the full dispatch rules.
+The `call()` method returns a 5-tuple `[routeResult, routeError, fatal, middleFnResults, middleFnErrors]` - it **never throws**.
+`routeError` is the route's **declared** errors `| ValidationError` (strongly typed); each middleFn's declared
+errors arrive by name in `middleFnErrors` (also strongly typed); anything **nobody** declared — a timeout, a
+platform failure, an undeclared throw — surfaces once in the untyped `fatal` slot. See
+[Error Handling](/client/error-handling) for the full dispatch rules.
 
 <code-import path="packages/examples/src/client/client-calling-routes.ts" lang="ts" />
 
@@ -50,9 +51,9 @@ For cases like authorization middleFns that are required for all requests, we ca
 
 When using prefilled middleFns, middleFn results and errors are available in **two ways**:
 1. **TypedEvent handlers** - Strongly typed by errors (registered via `.prefill()` or directly on the middleFn with `.onError()`)
-2. **the tuple** - results by name in `middleFnResults`; a failing middleFn surfaces untyped in the `unexpected` slot
+2. **the tuple** - results by name in `middleFnResults`, declared errors by name in `middleFnErrors`
 
-Undeclared errors (transport, platform, framework) are **never** delivered to TypedEvent handlers — they only reach the `unexpected` slot.
+Undeclared errors (transport, platform, framework) are **never** delivered to TypedEvent handlers — they only reach the `fatal` slot.
 
 <code-import path="packages/examples/src/client/client-prefill-middleFns.ts" lang="ts" />
 
@@ -77,8 +78,8 @@ Use **TypedEvent handlers** for global error handling with prefilled middleFns. 
 
 ### Result
 
-The `Result` type is a 4-tuple used by `call()` to return route and middleFn results without throwing.
-Only the route's declared response is strongly typed; the `unexpected` slot is an open `RpcError<string>`.
+The `Result` type is a 5-tuple used by `call()` to return route and middleFn results without throwing.
+Declared responses are strongly typed (route in slots 0-1, middleFns in slots 3-4); the `fatal` slot is an open `RpcError<string>`.
 
 <code-import path="packages/client/src/types.ts" lang="ts" commentStart="// type-result-start" commentEnd="// type-result-end" />
 

--- a/website/content/3.client/1.error-handling.md
+++ b/website/content/3.client/1.error-handling.md
@@ -6,24 +6,26 @@ toc: false
 
 ## The Result Pattern
 
-mion client uses a **Result Pattern** for responses, that returns a tuple with 4 elements:
+mion client uses a **Result Pattern** for responses, that returns a tuple with 5 elements:
 
 ```ts
-[routeResult, routeError, unexpected, middleFnResults]
+[routeResult, routeError, fatal, middleFnResults, middleFnErrors]
 ```
 
 - `0` **result**: what the route returned (if it ran and succeeded)
 - `1` **error**: the route's **declared** errors `| ValidationError` — a **closed**, strongly typed union
-- `2` **unexpected**: anything the route did **not** declare — a middleFn's error, a transport failure
-  (timeout, abort, network), a platform error, or an undeclared throw. An **open** `RpcError<string>`
+- `2` **fatal**: anything **nobody** declared — a transport failure (timeout, abort, network), a
+  platform error, a framework error, or an undeclared throw. An **open** `RpcError<string>`
 - `3` **middleFnResults**: MiddleFn results (by middleFn name)
+- `4` **middleFnErrors**: each middleFn's **declared** errors `| ValidationError`, by name — one slot
+  per middleFn, so nothing is lost when several fail
 
 The API calls **never throw**, this provides type-safe error handling with full TypeScript support!
 
 ::note
-Only the route's declared response is strongly typed — that is the point of slot 1 staying closed.
-Everything else goes through slot 2 untyped; a middleFn's errors keep their strongly typed channel
-through its `onError` handlers (see [Prefilling MiddleFns](#prefilling-middlefns)).
+Only what a handler declared is strongly typed — the route's errors in slot 1, each middleFn's in
+slot 4 (and through its `onError` handlers, see [Prefilling MiddleFns](#prefilling-middlefns)).
+Everything undeclared goes through the `fatal` slot untyped.
 ::
 
 ## The Dispatch Rules
@@ -34,15 +36,15 @@ Every error lands in exactly one place, by these rules:
 |---|-------|---------|
 | 1 | route returned its own **declared** error | slot 1 (that route's index in a flow) |
 | 2 | **param validation** failed for a route (client- or server-side) | slot 1 |
-| 3 | **middleFn** returned its declared error, or its params failed validation | its `onError` handler (typed) **and** slot 2 (untyped) |
-| 4 | anything **thrown / undeclared** — transport, platform, framework | slot 2 only; **no** handler fires |
+| 3 | **middleFn** returned its declared error, or its params failed validation | slot 4 under its name **and** its `onError` handler |
+| 4 | anything **thrown / undeclared** — transport, platform, framework, or an error for a middleFn that was not part of the request | slot 2 (`fatal`) only; **no** handler fires. Several fatals: the **first in execution order** wins the slot |
 | 5 | route produced a **result** | slot 0 keeps it, whatever else failed |
 | 6 | an error the route did not declare | **never** appears in slot 1 |
-| 7 | several non-route errors | slot 2 holds the **first in execution order** (middleFns run before the route); every middleFn's declared error still reaches its own handler |
 
-Because of rules 5–7, the result and error slots can both be populated at once (e.g. the route
-succeeded while a middleFn failed). A common shorthand — reading the slots in order — is a
-caller's choice, not something the client enforces:
+Because of rules 3–5, several slots can be populated at once (e.g. the route succeeded while a
+middleFn failed, or a middleFn failed while the route threw — each error keeps its own slot).
+A common shorthand — reading the slots in order — is a caller's choice, not something the client
+enforces:
 
 <code-import path="packages/examples/src/client/client-error-slots.ts" lang="ts" />
 
@@ -108,9 +110,9 @@ When you prefill a middleFn, you can register persistent success/error handlers 
 
 <code-import path="packages/client/src/types.ts" lang="ts" commentStart="// type-result-start" commentEnd="// type-result-end" />
 
-### UnexpectedError
+### FatalError
 
-<code-import path="packages/client/src/types.ts" lang="ts" commentStart="// type-unexpected-error-start" commentEnd="// type-unexpected-error-end" />
+<code-import path="packages/client/src/types.ts" lang="ts" commentStart="// type-fatal-error-start" commentEnd="// type-fatal-error-end" />
 
 ### TypedEvent
 

--- a/website/content/3.client/3.client-flow.md
+++ b/website/content/3.client/3.client-flow.md
@@ -107,10 +107,10 @@ The key difference between `call()` and `routesFlow()` is in the response struct
 
 ```ts
 // Single route call - direct result/error
-const [result, error, unexpected, middleFnResults] = await route.call();
+const [result, error, fatal, middleFnResults, middleFnErrors] = await route.call();
 
-// RoutesFlow - arrays of results/errors; `unexpected` is request-scoped (ONE slot for the whole flow)
-const [[result1, result2], [error1, error2], unexpected, middleFnResults] = await routesFlow([route1, route2]).call();
+// RoutesFlow - arrays of results/errors; `fatal` is request-scoped (ONE slot for the whole flow)
+const [[result1, result2], [error1, error2], fatal, middleFnResults, middleFnErrors] = await routesFlow([route1, route2]).call();
 ```
 
 ::tip

--- a/website/content/3.client/4.cancellation-timeouts.md
+++ b/website/content/3.client/4.cancellation-timeouts.md
@@ -6,13 +6,13 @@ toc: false
 
 ## Per-request Cancellation
 
-Use a standard `AbortController` to cancel a specific request. Pass the signal via the `call()` setup object. Aborted requests surface an error with `type === 'request-aborted'` in the tuple's **unexpected** slot (transport failures are never part of the route's typed error union).
+Use a standard `AbortController` to cancel a specific request. Pass the signal via the `call()` setup object. Aborted requests surface an error with `type === 'request-aborted'` in the tuple's **fatal** slot (transport failures are never part of the route's typed error union).
 
 <code-import path="packages/examples/src/client/cancellation-abort-signal.ts" lang="ts" />
 
 ## Per-request Timeout
 
-Set a `timeout` in milliseconds to automatically cancel a request if it takes too long. Timed-out requests surface an error with `type === 'request-timeout'` in the tuple's **unexpected** slot.
+Set a `timeout` in milliseconds to automatically cancel a request if it takes too long. Timed-out requests surface an error with `type === 'request-timeout'` in the tuple's **fatal** slot.
 
 <code-import path="packages/examples/src/client/cancellation-timeout.ts" lang="ts" />
 


### PR DESCRIPTION
Follow-up to #136, revising the client result tuple to the originally planned 5-slot design:

```ts
// before (#136)
const [result, error, unexpected, middleFnResults] = await route.call();
// after
const [result, error, fatal, middleFnResults, middleFnErrors] = await route.call();
```

## Why

The single shared `unexpected` slot silently dropped information: several middleFns can fail at once, and a middleFn failure can coexist with a fatal error, but one slot can only hold one error (the "first in execution order" precedence rule discarded the rest). Separating the slots removes that rule for middleFn errors entirely — each keeps its own place.

## What changed

- **Slot 4 restores the typed per-middleFn errors record** (`{[K in keyof H]?: MiddleFnError<H[K]>}`): each middleFn's declared errors `| ValidationError`, strongly typed by name. Nothing is lost when several fail.
- **Slot 2 (`fatal`, open `RpcError<string>`) keeps only what nobody declared**: transport, platform, framework, undeclared throws (including a middleFn that *throws* — its typed record slot can't carry an undeclared code), and errors for middleFns that were not part of the request.
- **MiddleFns restored from prefill while an explicit `middleFns` record was passed** are now merged into the result records under their id, so their results/errors are never dropped.
- Listeners unchanged: typed, declared errors only, registrable without prefill.
- `WorkflowResult` mirrors the shape with one request-scoped `fatal` slot.

## Tests

- Contract tests updated; **T17 was rewritten into the scenario that motivated this revision**: a failing `runOnError` middleFn plus a route that throws now shows **both** errors (`middleFnErrors.audit = 'audit-failed'`, `fatal = 'db-connection-lost'`) where the single slot kept only one.
- Type-level assertions in `client-error-slots.ts` extended: `middleFnErrors.auth.type === 'not-authorized'` narrows `errorData`; an unpassed middleFn name is a compile error.
- Full monorepo suite 746/746, lint, format, `check-code-imports` (142/142) and `check-types-examples` green.

## Docs

Examples, the four client website pages, and the contract record in `docs/done/client-error-dispatch-contract.md` (with a revision note explaining the revert of the single-slot design) all follow the 5-tuple.

## Breaking changes

- Tuple arity 4 → 5: `fatal` inserted at index 2, middleFn results/errors records shift to 3/4. Positional destructuring past index 1 breaks.
- A middleFn's declared error moves from the shared slot to its own `middleFnErrors[name]`; an error for a middleFn not part of the request is fatal, never a raw-id record entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQvbHVb15L4akzNupskdTc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQvbHVb15L4akzNupskdTc)_