### PR TITLE
Guard bundle assertions and clean generated artifacts

### DIFF
--- a/docs/done/stale-test-server-edge-bundles.md
+++ b/docs/done/stale-test-server-edge-bundles.md
@@ -121,3 +121,21 @@ Negative checks, both confirmed to fail as intended: dropping `emitMode: 'both'`
 [server-mappers-from-generated-pure-fn-cache.md](server-mappers-from-generated-pure-fn-cache.md) was
 rewriting at the time, so it waited for that to merge. Fixed in this same PR once it did — see
 [pnpm-build-fails-on-clean-tree.md](pnpm-build-fails-on-clean-tree.md).
+
+## Follow-ups landed after the record above
+
+Both found while re-verifying this spec end to end (clean tree and post-`pnpm run build` tree; both
+orderings green, 57 files / 785 tests, and the negative check still fires — restoring the alias map
+trips `assertBuiltFromSource` naming 174 `.dist` modules).
+
+- **The guard only covered the test path.** `build:edge` / `build:cloudflare` ran `vite build --config`
+  directly, so `assertBuiltFromSource` — the whole reason a `.dist`-inlined bundle cannot ship
+  unnoticed — ran only under the vitest `globalSetup`. `buildTestBundle.ts` now doubles as a CLI
+  (`node buildTestBundle.ts <edge|cloudflare>`) and both scripts go through it, so every path that
+  produces a bundle is guarded.
+- **`clean` left the generated artifacts behind.** Making the bundles generated moved them into the
+  set of things `pnpm run clean` is expected to remove, and it removed neither them nor the
+  `__runtypes*` genDirs — repo-wide, no package cleaned its `__runtypes/` at all. Every package's
+  `clean` now takes all its generated dirs in one `rimraf` (`.dist .coverage __runtypes`, plus
+  `build`, the two extra genDirs and `.mion` where they exist), instead of backgrounding a second
+  `rimraf` with a stray `&`.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -50,7 +50,7 @@
         "lint": "eslint src",
         "format": "prettier --write src/**/*.ts",
         "build": "vite build",
-        "clean": "rimraf .dist & rimraf .coverage",
+        "clean": "rimraf .dist .coverage __runtypes .mion",
         "fresh-start": "pnpm run clean && rimraf node_modules",
         "run-test-server": "ts-node --project test/tsconfig.json test/test-server.ts"
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
         "lint": "eslint src",
         "format": "prettier --write src/**/*.ts",
         "build": "vite build",
-        "clean": "rimraf .dist & rimraf .coverage",
+        "clean": "rimraf .dist .coverage __runtypes",
         "fresh-start": "pnpm run clean && rimraf node_modules"
     },
     "dependencies": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -58,7 +58,7 @@
         "build": "pnpm run build:eslint && pnpm run build:vite-plugin",
         "build:eslint": "vite build --config vite.eslint.config.ts",
         "build:vite-plugin": "vite build --config vite.vite-plugin.config.ts",
