### PR TITLE
chore: finish branch-rename references, file specs for merge phases 2-8

### DIFF
--- a/.github/workflows/nuxtjs.yml
+++ b/.github/workflows/nuxtjs.yml
@@ -7,7 +7,7 @@ name: Deploy Nuxt site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['master']
+    branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ mion is a lightweight TypeScript-based framework designed for building serverles
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ## Why Another Framework?
 
@@ -67,7 +67,7 @@ By leveraging runtime types, mion offers advanced capabilities such as request v
 
 ## Full Stack APIs
 
-![type safes apis](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/type-safe-apis.gif)
+![type safes apis](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/type-safe-apis.gif)
 
 Thats it 👆, thats all you need to write a Fully Type Safe Api and Client &nbsp; 🚀  
 All parameters and return values will also be automatically validated and serialized without any extra code required.

--- a/docs/done/default-branch-rename-references.md
+++ b/docs/done/default-branch-rename-references.md
@@ -1,9 +1,9 @@
 # Update in-repo references after the default branch is renamed to main
 
-**Status:** open
+**Status:** done (2026-08-24)
 **Created:** 2026-08-23
 
-The default branch is still `master`. Renaming it to `main` is an owner-only action in GitHub
+The default branch was renamed to `main` by the owner on 2026-08-24, and every in-repo reference below was updated the same day. Renaming it was an owner-only action in GitHub
 settings (Settings → Branches → rename), and it is a prerequisite of step 2 of
 [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md)
 (decision 4). Several in-repo references hardcode the branch name and must be updated once the

