### PR TITLE
docs: add merge master plan and pre-merge cleanup spec

### DIFF
--- a/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
+++ b/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
@@ -1,0 +1,259 @@
+# Merge the ts-run-types repo into the mion monorepo (master plan)
+
+**Status:** open
+**Created:** 2026-08-23
+
+This is the master plan for moving everything in `MionKit/ts-run-types` back into
+`MionKit/mion`, keeping the full git history of both repos. Each numbered step below
+becomes its own `docs/todos/` spec with a detailed plan before any code is written.
+This document is the map, the ordering, and the list of decisions that must be made
+before or during the move.
+
+## Why
+
+ts-run-types was extracted from mion to become a standalone library, but the
+standalone path is being dropped (adoption effort, pressure to broaden the feature
+set away from the TS-vertical design, and naming collisions with the well-known
+"runtypes" library). The code comes home to mion. The ts-run-types repo has the
+newer, better setup (skills, containers, verdaccio e2e, release automation, CI),
+so after the merge the combined repo adopts the ts-run-types way of working, and
+mion's older equivalents are retired.
+
+## Evidence (facts the plan is built on)
+
+Both clones were unshallowed and compared on 2026-08-23:
+
+- **Histories are unrelated.** ts-run-types has 1,991 commits on `main`, mion has
+  1,617 on `master`, zero shared commit hashes. Its first commit ("feat:
+  compile-time type resolver for mion runtypes on ts-go") started fresh, so the
+  join must be a `--allow-unrelated-histories` merge commit.
+- **The collision surface is tiny.** Only 14 exact file paths exist in both repos,
+  all root-level config (`package.json`, `pnpm-workspace.yaml`, `tsconfig.json`,
+  `vitest.config.ts`, `pnpm-lock.yaml`, `CLAUDE.md`, `README.md`, `LICENSE`,
+  `.gitignore`, `.npmrc`, `.prettierrc`, `.husky/pre-commit`,
+  `.vscode/settings.json`) plus `packages/examples/tsconfig.json`. No package
+  directory collides except `packages/examples`, and the two examples trees have
+  no overlapping source files (both even use the same `src/_homepage` convention),
+  so they union into one package.
+- **The toolchains already agree.** Both are pnpm 11 workspaces with
+  `packages: ['packages/*']`, exact pinning, `ignoreScripts`, 30-day
+  `minimumReleaseAge`. Both websites are Nuxt 4.4.2 + Docus 5.9.0 + @nuxt/content
+  3.12.0 with the same code-import pipeline. `.prettierrc` is identical on both
+  sides (and ts-run-types' oxfmt mirrors it), so reformat churn will be small.
+- **Both are lockstep-versioned.** mion via lerna (`0.8.10`, fixed, forcePublish);
+  ts-run-types via `version.json` + `scripts/release/bump-version.mjs` (`0.12.2`).
+  mion pins `@ts-runtypes/{core,devtools,bin}` at exactly `0.12.2` (the current
+  npm latest), so the trees are in sync right now — the ideal moment to merge.
+- **mion's e2e is local tarballs, no verdaccio, no CI publish.**
+  `test-publish/` + `scripts/pre-publish-test.sh` + manual `scripts/publish.sh`
+  (lerna, interactive OTP). ts-run-types has the full automated flow: verdaccio in
+  the `tsrt-e2e` podman image, `rtx release e2e`, release-gate/publish workflows,
+  staged npm publish with 2FA approval.
+- **mion carries dead weight** that should not travel through the merge: stale
+  npm-era `setup.sh`, dead `jest.config.js`, stale `AGENTS.md` + `.augment*`
+  (contains the reversed deepkit-era `import type` warning), `plans/` specs
+  written against removed APIs (`aotCaches`, `virtual:client-mion-aot`),
+  `test-publish` overrides for removed packages (`@mionjs/run-types`,
+  `@mionjs/type-formats`), `docs/todos/` missing entirely while CLAUDE.md links
+  it, `docs/done/migration-overview.md` saying 0.12.0 while the pin is 0.12.2,
+  and `@mionjs/run-types@0.8.10` still live (undeprecated) on npm.
+- **Repo-name references are enumerated.** `MionKit/ts-run-types` is hardcoded in
+  the root/package `package.json` repository fields, package READMEs, both
+  Containerfile `org.opencontainers.image.source` labels, the website
+  `app.config.ts` github block, several content pages, `build-binaries.mjs`,
+  `setup-claude-web.sh`, and `repo-contracts.test.ts`. GHCR coordinates
+  (`ghcr.io/mionkit/tsrt-website|tsrt-e2e`) are org-scoped and unaffected by the
+  move. The Go module path `github.com/mionkit/ts-runtypes` is also org-scoped
+  and can stay.
+
+## Target end state
+
+One repo, `MionKit/mion`, laid out like ts-run-types today with mion's packages
+joining the same `packages/` workspace:
+
+- Full commit history of both repos reachable from the default branch.
+- `ts-go-runtypes/` (Go resolver + tsgolint submodule + patches), `container/`
+  (website, benchmarks, pre-publish-e2e), `scripts/` (`rtx` CLI), `.claude/`
+  (hooks, skills, output style) — all carried over from ts-run-types unchanged in
+  spirit, extended to cover the mion packages.
+- `packages/` = `ts-runtypes`, `ts-runtypes-devtools`, `ts-runtypes-bin`,
+  `ts-runtypes-go-be-sidecar`, `examples` (merged) + `core`, `router`, `client`,
+  `devtools`, `drizzle`, `platform-*`, `test-server`. `@mionjs/*` packages depend
+  on `@ts-runtypes/*` via `workspace:*`, not npm pins.
+- One Nuxt install (`container/website/`) serving both documentation sets; the
+  host-run `website/` directory is gone.
+- One e2e gate: verdaccio in the `tsrt-e2e` image publishes and exercises the
+  `@ts-runtypes/*` AND `@mionjs/*` tarballs; `test-publish/` is gone.
+- One release train: `version.json` lockstep across every published package,
+  `main` → `prod` release flow, staged npm publish, git-cliff changelog,
+  commitlint enforced.
+- CLAUDE.md follows the ts-run-types rules with a mion-specifics section; stale
+  mion guidance (AGENTS.md and friends) deleted.
+- The ts-run-types GitHub repo archived with a pointer README.
+
+## Decisions needed (blocking or shaping specific steps)
+
+1. **npm package names.** Recommendation: keep publishing `@ts-runtypes/*` from
+   the mion repo for now; a rebrand (e.g. into `@mionjs/*`) is a separate later
+   project (it touches binary package names, the version hash embedding, and
+   every consumer). Blocks nothing if the recommendation is accepted.
+2. **One version train or two.** Recommendation: one. `bump-version.mjs` already
+   stamps every `packages/*/package.json`, so `@mionjs/*` jumps from 0.8.10 to
+   the next unified version (e.g. 0.13.0). Shapes step 6.
+3. **Website domain + deploy target.** ts-run-types deploys to Cloudflare Pages
+   (runtypes.pages.dev, pinned to `prod`); mion deploys to GitHub Pages (with a
+   commented-out plan for mion.io). One Nuxt install means one deploy — which
+   domain serves it, and does the other redirect? Shapes step 4.
+4. **Default branch rename `master` → `main` + creation of `prod`.** Required for
+   the ts-run-types CI/release flow to apply unchanged. Needs a GitHub settings
+   change (owner action). Shapes steps 1 and 6.
+5. **Landing the join commit.** The unrelated-histories merge commit cannot land
+   via rebase-merge (it would be flattened). It needs either a direct push to the
+   default branch or a one-off merge-commit PR (repo setting). Owner action in
+   step 2.
+6. **Fate of `plans/`.** `01`/`02` (AOT-era) and `vercel-adapter-spec.md`
+   (shipped) look deletable; `mion-ui-spec.md` and `client-missing-features.md`
+   may still be wanted — if so they are rewritten from scratch as fresh
+   `docs/todos/` specs (per the replacement-spec rule), never moved as-is.
+   Shapes step 1.
+7. **mion benchmarks.** The website copies benchmark data from a sibling
+   `mion-benchmarks` repo (`copy-benchmarks` script). Fold that repo into
+   `container/benchmarks/` later, keep the copy flow, or drop the page? Shapes
+   step 4 (can be deferred without blocking it).
+
+## Steps
+
+Each step is one `docs/todos/` spec + one PR (except step 2, which is the join
+commit itself). Order is load-bearing: every step leaves the repo green
+(install, build, both test suites, lint) so the migration can pause safely at
+any boundary.
+
+### Step 1 — Pre-merge cleanup of mion
+
+Shrink the collision surface and stop dead weight from traveling through the
+merge. In the mion repo, on a normal PR:
+
+- Delete: `setup.sh`, `jest.config.js`, `AGENTS.md`, `.augment-guidelines.md`,
+  `.augment/`, dead `plans/` files (per decision 6; wanted ones become fresh
+  `docs/todos/` specs), stale `@mionjs/run-types` / `@mionjs/type-formats` /
+  `@deepkit/type-compiler` remnants in `test-publish/pnpm-workspace.yaml` and its
+  lockfile, the stale `packages/test-publish/**` eslint ignore, the hardcoded
+  macOS paths in `.claude/settings.local.json`.
+- Create `docs/todos/` (this file lives there) and fix CLAUDE.md's stale links
+  (`docs/todos/`, `@mionjs/run-types` in the peer-deps line) and
+  `migration-overview.md`'s 0.12.0 → 0.12.2 note.
+- `npm deprecate @mionjs/run-types` (still live at 0.8.10) with a pointer to
+  `@ts-runtypes/core`.
+- Rename the default branch `master` → `main` (decision 4) and update the
+  in-repo references: `nuxtjs.yml` trigger, `nx.json` `defaultBase`, the
+  `raw.githubusercontent.com/.../master/...` image URLs in package READMEs.
+
+### Step 2 — Freeze ts-run-types and land the join commit
+
+- Land or explicitly abandon any open work in ts-run-types; confirm the tree
+  matches published 0.12.2 (it does today). From then on ts-run-types is frozen —
+  all work happens in mion.
+- In mion: `git remote add rt <ts-run-types>`, `git fetch rt`, then
+  `git merge rt/main --allow-unrelated-histories` on a branch. Resolve the 14
+  file conflicts: ts-run-types content wins for root configs (`package.json`,
+  `pnpm-workspace.yaml`, `.gitignore`, `.npmrc`, `.husky/pre-commit`,
+  `README.md`, `CLAUDE.md` — with a short "mion packages" addendum where needed);
+  union for `tsconfig.json` references, `vitest.config.ts` projects,
+  `packages/examples/tsconfig.json`, `.vscode/settings.json`; regenerate
+  `pnpm-lock.yaml`. `.gitmodules` + the tsgolint submodule carry over untouched.
+- Keep the merge commit minimal and verifiable: mion packages STILL consume
+  `@ts-runtypes/*@0.12.2` from npm in this commit; no workspace rewiring yet.
+  Green bar = pnpm install, Go build + tests, both vitest suites, both lint
+  flows still passing.
+- Land via direct push or one-off merge-commit PR (decision 5). Tag the
+  pre-merge heads of both repos first (e.g. `pre-merge-mion`,
+  `pre-merge-ts-run-types`) so the join is easy to find forever.
+
+### Step 3 — Workspace and toolchain unification
+
+- One root `package.json` (ts-run-types base): devDependency union, engines
+  node ≥ 26, `rtx` scripts + mion's `test:ci` batching (OOM guard) preserved.
+- Adopt ts-run-types' `pnpm-workspace.yaml` policies wholesale; carry over only
+  the mion-specific needs (e.g. `allowBuilds` entries mion actually requires,
+  `@ts-runtypes/*` dropped from `minimumReleaseAgeExclude` once workspace-linked).
+- Switch every `@mionjs/*` dependency on `@ts-runtypes/*` from `0.12.2` to
+  `workspace:*`; delete lerna + nx (`lerna.json`, `nx.json`,
+  `packages/client/project.json`, the lerna-driven root scripts) and rewire
+  `lint`/`build`/`clean` to `rtx` / plain pnpm recursion.
+- Unify format/lint: oxfmt + prettier-for-markdown scope extended over the mion
+  packages (settings already identical, so churn is a one-time small diff);
+  mion's eslint flat config (its own plugin rules + the runtypes rules) kept and
+  wired into the root `lint` alongside oxlint. Decide file-by-file nothing —
+  this step's spec pins the exact tool-per-tree matrix.
+- Root vitest config: union of the 5 ts-run-types projects + 10 mion projects;
+  `pretest` (Go binary + dists) covers everything. Rename `packages/drizze` →
+  `packages/drizzle` while we're touching every config that names it.
+- Green bar: full `pnpm test` + `go test` + `rtx core smoke` from one clean
+  clone bootstrapped by the ts-runtypes-setup skill.
+
+### Step 4 — Website merge (one Nuxt install)
+
+- Fold mion's `website/` into `container/website/` (the containerized install is
+  the base: playground, bench tables, twoslash server, agent-heartbeat). Merge
+  mion's content dirs (`introduction`, `server`, `drizzle-orm`, `client`,
+  `run-types`, `devtools`, `platforms`, `benchmarks`, `articles`) into the
+  combined Docus nav next to the runtypes docs; reconcile the duplicated
+  `run-types` topic pages against the authoritative runtypes guide.
+- Merge mion's app components/utils into the container app; dependency lists are
+  near-identical (same Nuxt/Docus/content/ui/shiki versions), so the image's
+  `_deps` grows by the mion-only extras. Rebuild + push `tsrt-website`.
+- The merged `packages/examples` feeds code-import for both doc sets; port
+  mion's `check-links` / `check-unused-examples` into the container scripts if
+  they differ.
+- Delete `website/` (including its stale docus-starter README/name and the
+  `.vscode-extension`, which moves only if still wanted), delete `pages-build` /
+  `copy-benchmarks` root scripts (decision 7 may re-home the benchmark data
+  later), retire `nuxtjs.yml`.
+- Deploy per decision 3 (single deploy from `website-deploy.yml`).
+
+### Step 5 — e2e unification on verdaccio
+
+- Extend `container/pre-publish-e2e/`: verdaccio config serves `@mionjs/*` (like
+  `@ts-runtypes/*`) only from local publishes, never proxied; `e2e-serve.sh`
+  publishes the mion tarballs after the runtypes ones in dependency order.
+- Port `test-publish/`'s four specs (json flow, binary, packaged-sources,
+  build-output/inlining) into a mion consumer app under `apps/` driven by
+  `build-all.mjs`, installing from verdaccio exactly like the other apps.
+- Extend `scripts/release/pack.mjs` + `e2e.mjs` (+ receipt) to include the 11
+  public `@mionjs/*` packages. Rebuild + push `tsrt-e2e`.
+- Delete `test-publish/`, `scripts/pack-packages.sh`, `scripts/pack-and-install.sh`,
+  `scripts/pre-publish-test.sh`.
+
+### Step 6 — One release train + CI unification
+
+- ts-run-types CI becomes the repo CI: `ci.yml` gains the mion vitest batches +
+  bun tests + mion eslint; `release-gate.yml` gains the mion e2e app; mion's
+  `pull-requests.yml` retired.
+- Release: `version.json` lockstep covers all packages (decision 2);
+  `publish-tarballs.mjs` / `publish.mjs` / `stage-approve.mjs` /
+  `verify-live.mjs` / `unpublish.mjs` extended with the `@mionjs/*` set in
+  dependency-safe order; mion's `scripts/publish.sh` / `unpublish.sh` deleted.
+- Create the `prod` branch; enable the branch protections the flow assumes
+  (merge-commit-only promotion, commitlint on PRs). First unified release ships
+  every package at the new version.
+- git-cliff changelog + commitlint now cover the whole repo (mion history predates
+  conventional commits; the config's tag pattern and skip rules make that fine).
+
+### Step 7 — Guidelines, skills, docs, metadata sweep
+
+- Final CLAUDE.md: ts-run-types rules as the spine + a mion-specifics section
+  (devtools committed-build requirement, test:ci batching, SFC/bun loaders,
+  platform adapters); SETUP.md + ARCHITECTURE.md gain the mion side; ROADMAP
+  reflects the standalone-library idea being dropped.
+- Repo-reference sweep `MionKit/ts-run-types` → `MionKit/mion`: package.json
+  repository fields (+ `directory`), package READMEs, both Containerfile source
+  labels, website `app.config.ts` github block + content pages,
+  `build-binaries.mjs`, `setup-claude-web.sh`, `.claude` hooks/skills,
+  `repo-contracts.test.ts` (update the pinned contract, don't delete it).
+- Skills: the 8 `.claude/skills` carry over; `ts-runtypes-setup` + the
+  session-start hook extended to cover the mion packages (they only need pnpm on
+  top of the existing bootstrap).
+- docs merge hygiene: mion's 63 `docs/done` specs + runtypes' specs coexist;
+  `docs/maybe/` keeps its parked specs; this master plan moves to `docs/done/`
+  when the last step lands.
+- Archive `MionKit/ts-run-types` on GitHub with a README pointing at mion.

--- a/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
+++ b/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
@@ -95,7 +95,9 @@ joining the same `packages/` workspace:
 ## Decisions (settled with the maintainer, 2026-08-23)
 
 1. **npm package names: keep `@ts-runtypes/*`** published from the mion repo. A
-   rebrand, if ever, is a separate later project.
+   rebrand, if ever, is a separate later project — one candidate being a return
+   to the `@mionjs/run-types` name, which therefore stays live and undeprecated
+   on npm.
 2. **One version train.** `bump-version.mjs` stamps every
    `packages/*/package.json`; `@mionjs/*` jumps from 0.8.10 to the next unified
    version at the first joint release.
@@ -148,8 +150,8 @@ merge. In the mion repo, on a normal PR:
   (`docs/todos/`, `@mionjs/run-types` in the peer-deps line) and
   `migration-overview.md`'s 0.12.0 → 0.12.2 note. Fix `test-publish/CLAUDE.md`'s
   references to scripts/specs that no longer exist.
-- `npm deprecate @mionjs/run-types` (still live at 0.8.10) with a pointer to
-  `@ts-runtypes/core`.
+- `@mionjs/run-types` on npm stays live and undeprecated (possible future home
+  of `@ts-runtypes/core`, per decision 1).
 - After the owner renames the default branch `master` → `main` in GitHub
   settings, update the in-repo references: `nuxtjs.yml` trigger, `nx.json`
   `defaultBase`, the `raw.githubusercontent.com/.../master/...` image URLs in

--- a/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
+++ b/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
@@ -80,8 +80,9 @@ joining the same `packages/` workspace:
   `ts-runtypes-go-be-sidecar`, `examples` (merged) + `core`, `router`, `client`,
   `devtools`, `drizzle`, `platform-*`, `test-server`. `@mionjs/*` packages depend
   on `@ts-runtypes/*` via `workspace:*`, not npm pins.
-- One Nuxt install (`container/website/`) serving both documentation sets; the
-  host-run `website/` directory is gone.
+- One Nuxt install (`container/website/`) building TWO separate sites from two
+  content trees — mion.pages.dev and runtypes.pages.dev, both on Cloudflare
+  Pages; the host-run `website/` directory and the GitHub Pages deploy are gone.
 - One e2e gate: verdaccio in the `tsrt-e2e` image publishes and exercises the
   `@ts-runtypes/*` AND `@mionjs/*` tarballs; `test-publish/` is gone.
 - One release train: `version.json` lockstep across every published package,
@@ -91,35 +92,39 @@ joining the same `packages/` workspace:
   mion guidance (AGENTS.md and friends) deleted.
 - The ts-run-types GitHub repo archived with a pointer README.
 
-## Decisions needed (blocking or shaping specific steps)
+## Decisions (settled with the maintainer, 2026-08-23)
 
-1. **npm package names.** Recommendation: keep publishing `@ts-runtypes/*` from
-   the mion repo for now; a rebrand (e.g. into `@mionjs/*`) is a separate later
-   project (it touches binary package names, the version hash embedding, and
-   every consumer). Blocks nothing if the recommendation is accepted.
-2. **One version train or two.** Recommendation: one. `bump-version.mjs` already
-   stamps every `packages/*/package.json`, so `@mionjs/*` jumps from 0.8.10 to
-   the next unified version (e.g. 0.13.0). Shapes step 6.
-3. **Website domain + deploy target.** ts-run-types deploys to Cloudflare Pages
-   (runtypes.pages.dev, pinned to `prod`); mion deploys to GitHub Pages (with a
-   commented-out plan for mion.io). One Nuxt install means one deploy — which
-   domain serves it, and does the other redirect? Shapes step 4.
-4. **Default branch rename `master` → `main` + creation of `prod`.** Required for
-   the ts-run-types CI/release flow to apply unchanged. Needs a GitHub settings
-   change (owner action). Shapes steps 1 and 6.
-5. **Landing the join commit.** The unrelated-histories merge commit cannot land
-   via rebase-merge (it would be flattened). It needs either a direct push to the
-   default branch or a one-off merge-commit PR (repo setting). Owner action in
-   step 2.
-6. **Fate of `plans/`.** `01`/`02` (AOT-era) and `vercel-adapter-spec.md`
-   (shipped) look deletable; `mion-ui-spec.md` and `client-missing-features.md`
-   may still be wanted — if so they are rewritten from scratch as fresh
-   `docs/todos/` specs (per the replacement-spec rule), never moved as-is.
-   Shapes step 1.
-7. **mion benchmarks.** The website copies benchmark data from a sibling
-   `mion-benchmarks` repo (`copy-benchmarks` script). Fold that repo into
-   `container/benchmarks/` later, keep the copy flow, or drop the page? Shapes
-   step 4 (can be deferred without blocking it).
+1. **npm package names: keep `@ts-runtypes/*`** published from the mion repo. A
+   rebrand, if ever, is a separate later project.
+2. **One version train.** `bump-version.mjs` stamps every
+   `packages/*/package.json`; `@mionjs/*` jumps from 0.8.10 to the next unified
+   version at the first joint release.
+3. **Two sites from one Nuxt install.** The same `container/website/` codebase
+   builds two separate static sites from two content trees: mion.pages.dev and
+   runtypes.pages.dev, both Cloudflare Pages. mion's GitHub Pages deploy is
+   retired.
+4. **Default branch renames to `main`; `prod` is created for the release line.**
+   The rename itself is a one-click GitHub settings action (owner); everything
+   in-repo is handled inside the migration steps.
+5. **The join commit** lands via a one-off merge-commit PR or a direct push to
+   `main` — the owner either flips the "allow merge commits" repo setting for
+   that PR or green-lights the direct push at step 2 time.
+6. **`plans/` stays untouched.** It is an ideas folder, not a todo backlog;
+   CLAUDE.md gets a line saying so, so nobody keeps flagging it as stale.
+7. **mion benchmarks move into `container/benchmarks/`** (from the sibling
+   `mion-benchmarks` repo) — deliberately LAST, only after everything else works
+   and the first unified release is published. This is step 8.
+
+### Owner-only actions (everything else is agent work)
+
+- Before step 2: rename the default branch `master` → `main` in GitHub settings.
+- At step 2: allow the one merge commit to land (setting flip or direct-push OK).
+- At step 4: create the Cloudflare Pages project for mion.pages.dev and make
+  sure the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets
+  cover it.
+- At step 6: branch protections for `main`/`prod` (merge-commit-only promotion,
+  required checks) — recommended, and only the owner can set them.
+- At release time: the npm 2FA stage-approve, exactly as ts-run-types does today.
 
 ## Steps
 
@@ -134,19 +139,21 @@ Shrink the collision surface and stop dead weight from traveling through the
 merge. In the mion repo, on a normal PR:
 
 - Delete: `setup.sh`, `jest.config.js`, `AGENTS.md`, `.augment-guidelines.md`,
-  `.augment/`, dead `plans/` files (per decision 6; wanted ones become fresh
-  `docs/todos/` specs), stale `@mionjs/run-types` / `@mionjs/type-formats` /
+  `.augment/`, stale `@mionjs/run-types` / `@mionjs/type-formats` /
   `@deepkit/type-compiler` remnants in `test-publish/pnpm-workspace.yaml` and its
   lockfile, the stale `packages/test-publish/**` eslint ignore, the hardcoded
-  macOS paths in `.claude/settings.local.json`.
+  macOS paths in `.claude/settings.local.json`. `plans/` is NOT touched
+  (decision 6); CLAUDE.md gets a line marking it as an ideas folder.
 - Create `docs/todos/` (this file lives there) and fix CLAUDE.md's stale links
   (`docs/todos/`, `@mionjs/run-types` in the peer-deps line) and
-  `migration-overview.md`'s 0.12.0 → 0.12.2 note.
+  `migration-overview.md`'s 0.12.0 → 0.12.2 note. Fix `test-publish/CLAUDE.md`'s
+  references to scripts/specs that no longer exist.
 - `npm deprecate @mionjs/run-types` (still live at 0.8.10) with a pointer to
   `@ts-runtypes/core`.
-- Rename the default branch `master` → `main` (decision 4) and update the
-  in-repo references: `nuxtjs.yml` trigger, `nx.json` `defaultBase`, the
-  `raw.githubusercontent.com/.../master/...` image URLs in package READMEs.
+- After the owner renames the default branch `master` → `main` in GitHub
+  settings, update the in-repo references: `nuxtjs.yml` trigger, `nx.json`
+  `defaultBase`, the `raw.githubusercontent.com/.../master/...` image URLs in
+  the package READMEs and root README.
 
 ### Step 2 — Freeze ts-run-types and land the join commit
 
@@ -191,25 +198,34 @@ merge. In the mion repo, on a normal PR:
 - Green bar: full `pnpm test` + `go test` + `rtx core smoke` from one clean
   clone bootstrapped by the ts-runtypes-setup skill.
 
-### Step 4 — Website merge (one Nuxt install)
+### Step 4 — Website merge (one Nuxt install, two sites)
 
 - Fold mion's `website/` into `container/website/` (the containerized install is
-  the base: playground, bench tables, twoslash server, agent-heartbeat). Merge
-  mion's content dirs (`introduction`, `server`, `drizzle-orm`, `client`,
-  `run-types`, `devtools`, `platforms`, `benchmarks`, `articles`) into the
-  combined Docus nav next to the runtypes docs; reconcile the duplicated
-  `run-types` topic pages against the authoritative runtypes guide.
+  the base: playground, bench tables, twoslash server, agent-heartbeat). The one
+  codebase builds TWO separate static sites (decision 3): a site selector (e.g.
+  an `RT_SITE=mion|runtypes` env var read by `nuxt.config.ts` / the build
+  scripts) picks the content tree, app.config (nav, socials, github block,
+  branding) and public assets per site; components, server utils, layouts and
+  the code-import pipeline are shared.
+- The two content trees stay separate (no nav merging): the runtypes docs as
+  they are today, and mion's content dirs (`introduction`, `server`,
+  `drizzle-orm`, `client`, `run-types`, `devtools`, `platforms`, `benchmarks`,
+  `articles`) as the mion site. Reconcile mion's `run-types` section so it
+  introduces the topic and links across to the runtypes site rather than
+  duplicating its guide.
 - Merge mion's app components/utils into the container app; dependency lists are
   near-identical (same Nuxt/Docus/content/ui/shiki versions), so the image's
   `_deps` grows by the mion-only extras. Rebuild + push `tsrt-website`.