-        "clean": "rimraf .dist && rimraf .coverage",
+        "clean": "rimraf .dist .coverage __runtypes",
         "fresh-start": "pnpm run clean && rimraf node_modules"
     },
     "bugs": {

--- a/packages/drizze/package.json
+++ b/packages/drizze/package.json
@@ -50,7 +50,7 @@
         "lint": "eslint src",
         "format": "prettier --write src/**/*.ts",
         "build": "vite build",
-        "clean": "rimraf .dist & rimraf .coverage",
+        "clean": "rimraf .dist .coverage __runtypes",
         "fresh-start": "pnpm run clean && rimraf node_modules"
     },
     "bugs": {

--- a/packages/platform-aws/package.json
+++ b/packages/platform-aws/package.json
@@ -50,7 +50,7 @@
     "lint": "eslint src",
     "format": "prettier --write src/**/*.ts",
     "build": "vite build",
-    "clean": "rimraf .dist & rimraf .coverage",
+    "clean": "rimraf .dist .coverage __runtypes",
     "fresh-start": "pnpm run clean && rimraf node_modules"
   },
   "bugs": {

--- a/packages/platform-bun/package.json
+++ b/packages/platform-bun/package.json
@@ -54,7 +54,7 @@
         "lint": "eslint src",
         "format": "prettier --write src/**/*.ts",
         "build": "vite build",
-        "clean": "rimraf .dist & rimraf .coverage",
+        "clean": "rimraf .dist .coverage __runtypes",
         "fresh-start": "pnpm run clean && rimraf node_modules"
     },
     "bugs": {

--- a/packages/platform-cloudflare/package.json
+++ b/packages/platform-cloudflare/package.json
@@ -49,7 +49,7 @@
     "lint": "eslint src",
     "format": "prettier --write src/**/*.ts",
     "build": "vite build",
-    "clean": "rimraf .dist & rimraf .coverage",
+    "clean": "rimraf .dist .coverage __runtypes",
     "fresh-start": "pnpm run clean && rimraf node_modules"
   },
   "bugs": {

--- a/packages/platform-gcloud/package.json
+++ b/packages/platform-gcloud/package.json
@@ -50,7 +50,7 @@
     "lint": "eslint src",
     "format": "prettier --write src/**/*.ts",
     "build": "vite build",
-    "clean": "rimraf .dist & rimraf .coverage",
+    "clean": "rimraf .dist .coverage __runtypes",
     "fresh-start": "pnpm run clean && rimraf node_modules"
   },
   "bugs": {

--- a/packages/platform-node/package.json
+++ b/packages/platform-node/package.json
@@ -50,7 +50,7 @@
     "lint": "eslint src",
     "format": "prettier --write src/**/*.ts",
     "build": "vite build",
-    "clean": "rimraf .dist & rimraf .coverage",
+    "clean": "rimraf .dist .coverage __runtypes",
     "fresh-start": "pnpm run clean && rimraf node_modules"
   },
   "bugs": {

--- a/packages/platform-vercel/package.json
+++ b/packages/platform-vercel/package.json
@@ -54,7 +54,7 @@
     "lint": "eslint src",
     "format": "prettier --write src/**/*.ts",
     "build": "vite build",
-    "clean": "rimraf .dist & rimraf .coverage",
+    "clean": "rimraf .dist .coverage __runtypes",
     "fresh-start": "pnpm run clean && rimraf node_modules"
   },
   "bugs": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -51,7 +51,7 @@
         "lint": "eslint src",
         "format": "prettier --write src/**/*.ts",
         "build": "vite build",