--- a/docs/todos/fold-mion-benchmarks-into-container.md
+++ b/docs/todos/fold-mion-benchmarks-into-container.md
@@ -1,0 +1,44 @@
+# Fold the mion-benchmarks repo into the benchmarks container (merge master plan, step 8)
+
+**Status:** open
+**Created:** 2026-08-24
+
+Step 8 — the LAST step — of
+[merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Settled decision 7: this runs only after steps 2–7 are landed AND the first unified release is
+published. Goal: the sibling `mion-benchmarks` repo moves into `container/benchmarks/`, the mion
+site's benchmark pages render from data generated at website-build time, and the old
+copy-from-sibling-repo flow is fully gone.
+
+## Background
+
+The mion site's benchmarks section was fed by a root `copy-benchmarks` script copying results
+from a sibling `../mion-benchmarks` checkout (script retired in step 4, data frozen as static
+content since). The runtypes side already has the pattern to adopt: each competitor toolchain is
+an isolated pnpm project under `container/benchmarks/_deps/`, baked into the `tsrt-website` image
+(deps-hash-labelled), driven by `scripts/website/bench-data/` (`pnpm rtx bench`), with published
+numbers generated inside the container during the website deploy on the dedicated runner.
+
+## Tasks
+
+- Import the mion-benchmarks sources (history import via a second small
+  `--allow-unrelated-histories` merge is optional — decide based on how much history that repo
+  has worth keeping; a plain code import is acceptable for a benchmarks harness if not).
+- Restructure to the container pattern: framework competitors under
+  `container/benchmarks/_deps/` as isolated projects, harness + cases beside the existing
+  validation benchmark layout, results flowing through `bench-data/gen-docs.mjs`-style generators
+  into the mion site's content.
+- Extend `scripts/website/bench-data/` (or add a sibling module) and the `rtx bench` area to run
+  the mion benchmarks; bake the new deps into `tsrt-website` and push (deps-hash updates
+  enforced by the image label check).
+- Replace the mion site's frozen static benchmark data with the generated output;
+  `website-deploy.yml` produces both sites' numbers in the same run.
+- Archive the `mion-benchmarks` repo with a pointer README (owner flips the archive switch).
+- Move the master plan spec to `docs/done/` — this step completes the migration.
+
+## Done criteria
+
+- `pnpm rtx bench` runs the mion benchmarks inside the container locally; the website build
+  renders the mion benchmark pages from generated data.
+- No repo references to the sibling checkout remain; `mion-benchmarks` is archived.
+- The master plan lives in `docs/done/` with a completion note.

--- a/docs/todos/guidelines-skills-docs-metadata-sweep.md
+++ b/docs/todos/guidelines-skills-docs-metadata-sweep.md
@@ -1,0 +1,47 @@
+# Guidelines, skills, docs and repo-metadata sweep (merge master plan, step 7)
+
+**Status:** open
+**Created:** 2026-08-24
+
+Step 7 of [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Requires steps 2–6 landed. Goal: the combined repo reads as ONE project — guidance, skills, docs
+and every hardcoded coordinate updated — and the old ts-run-types repo is archived.
+
+## Tasks
+
+- **CLAUDE.md, final form:** the ts-run-types rules as the spine (they describe the setup that
+  now governs the repo) merged for real with the mion specifics the join-commit addendum carried:
+  package map, devtools committed-build/rebuild requirement, `test:ci` batching, SFC/Bun loader
+  notes, platform adapters, the `plans/` ideas-folder note, the docs/todos workflow. One
+  document, no addendum seams. `SETUP.md` gains the mion packages (they need only pnpm on top of
+  the existing bootstrap); `docs/ARCHITECTURE.md` gains the mion side of the map;
+  `docs/ROADMAP.md` records that the standalone-library path was dropped and why.
+- **Repo-reference sweep** `MionKit/ts-run-types` → `MionKit/mion` (list enumerated in the master
+  plan's evidence section): root + package `package.json` repository/bugs fields (add
+  `repository.directory` per package), the three published package READMEs, both Containerfile
+  `org.opencontainers.image.source` labels (then rebuild + push both images), the website
+  `app.config.ts` github block + the content pages that link the repo,
+  `scripts/release/build-binaries.mjs` (generated binary-package READMEs),
+  `scripts/setup-claude-web.sh`, `.claude/hooks/session-start.sh`, the setup/website skills, and
+  `repo-contracts.test.ts` — update the pinned contract values, never delete the test. GHCR
+  coordinates (`ghcr.io/mionkit/*`) and the Go module path (`github.com/mionkit/ts-runtypes`)
+  are org-scoped and stay.
+- **Skills:** the 8 `.claude/skills/` dirs are now repo skills; extend `ts-runtypes-setup` and
+  the session-start hook to cover the mion packages; retarget `create-todo` / `implement-todo` /
+  `task-reset` wording where it says "RunTypes" but now means the whole repo; keep the published
+  skills under `packages/ts-runtypes/skills/` untouched (they ship with the package).
+- **Docs hygiene:** mion's `docs/done` records and runtypes' coexist; `docs/maybe/` keeps its
+  parked specs; `plans/` stays the ideas folder. Root README final pass (mion landing page with
+  the RunTypes section, links to both sites).
+- **Archive the old repo:** final README pointer commit in `MionKit/ts-run-types`
+  ("development moved to MionKit/mion, history preserved there — see the `pre-merge-ts-run-types`
+  tag"), then the owner flips it to Archived in GitHub settings.
+
+## Done criteria
+
+- Repo-wide grep for `MionKit/ts-run-types` matches only history records under `docs/done/` and
+  the archive pointer note.
+- `repo-contracts.test.ts` passes with the new coordinates; both images rebuilt with the new
+  source labels; a fresh-clone bootstrap via the setup skill works end to end on the unified
+  CLAUDE.md/SETUP.md instructions alone.
+- `MionKit/ts-run-types` is archived.

--- a/docs/todos/join-ts-runtypes-history.md
+++ b/docs/todos/join-ts-runtypes-history.md
@@ -1,0 +1,102 @@
+# Freeze ts-run-types and land the unrelated-histories join (merge master plan, step 2)
+
+**Status:** open
+**Created:** 2026-08-24
+
+Step 2 of [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Goal: bring the FULL commit history of `MionKit/ts-run-types` (1,991 commits, zero shared with
+mion's 1,617) into this repo as one verifiable merge commit, with both test suites green, while
+changing as little as possible — the toolchain unification is step 3, not here.
+
+## Prerequisites
+
+- Default branch renamed to `main` — DONE 2026-08-24.
+- **Owner decision (master plan, decision 5):** the join is a real 2-parent merge commit and
+  cannot land through a rebase-merge (it would be flattened). Either enable "Allow merge
+  commits" in Settings → General → Pull Requests for a one-off merge-commit PR, or approve a
+  direct push to `main`.
+- **Owner:** make sure the GHCR packages `ghcr.io/mionkit/tsrt-website` and
+  `ghcr.io/mionkit/tsrt-e2e` are pullable from THIS repo's Actions (they were published from the
+  ts-run-types repo; grant the mion repo access under the org package settings, or make them
+  public). ts-run-types' `ci.yml` smoke job and the release gate pull them and never build them.
+- Freeze ts-run-types: land or explicitly abandon anything open there; confirm the tree matches
+  published 0.12.2 (true as of 2026-08-23). After the join, that repo receives no more commits.
+
+## Mechanics
+
+1. Tag the pre-merge heads so the join point stays findable: `pre-merge-mion` on mion `main`,
+   `pre-merge-ts-run-types` on ts-run-types `main`; push both tags.
+2. In a mion clone (NOT shallow — `git fetch --unshallow` first if needed):
+   `git remote add rt https://github.com/MionKit/ts-run-types && git fetch rt --tags`, branch off
+   `main`, then `git merge rt/main --allow-unrelated-histories`.
+3. `.gitmodules` and the `ts-go-runtypes/third_party/tsgolint` submodule pointer arrive from the
+   ts-run-types side with no conflict. After the merge: `git submodule update --init --recursive`
+   plus `pnpm rtx` / `scripts/core/ensure-tsgolint.mjs` to apply the patches, then build
+   `bin/ts-runtypes` and the dists (`pnpm run check:builds`).
+
+## Conflict matrix (the 14 colliding paths, verified 2026-08-23)
+
+**ts-run-types side wins:** `pnpm-workspace.yaml` (but KEEP `@ts-runtypes/*` in
+`minimumReleaseAgeExclude` until step 3 switches to `workspace:*`, and carry over any
+`allowBuilds` entries mion actually needs, e.g. esbuild), `.npmrc`, `.prettierrc` (identical
+values anyway), `.husky/pre-commit` (both run lint-staged; `commit-msg` arrives as a new file).
+
+**Union:**
+
+- Root `package.json` — ts-run-types base (name, engines node ≥ 26, packageManager, rtx
+  scripts). Add mion's devDependencies (lerna, nx, eslint stack, prettier; on the
+  typescript 6.0.2 vs 6.0.3 clash take 6.0.3). Colliding script names (`test`, `lint`, `build`,
+  `clean`, `fresh-start`) keep the ts-run-types meaning; mion's equivalents survive under a
+  temporary `:mion` suffix (`lint:mion` → `lerna run lint`, …) that step 3 removes. mion-only
+  scripts (`test:ci`, `test:bun`, `check-code-imports`, `check-types-examples`,
+  `pre-publish-test`, `npm-publish`) carry over as-is.
+- `.github/workflows/pull-requests.yml` — update its script calls to the `:mion` names in the
+  same commit, or it silently runs the runtypes suite instead of mion's.
+- Root `tsconfig.json` — union of project references (both sides), mion's `@mionjs/*` paths
+  kept, ts-run-types' excludes (`ts-go-runtypes`, `bin`) kept.
+- Root `vitest.config.ts` — union of projects (5 runtypes + 10 mion). Note this makes the
+  ts-run-types `pretest` (Go binary + dists) a prerequisite of the FULL `pnpm test`.
+- `packages/examples/tsconfig.json` — the only in-package collision. The two examples trees have
+  no overlapping files; keep mion's `package.json` for the merged package and union the tsconfig
+  `paths` so both example sets typecheck (runtypes examples resolve `@ts-runtypes/*` via paths to
+  built dists; mion examples via workspace deps).
+- `.gitignore` — union; mion's exception that commits `packages/devtools/build/` MUST survive.
+- `.vscode/settings.json` — union.
+
+**mion side wins:** `README.md` (this repo's GitHub landing page stays mion's, plus a short
+RunTypes section pointing at the runtypes docs; the full rework is step 7). `LICENSE` (verify
+both are the same MIT text first; if identical it's a non-choice).
+
+**CLAUDE.md:** ts-run-types' becomes the spine (its rules describe the setup that now lives
+here) with a clearly-marked temporary "mion packages" addendum: package list, devtools
+committed-build/rebuild requirement, `test:ci` batching, `:mion` script names. Step 7 does the
+real merge of the two documents.
+
+**`pnpm-lock.yaml`:** never hand-merged — regenerate from the union manifests
+(`@ts-runtypes/*@0.12.2` still resolves from npm in this commit; the switch to `workspace:*` is
+step 3).
+
+## Green bar (all before landing)
+
+- `pnpm install` clean on the regenerated lockfile.
+- `go -C ts-go-runtypes test ./internal/...` and `pnpm run check:builds`.
+- Full `pnpm test` (all 15 vitest projects) — use the mion batching if one run OOMs.
+- `pnpm run lint` + `pnpm run check-format` (runtypes scope) and `lint:mion` +
+  mion `check-format` equivalent.
+- Both workflow sets green on the PR (filenames don't collide; ts-run-types' `ci.yml` will
+  trigger on PRs to `main` and must pass here too — its bootstrap action handles submodules,
+  and the smoke job needs the GHCR access from Prerequisites).
+
+## Landing
+
+Per the owner's decision 5 choice: one-off merge-commit PR (never squash, never rebase) or
+direct push to `main`. Immediately after landing, push a final commit to ts-run-types' README
+saying development moved to MionKit/mion (the archive flip itself is step 7).
+
+## Done criteria
+
+- `git log` from `main` reaches both pre-merge tags; `git log --follow` works for a sample file
+  from each side (e.g. `packages/router/src/router.ts` and
+  `ts-go-runtypes/internal/reflection/`).
+- The green-bar list above passes on `main` after landing.
+- ts-run-types receives no further development commits.

--- a/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
+++ b/docs/todos/merge-ts-runtypes-into-mion-master-plan.md
@@ -154,16 +154,18 @@ rename and are tracked in
 
 ### Step 2 — Freeze ts-run-types and land the join commit
 
+Spec: [join-ts-runtypes-history.md](join-ts-runtypes-history.md)
+
 - Land or explicitly abandon any open work in ts-run-types; confirm the tree
   matches published 0.12.2 (it does today). From then on ts-run-types is frozen —
   all work happens in mion.
 - In mion: `git remote add rt <ts-run-types>`, `git fetch rt`, then
   `git merge rt/main --allow-unrelated-histories` on a branch. Resolve the 14
-  file conflicts: ts-run-types content wins for root configs (`package.json`,
-  `pnpm-workspace.yaml`, `.gitignore`, `.npmrc`, `.husky/pre-commit`,
-  `README.md`, `CLAUDE.md` — with a short "mion packages" addendum where needed);
-  union for `tsconfig.json` references, `vitest.config.ts` projects,
-  `packages/examples/tsconfig.json`, `.vscode/settings.json`; regenerate
+  file conflicts per the matrix in the step spec — broadly: ts-run-types wins
+  the toolchain configs, unions for `package.json` / `tsconfig.json` /
+  `vitest.config.ts` / `packages/examples/tsconfig.json` / `.gitignore` /
+  `.vscode/settings.json`, mion keeps the repo `README.md`, CLAUDE.md becomes
+  the ts-run-types rules plus a temporary mion addendum; regenerate
   `pnpm-lock.yaml`. `.gitmodules` + the tsgolint submodule carry over untouched.
 - Keep the merge commit minimal and verifiable: mion packages STILL consume
   `@ts-runtypes/*@0.12.2` from npm in this commit; no workspace rewiring yet.
@@ -174,6 +176,8 @@ rename and are tracked in
   `pre-merge-ts-run-types`) so the join is easy to find forever.
 
 ### Step 3 — Workspace and toolchain unification
+
+Spec: [unify-workspace-and-toolchain.md](unify-workspace-and-toolchain.md)
 
 - One root `package.json` (ts-run-types base): devDependency union, engines
   node ≥ 26, `rtx` scripts + mion's `test:ci` batching (OOM guard) preserved.
@@ -196,6 +200,8 @@ rename and are tracked in
   clone bootstrapped by the ts-runtypes-setup skill.
 
 ### Step 4 — Website merge (one Nuxt install, two sites)
+
+Spec: [merge-websites-one-nuxt-two-sites.md](merge-websites-one-nuxt-two-sites.md)
 
 - Fold mion's `website/` into `container/website/` (the containerized install is
   the base: playground, bench tables, twoslash server, agent-heartbeat). The one
@@ -226,6 +232,8 @@ rename and are tracked in
 
 ### Step 5 — e2e unification on verdaccio
 
+Spec: [unify-e2e-on-verdaccio.md](unify-e2e-on-verdaccio.md)
+
 - Extend `container/pre-publish-e2e/`: verdaccio config serves `@mionjs/*` (like
   `@ts-runtypes/*`) only from local publishes, never proxied; `e2e-serve.sh`
   publishes the mion tarballs after the runtypes ones in dependency order.
@@ -238,6 +246,8 @@ rename and are tracked in
   `scripts/pre-publish-test.sh`.
 
 ### Step 6 — One release train + CI unification
+
+Spec: [unify-release-train-and-ci.md](unify-release-train-and-ci.md)
 
 - ts-run-types CI becomes the repo CI: `ci.yml` gains the mion vitest batches +
   bun tests + mion eslint; `release-gate.yml` gains the mion e2e app; mion's
@@ -253,6 +263,8 @@ rename and are tracked in
   conventional commits; the config's tag pattern and skip rules make that fine).
 
 ### Step 7 — Guidelines, skills, docs, metadata sweep
+
+Spec: [guidelines-skills-docs-metadata-sweep.md](guidelines-skills-docs-metadata-sweep.md)
 
 - Final CLAUDE.md: ts-run-types rules as the spine + a mion-specifics section
   (devtools committed-build requirement, test:ci batching, SFC/bun loaders,
@@ -271,6 +283,8 @@ rename and are tracked in
 - Archive `MionKit/ts-run-types` on GitHub with a README pointing at mion.
 
 ### Step 8 — Fold mion-benchmarks into the container (last)
+
+Spec: [fold-mion-benchmarks-into-container.md](fold-mion-benchmarks-into-container.md)
 
 Only after everything above works and the first unified release is published:
 

--- a/docs/todos/merge-websites-one-nuxt-two-sites.md
+++ b/docs/todos/merge-websites-one-nuxt-two-sites.md
@@ -1,0 +1,52 @@
+# One Nuxt install, two sites: fold mion's website into the container (merge master plan, step 4)
+
+**Status:** open
+**Created:** 2026-08-24
+
+Step 4 of [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Requires [unify-workspace-and-toolchain.md](unify-workspace-and-toolchain.md) landed. Goal
+(settled decision 3): the single `container/website/` Nuxt codebase builds TWO separate static
+sites — mion.pages.dev and runtypes.pages.dev, both Cloudflare Pages — and the host-run
+`website/` directory plus the GitHub Pages deploy are retired.
+
+## Owner actions
+
+- Create the Cloudflare Pages project for mion.pages.dev and confirm the existing
+  `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets cover both projects.
+
+## Tasks
+
+- **Site selector.** Add an `RT_SITE=runtypes|mion` switch (registered in the env REGISTRY) read
+  by `nuxt.config.ts` and the website build scripts. It picks per site: the content tree, the
+  app.config (nav, github block, socials, branding), and public assets (favicons, banners,
+  redirects). Components, layouts, server utils (code-import, twoslash, highlighter) and the
+  playground stay shared. The two content trees are NOT merged — the runtypes docs stay as they
+  are; mion's dirs (`introduction`, `server`, `drizzle-orm`, `client`, `run-types`, `devtools`,
+  `platforms`, `benchmarks`, `articles`) become the mion site's tree.
+- **Content reconciliation, mion side only:** rewrite mion's `run-types` section to introduce the
+  topic and link across to the runtypes site instead of duplicating its guide; point every code
+  example at the merged `packages/examples` package (both sites use `<code-import>`, so the root
+  typecheck keeps both honest). Port mion's `check-links` / `check-unused-examples` /
+  twoslash-test scripts where they differ from the container's own.
+- **Dependencies/image.** Both sites already use Nuxt 4.4.2 + Docus 5.9.0 + @nuxt/content 3.12.0
+  + the same shiki/twoslash stack; add mion-only extras to `container/website/_deps` and rebuild +
+  push `tsrt-website` (`pnpm rtx container push website`). The deps-hash label mechanism enforces
+  the manifests match.
+- **Benchmarks pages:** the mion site's benchmark pages keep rendering from committed data for
+  now — the data pipeline moves in step 8, so whatever `copy-benchmarks` produced last is checked
+  in as static content until then.
+- **Deletions:** `website/` (the whole host app, including its stale docus-starter name/README;
+  move `.vscode-extension/` into the container app only if still wanted), the root `pages-build` +
+  `copy-benchmarks` scripts, and `.github/workflows/nuxtjs.yml` (GitHub Pages deploy retired).
+- **Deploy:** extend `website-deploy.yml` and `scripts/website/build.mjs` to build and deploy both
+  sites (two `wrangler`/Pages targets, same guard rules: `verify-live` before publishing docs for
+  a released version).
+
+## Done criteria
+
+- `pnpm rtx website dev` (or the site script's site flag) serves either site locally from the
+  container; `pnpm rtx website build` produces both static outputs and `check-static` passes for
+  each.
+- Both Cloudflare Pages projects deploy from `website-deploy.yml`; the GitHub Pages workflow is
+  gone; `website/` is gone.
+- Repo-wide grep finds no reference to the deleted host `website/` paths.

--- a/docs/todos/unify-e2e-on-verdaccio.md
+++ b/docs/todos/unify-e2e-on-verdaccio.md
@@ -1,0 +1,49 @@
+# Move mion's publish e2e into the verdaccio container (merge master plan, step 5)
+
+**Status:** open
+**Created:** 2026-08-24
+
+Step 5 of [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Requires [unify-workspace-and-toolchain.md](unify-workspace-and-toolchain.md) landed (can run in
+parallel with step 4). Goal: one pre-publish gate — the `tsrt-e2e` image's verdaccio serves BOTH
+package families, mion's consumer checks run inside the same matrix, and the local-tarball
+`test-publish/` flow is retired.
+
+## Background
+
+mion today: `test-publish/` installs `file:./tarballs/*.tgz` via pnpm overrides and runs 4 specs
+(json flow, binary, packaged-sources, build-output inlining), driven by
+`scripts/pre-publish-test.sh` — manual, host-only, no registry semantics. ts-run-types today:
+verdaccio 6.7.2 inside `container/pre-publish-e2e/`, `e2e-serve.sh` publishes the packed tarballs
+in dependency order, consumer apps under `apps/` install from the registry and a feature matrix +
+host-native smoke run against them, all fronted by `rtx release e2e` with container / host-npx /
+npm backends.
+
+## Tasks
+
+- **Verdaccio config:** add `@mionjs/*` to `registry/verdaccio.yaml` (and the CI host-npx twin
+  `.github/verdaccio.yaml`) with the same posture as `@ts-runtypes/*` — served ONLY from local
+  publishes, never proxied to npmjs (both scopes have live npm versions that must not leak in).
+- **Publish order:** extend `e2e-serve.sh` to publish the mion tarballs after the runtypes ones:
+  platform binaries → bin → core → devtools → `@mionjs/core` → router/client/drizzle → mion
+  devtools → platform adapters; fail loudly if a required family is missing.
+- **mion consumer app:** port the 4 `test-publish` specs into a new `apps/` member (e.g.
+  `apps/mion-server`) driven by `build-all.mjs`: installs `@mionjs/*` from verdaccio, boots the
+  test server (the old `globalSetup.ts` / port 8086 flow), runs the json/binary round-trips,
+  inspects the installed tarball contents, and asserts compiled runtypes + harvested mappers are
+  inlined in a production build. Include a Bun lane if `platform-bun` is to be covered
+  (bun is already baked into the image).
+- **Pack + gate:** extend `scripts/release/pack.mjs` (and the e2e receipt) to pack the 11 public
+  `@mionjs/*` packages alongside the 10 runtypes ones; `rtx release e2e` needs no new flags, just
+  the bigger tarball set. Rebuild + push `tsrt-e2e` (`pnpm rtx container push e2e`).
+- **Deletions:** `test-publish/` (workspace, lockfile, specs — all superseded),
+  `scripts/pack-packages.sh`, `scripts/pack-and-install.sh`, `scripts/pre-publish-test.sh`, and
+  the CLAUDE.md sections that describe them.
+
+## Done criteria
+
+- `pnpm rtx release e2e` (container backend) publishes both families to verdaccio and the full
+  matrix — runtypes apps AND the mion consumer app — passes locally.
+- The `host-npx` and `npm` backends still work (npm backend gains the mion packages only after
+  the first unified release in step 6; guard accordingly).
+- `test-publish/` and the three shell scripts are gone; nothing references them.

--- a/docs/todos/unify-release-train-and-ci.md
+++ b/docs/todos/unify-release-train-and-ci.md
@@ -1,0 +1,51 @@
+# One release train and one CI (merge master plan, step 6)
+
+**Status:** open
+**Created:** 2026-08-24
+
+Step 6 of [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Requires [unify-e2e-on-verdaccio.md](unify-e2e-on-verdaccio.md) landed (and step 4 for the
+website-deploy hook). Goal (settled decision 2): every published package — 10 `@ts-runtypes/*` +
+11 `@mionjs/*` — ships from one `version.json` lockstep train through the `main` → `prod` flow,
+and the ts-run-types CI is THE repo CI.
+
+## Owner actions
+
+- Branch protections for `main` (rebase-merge PRs, required checks) and `prod` (merge-commit-only
+  promotion; `publish.yml`'s `merge-shape` job enforces the commit shape, but the protection
+  keeps humans honest).
+- The first unified release's npm 2FA stage-approve (`pnpm rtx release stage-approve`), as for
+  every release.
+
+## Tasks
+
+- **CI:** extend `ci.yml`'s `js-lint` lane with the mion suites (`test:ci` batches, `test:bun`,
+  mion eslint, `check-code-imports` equivalent) — or a parallel `mion` job if runtime demands it;
+  keep the paths-filter job in sync. Retire `.github/workflows/pull-requests.yml`. Extend
+  `release-gate.yml`'s e2e job expectations to the enlarged matrix from step 5 (mostly free —
+  the gate calls `rtx release e2e`).
+- **Versioning:** `@mionjs/*` joins `version.json` lockstep. `bump-version.mjs` already stamps
+  every `packages/*/package.json`; verify it handles the mion set (including private ones like
+  `test-server` and `examples`, which move to the same version like the runtypes private
+  packages do). First joint version: next minor above 0.12.2 (e.g. 0.13.0); `@mionjs/*` jumps
+  from 0.8.10, which npm is fine with.
+- **Publish flow:** extend `publish-tarballs.mjs` / `publish.mjs` / `manual-publish.mjs` /
+  `verify-live.mjs` / `unpublish.mjs` with the `@mionjs/*` set in dependency-safe order
+  (runtypes first, then `@mionjs/core`, then its dependents). `stage-approve.mjs`'s leaves-first
+  walk gains the new packages. Delete mion's `scripts/publish.sh` and `scripts/unpublish.sh`.
+- **`prod` branch:** create it from `main` at the first release cut; `pre-publish.yml` /
+  `publish.yml` / the release-to-prod skill then apply unchanged. Note for the first release:
+  `main-ancestor` and `version-fresh` jobs must pass with the joined history (the version check
+  queries npm for the new version across ALL packages — extend its package list).
+- **Changelog:** git-cliff (`cliff.toml`) covers the whole repo from now on; mion's pre-merge
+  history predates conventional commits, which is fine — the tag pattern starts the changelog at
+  the runtypes tags. Commitlint (already enforced by `ci.yml` on PRs) now governs mion work too.
+- Update the release-to-prod skill's package expectations and CLAUDE.md's publishing section.
+
+## Done criteria
+
+- A full dry pass: `rtx release preflight` → `pack` → `e2e` green with 21 packages.
+- First unified release ships to npm through `pre-publish.yml` → `publish.yml` →
+  stage-approve, and `post-publish.yml`'s live-registry e2e passes including the mion consumer.
+- `verify-live` confirms every package at the unified version; the website deploy gate accepts it.
+- No lerna-era or manual-publish scripts remain.

--- a/docs/todos/unify-workspace-and-toolchain.md
+++ b/docs/todos/unify-workspace-and-toolchain.md
@@ -1,0 +1,49 @@
+# Unify the workspace and toolchain after the join (merge master plan, step 3)
+
+**Status:** open
+**Created:** 2026-08-24
+
+Step 3 of [merge-ts-runtypes-into-mion-master-plan.md](merge-ts-runtypes-into-mion-master-plan.md).
+Requires [join-ts-runtypes-history.md](join-ts-runtypes-history.md) landed. Goal: one toolchain —
+the temporary `:mion` seams from the join disappear, mion consumes the runtypes packages from the
+workspace instead of npm, and lerna/nx are gone.
+
+## Tasks
+
+- **Switch `@mionjs/*` → `workspace:*`** for every `@ts-runtypes/{core,devtools,bin}` dependency
+  (core, router, client, drizzle, devtools, platform-bun, examples). Drop `@ts-runtypes/*` from
+  `minimumReleaseAgeExclude`. Regenerate the lockfile. This is the moment the 0.12.2 npm pin
+  disappears; `@mionjs/devtools`' wrapper now builds against sibling source/dists — decide whether
+  its committed `build/` output stays committed (eslint consumers need compiled JS) or becomes a
+  build artifact like the runtypes dists, and document the choice.
+- **Delete lerna + nx:** `lerna.json`, `nx.json`, `packages/client/project.json`, the lerna-driven
+  `:mion` scripts. Re-wire `lint` / `build` / `clean` / `fresh-start` so the canonical
+  ts-run-types scripts (and `rtx`) cover the mion packages too. Keep mion's `test:ci` batching
+  (documented OOM guard: resolver processes are ~200 MB each) and `test:bun` as named lanes of the
+  unified test script set.
+- **Format/lint unification:** extend the `pnpm run format` scope (oxfmt for TS, prettier for
+  package markdown, gofmt for Go) over the mion packages — settings are identical to mion's
+  prettier config, so the one-time reformat diff should be small; commit it separately. Keep
+  mion's eslint flat config (its own plugin rules like `strong-typed-routes` are mion-specific)
+  wired into the root `lint` alongside oxlint; fold the duplicated `runtypes/*` rule wiring so the
+  rules are configured once.
+- **Root configs:** finish what the join deferred — single vitest project list with no
+  duplication, tsconfig references complete for every package (mion's list was missing drizzle,
+  platform-cloudflare and platform-vercel even before the merge), engines/node checks in one
+  place.
+- **Rename `packages/drizze` → `packages/drizzle`** (dir has been misspelled vs the
+  `@mionjs/drizzle` package name since its creation) and update the vitest project name, tsconfig
+  reference, and any path references.
+- **Env registry:** any env var the mion side reads gets added to the `REGISTRY` in
+  `scripts/lib/env.mjs` per the ts-run-types contract (`pnpm run check:env` enforces it).
+- Update CLAUDE.md's temporary addendum to match the unified reality (the full doc merge stays in
+  step 7).
+
+## Done criteria
+
+- One clean clone bootstrapped by the ts-runtypes-setup skill runs `pnpm install`,
+  `pnpm run check:builds`, full `pnpm test`, `go -C ts-go-runtypes test ./internal/...`,
+  `pnpm run lint`, `pnpm run check-format` — no `:mion` scripts left, no lerna/nx anywhere.
+- `pnpm why @ts-runtypes/core` resolves to the workspace link, not the registry.
+- `scripts/pre-publish-test.sh` still passes (it dies in step 5, but must not be broken before
+  its replacement exists).

--- a/nx.json
+++ b/nx.json
@@ -23,7 +23,7 @@
       "dependsOn": []
     }
   },
-  "defaultBase": "master",
+  "defaultBase": "main",
   "release": {
     "projects": ["packages/*", "!packages/test-server"]
   }

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -27,7 +27,7 @@ Modern client for mion APIs:
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -25,7 +25,7 @@ All items in this library should be isomorphic, this mean should used both in th
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/drizze/README.md
+++ b/packages/drizze/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, Typescript Full Stack APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, Typescript Full Stack APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -21,7 +21,7 @@
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -37,7 +37,7 @@ bun src/serve-bun.ts
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/platform-aws/README.md
+++ b/packages/platform-aws/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -20,7 +20,7 @@ This package contains handler functions to run mion on AWS Lambda.
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -20,7 +20,7 @@ This package contains a Bun server to run mion APIs!
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/platform-gcloud/README.md
+++ b/packages/platform-gcloud/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -22,7 +22,7 @@ This package contains handler functions to run mion on [Google Cloud functions](
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/platform-node/README.md
+++ b/packages/platform-node/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, a mikro kit for Typescript Serverless APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -20,7 +20,7 @@ This package contains a Node.js server to run mion APIs!
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png">
-    <img alt='mion, Typescript Full Stack APIs' src='https://raw.githubusercontent.com/MionKit/mion/master/assets/public/bannerx90.png'>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png">
+    <img alt='mion, Typescript Full Stack APIs' src='https://raw.githubusercontent.com/MionKit/mion/main/assets/public/bannerx90.png'>
   </picture>
 </p>
 <p align="center">
@@ -25,7 +25,7 @@ mion's is lightweight and fast. Unlike traditional routers. The Http method is n
 
 ## Check Out The [Website And Documentation](http://mion.io) 📚
 
-[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/master/assets/public/mion-website-banner.png)](http://mion.io)
+[![mion-website-banner](https://raw.githubusercontent.com/MionKit/mion/main/assets/public/mion-website-banner.png)](http://mion.io)
 
 ---
 

--- a/website/app/app.config.ts
+++ b/website/app/app.config.ts
@@ -46,7 +46,7 @@ export default defineAppConfig({
       credits: {
         icon: 'icon-park-outline:copyright',
         text: `MIT license - Copyright ${new Date().getFullYear()} Mion`,
-        href: 'https://github.com/MionKit/mion/blob/master/LICENSE',
+        href: 'https://github.com/MionKit/mion/blob/main/LICENSE',
       },
     }
   },


### PR DESCRIPTION
## Summary

Two things, both follow-ups to the merged step 1 cleanup (#146 and its successors):

1. **Implements `docs/todos/default-branch-rename-references.md`** — the half of the pre-merge cleanup that was blocked until the owner renamed the default branch to `main` (done 2026-08-24):
   - `.github/workflows/nuxtjs.yml` Pages deploy trigger `master` → `main`
   - `nx.json` `defaultBase` `master` → `main`
   - 38 `raw.githubusercontent.com/MionKit/mion/master/...` asset URLs → `main` across the root README and 9 package READMEs
   - `website/app/app.config.ts` LICENSE link `blob/master` → `blob/main`
   - The spec moves to `docs/done/` with status updated. Done-criteria grep confirms no `MionKit/mion` master links remain outside `docs/done/` history notes (the `MionKit/Benchmarks/blob/master` links are a different repo and stay).

2. **Files one `docs/todos/` spec per remaining merge phase** (steps 2–8 of the master plan), each linked from the master plan's step headings:
   - `join-ts-runtypes-history.md` — step 2, the unrelated-histories join, with the full 14-file conflict matrix, green-bar checklist, and the owner prerequisites (merge-commit landing, GHCR package access for this repo's Actions)
   - `unify-workspace-and-toolchain.md` — step 3, workspace:* switch, lerna/nx removal, format/lint unification, `drizze` → `drizzle` rename
   - `merge-websites-one-nuxt-two-sites.md` — step 4, one Nuxt install building mion.pages.dev + runtypes.pages.dev
   - `unify-e2e-on-verdaccio.md` — step 5, mion's publish e2e moves into the tsrt-e2e verdaccio matrix, test-publish retired
   - `unify-release-train-and-ci.md` — step 6, single version.json train + main→prod flow for all 21 packages
   - `guidelines-skills-docs-metadata-sweep.md` — step 7, final CLAUDE.md/SETUP/skills merge, repo-reference sweep, archive the old repo
   - `fold-mion-benchmarks-into-container.md` — step 8 (last), mion-benchmarks into container/benchmarks
   - The master plan's step 2 sketch was aligned with the detailed spec (mion keeps the repo README; unions where the sketch oversimplified)

https://claude.ai/code/session_01Ua6ERA46KtJhSyF9MKf8Y9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ua6ERA46KtJhSyF9MKf8Y9)_