-- The merged `packages/examples` feeds code-import for both doc sets; port
-  mion's `check-links` / `check-unused-examples` into the container scripts if
-  they differ.
+- The merged `packages/examples` feeds code-import for both sites; port mion's
+  `check-links` / `check-unused-examples` into the container scripts if they
+  differ.
 - Delete `website/` (including its stale docus-starter README/name and the
   `.vscode-extension`, which moves only if still wanted), delete `pages-build` /
-  `copy-benchmarks` root scripts (decision 7 may re-home the benchmark data
-  later), retire `nuxtjs.yml`.
-- Deploy per decision 3 (single deploy from `website-deploy.yml`).
+  `copy-benchmarks` root scripts (step 8 re-homes the benchmark data), retire
+  `nuxtjs.yml`.
+- Deploy: `website-deploy.yml` builds and deploys BOTH sites to Cloudflare Pages
+  (runtypes.pages.dev stays; mion.pages.dev is a new Pages project the owner
+  creates); mion's GitHub Pages deploy is retired.
 
 ### Step 5 — e2e unification on verdaccio
 
@@ -254,6 +270,17 @@ merge. In the mion repo, on a normal PR:
   session-start hook extended to cover the mion packages (they only need pnpm on
   top of the existing bootstrap).
 - docs merge hygiene: mion's 63 `docs/done` specs + runtypes' specs coexist;