-        "clean": "rimraf .dist & rimraf .coverage",
+        "clean": "rimraf .dist .coverage __runtypes",
         "fresh-start": "pnpm run clean && rimraf node_modules"
     },
     "bugs": {

--- a/packages/test-server/README.md
+++ b/packages/test-server/README.md
@@ -104,6 +104,10 @@ GENERATED and gitignored: the specs rebuild their own in a vitest `globalSetup`,
 stale. Both set `emitMode: 'both'`, which edge runtimes require (see
 `docs/done/stale-test-server-edge-bundles.md`).
 
+Both build scripts run `buildTestBundle.ts` rather than `vite build` directly, so its
+`assertBuiltFromSource` guard — the bundle must inline sibling packages from source, never from a
+sibling `.dist` — covers every path that produces a bundle, not only the `globalSetup` one.
+
 The `.dist/` ESM library build is a separate, opt-in script:
 
 ```bash

--- a/packages/test-server/buildTestBundle.ts
+++ b/packages/test-server/buildTestBundle.ts
@@ -53,3 +53,19 @@ function assertBuiltFromSource(target: TestBundleTarget): void {
             `runtimes this bundle targets forbid. Keep resolution pinned to the 'source' condition.`
     );
 }
+
+// ############ CLI ############
+
+/**
+ * `node buildTestBundle.ts <edge|cloudflare>` — the package's build scripts run this rather than
+ * `vite build --config` directly, so `assertBuiltFromSource` guards EVERY path that produces a
+ * bundle, not just the vitest globalSetup one.
+ */
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    const target = process.argv[2] as TestBundleTarget;
+    if (target !== 'edge' && target !== 'cloudflare') {
+        console.error(`[test-server] usage: node buildTestBundle.ts <edge|cloudflare> (got "${target ?? ''}")`);
+        process.exit(1);
+    }
+    await buildTestBundle(target);
+}

--- a/packages/test-server/package.json
+++ b/packages/test-server/package.json
@@ -47,9 +47,9 @@
     "format": "prettier --write src/**/*.ts",
     "build": "pnpm run build:edge && pnpm run build:cloudflare",
     "build:lib": "vite build",
-    "build:edge": "vite build --config vite.edge.config.ts",
-    "build:cloudflare": "vite build --config vite.cloudflare.config.ts",
-    "clean": "rimraf .dist & rimraf .coverage",
+    "build:edge": "node buildTestBundle.ts edge",
+    "build:cloudflare": "node buildTestBundle.ts cloudflare",
+    "clean": "rimraf .dist .coverage build __runtypes __runtypes-edge __runtypes-cloudflare .mion",
     "fresh-start": "pnpm run clean && rimraf node_modules"
   },
   "bugs": {


### PR DESCRIPTION
## Summary

Fixes two issues discovered during end-to-end verification of the test-server edge bundle spec:

1. **Bundle assertion guard was incomplete** — `assertBuiltFromSource` only ran in the vitest `globalSetup`, leaving the direct `vite build` commands in `build:edge` and `build:cloudflare` scripts unguarded.
2. **Clean script left generated artifacts behind** — `pnpm run clean` did not remove generated directories like `__runtypes/`, `__runtypes-edge/`, `__runtypes-cloudflare/`, `.mion`, and `.coverage`.

## Changes

- **`packages/test-server/buildTestBundle.ts`**: Added CLI entry point so the script can be invoked directly via `node buildTestBundle.ts <edge|cloudflare>`. This ensures `assertBuiltFromSource` guards every path that produces a bundle, not just the vitest setup.

- **`packages/test-server/package.json`**: 
  - Changed `build:edge` and `build:cloudflare` to invoke `buildTestBundle.ts` instead of `vite build --config` directly
  - Updated `clean` script to remove all generated artifacts in one `rimraf` call (`.dist .coverage build __runtypes __runtypes-edge __runtypes-cloudflare .mion`), replacing the backgrounded dual-`rimraf` with `&`

- **All other `package.json` files** (`client`, `core`, `devtools`, `drizze`, `platform-*`, `router`): Unified `clean` scripts to remove generated directories (`__runtypes`, `.mion`, `.coverage` where applicable) in a single `rimraf` call, replacing the backgrounded dual-`rimraf` pattern with `&`.

- **`packages/test-server/README.md`**: Documented that both build scripts now run through `buildTestBundle.ts` to ensure the `assertBuiltFromSource` guard covers all bundle-producing paths.

- **`docs/done/stale-test-server-edge-bundles.md`**: Added follow-up section documenting these fixes and their verification (57 files / 785 tests, both orderings green, negative check still fires as expected).

## Implementation Details

The `buildTestBundle.ts` CLI entry point uses `process.argv[1] === fileURLToPath(import.meta.url)` to detect direct invocation, validates the target argument, and calls the existing `buildTestBundle()` function. This reuses all existing logic while extending coverage to the npm scripts.

The `clean` script changes consolidate multiple `rimraf` calls into a single command with space-separated paths, eliminating the problematic `&` backgrounding pattern that could cause race conditions.

https://claude.ai/code/session_01HTqX53cLpQnA2ZEZGb3Drx