-  `docs/maybe/` keeps its parked specs; this master plan moves to `docs/done/`
-  when the last step lands.
+  `docs/maybe/` keeps its parked specs; `plans/` stays as the ideas folder.
 - Archive `MionKit/ts-run-types` on GitHub with a README pointing at mion.
+
+### Step 8 — Fold mion-benchmarks into the container (last)
+
+Only after everything above works and the first unified release is published:
+
+- Move the sibling `mion-benchmarks` repo into `container/benchmarks/` alongside
+  the validation benchmarks, following the same isolation pattern (each heavy
+  dependency set as its own pnpm project under `_deps/`, baked into the
+  `tsrt-website` image, results generated at website-build time).
+- Wire the mion site's benchmarks pages to the generated data, replacing the old
+  `copy-benchmarks`-from-sibling-repo flow for good; archive `mion-benchmarks`.
+- This master plan moves to `docs/done/` when this step lands.

--- a/docs/todos/premerge-cleanup-of-mion.md
+++ b/docs/todos/premerge-cleanup-of-mion.md
@@ -1,0 +1,89 @@
+# Pre-merge cleanup of mion (merge master plan, step 1)
+
+**Status:** open
+**Created:** 2026-08-23
+
+Step 1 of [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Goal: shrink the merge surface and stop dead weight from traveling through the
+upcoming unrelated-histories join with ts-run-types. Everything here is a normal
+PR against the current default branch; nothing depends on the merge itself.
+All file references verified on 2026-08-23.
+
+## Prerequisite (owner)
+
+Rename the default branch `master` → `main` in GitHub settings (Settings →
+Branches → rename). GitHub re-targets open PRs and shows the update hint for
+local clones automatically. The in-repo reference fixes below assume the rename
+has happened; if it hasn't yet, land them anyway — they are forward-compatible
+only for the README links, so the `nuxtjs.yml` / `nx.json` edits must wait for
+it or deploys/nx will look at a branch that no longer receives pushes.
+
+## Tasks
+
+### Delete dead files
+
+- `setup.sh` — npm-workspaces/jest/apt era, contradicts the pnpm-only policy.
+- `jest.config.js` — nothing references jest anywhere (no dependency, no
+  script; eslint explicitly ignores the file).
+- `AGENTS.md` — stale sibling of CLAUDE.md: npm-era commands, lists removed
+  packages, and still carries the deepkit-era "never use `import type`" warning
+  that CLAUDE.md explicitly reverses.
+- `.augment-guidelines.md` and `.augment/` — same stale lineage.
+- Do NOT touch `plans/` (settled: it is an ideas folder, not a todo backlog).
+
+### test-publish stale remnants
+
+- `test-publish/pnpm-workspace.yaml`: remove the overrides for removed packages
+  `@mionjs/run-types` (line 17) and `@mionjs/type-formats` (line 21) — their
+  tarballs are never produced by `scripts/pack-packages.sh`; remove the
+  `@deepkit/type-compiler: false` allowBuilds entry (line 43) and its
+  explanatory comment block (deepkit is gone).
+- `test-publish/pnpm-lock.yaml` still carries `@mionjs/run-types` entries.
+  Regenerating it needs the tarballs present: run `scripts/pack-and-install.sh`
+  (build + pack + install) and commit the resulting lockfile.
+- `test-publish/CLAUDE.md`: fix references to things that no longer exist —
+  `pnpm run test:aot` (now `test:build-output`), `src/tests/aot-build.spec.ts`
+  (now `src/tests/build-output.spec.ts`), `src/client/pureFns.ts` (gone), and
+  the `verify` script description (lines 35-44).
+
+### Config fixes
+
+- `eslint.config.js` line 23: ignore path `packages/test-publish/**` is stale —
+  the directory is root-level `test-publish/**`.
+- `.claude/settings.local.json`: 4 permission entries hardcode
+  `/Users/majerez/Projects/mion/...`; replace with relative forms or drop them.
+- `CLAUDE.md` line 17: drop `@mionjs/run-types` from the caret-range peer-deps
+  list (package no longer exists in the repo).
+- `CLAUDE.md`: add one line documenting `plans/` as a loose-ideas folder exempt
+  from the `docs/todos|done` workflow, so it stops being flagged as stale.
+- `docs/done/migration-overview.md`: the "Version status (2026-08-20)" section
+  says 0.12.0; the pinned version is 0.12.2. Note the bump; also note that its
+  `../todos/` links resolve again now that `docs/todos/` exists.
+
+### Default-branch reference updates (after the owner rename)
+
+- `.github/workflows/nuxtjs.yml` line 10: `branches: ['master']` → `['main']`.
+- `nx.json` line 26: `"defaultBase": "master"` → `"main"` (nx dies in step 3,
+  but it must not point at a dead branch in the meantime).
+- `raw.githubusercontent.com/MionKit/mion/master/...` asset URLs → `main` in:
+  root `README.md` and `packages/{client,core,drizze,examples,platform-aws,
+  platform-bun,platform-gcloud,platform-node,router}/README.md`.
+
+### npm
+
+- Deprecate the orphaned `@mionjs/run-types@0.8.10` (still live, package removed
+  from the repo long ago):
+  `npm deprecate @mionjs/run-types "Superseded by @ts-runtypes/core. See https://github.com/MionKit/mion"`.
+  Needs npm auth for the @mionjs scope (owner runs it, or an agent session with
+  the token).
+
+## Done criteria
+
+- `pnpm install --frozen-lockfile`, `pnpm run lint`, `pnpm run check-format`,
+  `pnpm run test:ci` all green (the pull-requests.yml gate).
+- `scripts/pre-publish-test.sh` still passes end to end (it exercises the
+  test-publish lockfile this spec regenerates).
+- Repo-wide grep for `run-types` finds only deliberate/documentary mentions
+  (migration records, the devtools removed-options guard, spec files) — no
+  config or lockfile entries.
+- `master` receives no further pushes; CI and Pages deploy run from `main`.

--- a/docs/todos/premerge-cleanup-of-mion.md
+++ b/docs/todos/premerge-cleanup-of-mion.md
@@ -71,11 +71,10 @@ it or deploys/nx will look at a branch that no longer receives pushes.
 
 ### npm
 
-- Deprecate the orphaned `@mionjs/run-types@0.8.10` (still live, package removed
-  from the repo long ago):
-  `npm deprecate @mionjs/run-types "Superseded by @ts-runtypes/core. See https://github.com/MionKit/mion"`.
-  Needs npm auth for the @mionjs scope (owner runs it, or an agent session with
-  the token).
+- Do NOT deprecate `@mionjs/run-types` (still live at 0.8.10). Settled with the
+  maintainer 2026-08-23: the name may become the future home of
+  `@ts-runtypes/core` if the packages are ever re-unified under it, so it stays
+  exactly as it is.
 
 ## Done criteria
 


### PR DESCRIPTION
## Summary

Add comprehensive documentation for merging the `ts-run-types` repository into the `mion` monorepo, including the master plan and the first step's detailed specification.

## Changes

- **`docs/todos/merge-ts-runtypes-into-mion-master-plan.md`** (new): Master plan document outlining the complete merge strategy across 8 sequential steps. Includes:
  - Rationale for the merge (standalone path being dropped, ts-run-types has superior tooling/automation)
  - Evidence of unrelated histories and minimal collision surface (14 root-level config files only)
  - Target end state (one repo with unified versioning, toolchain, and release automation)
  - 7 settled decisions with the maintainer (npm names, version train, dual sites, branch rename, etc.)
  - 8 ordered steps from pre-merge cleanup through folding mion-benchmarks, each leaving the repo green
  - Owner-only actions (branch rename, merge-commit allowance, Cloudflare Pages setup, branch protections)

- **`docs/todos/premerge-cleanup-of-mion.md`** (new): Step 1 specification for pre-merge cleanup. Details:
  - Prerequisite: owner renames default branch `master` → `main` in GitHub settings
  - Tasks: delete dead files (`setup.sh`, `jest.config.js`, `AGENTS.md`, `.augment*`), clean stale test-publish remnants, fix config references, update default-branch URLs, deprecate orphaned npm package
  - Done criteria: all test suites pass, pre-publish verification succeeds, no stale config entries remain

Both documents follow the `docs/todos/` workflow established in CLAUDE.md and are load-bearing prerequisites for the merge work.

https://claude.ai/code/session_01Ua6ERA46KtJhSyF9MKf8Y9