### PR TITLE
Convert recursive types to lazy pair form

### DIFF
--- a/container/website/sites/runtypes/content/02.guide/13.source-conversion.md
+++ b/container/website/sites/runtypes/content/02.guide/13.source-conversion.md
@@ -53,6 +53,15 @@ Conversion changes the spelling, never the shape. Every converted declaration re
 
 Everything the engine reflects: primitives and literals, string and number formats, arrays, tuples (labeled ones included, using RT.slot in builder form), objects (optional, readonly and quoted keys included), records (including an index signature beside named properties, which becomes an intersection in builder form), unions, enums, classes, Date, Map, Set, Promise, RegExp, Temporal types, functions (named parameters use RT.slot too), template literals, branded types, and recursive types. Recursive shapes come out as `RT.circular` with `RT.self()` in builder form.
 
+Some recursive types have no value spelling for the loop. A type that also needs the `getRunType` escape (a method member is the usual reason) is one case, and a type that loops back through one of its own tuple slots, like `type Pair = [number, Pair]`, is the other. For these the converter keeps the type declaration as written and adds a handle const beside it:
+
+```ts
+export type TreeNode = {label(): string; kids: TreeNode[]};
+export const treeNodeRT = getRunType<TreeNode>();
+```
+
+That pair is the builder form for such a type. Running the conversion again leaves it alone, and converting back to the type form removes the const.
+
 Declarations that reference each other stay references. A type that names another converted type keeps the name in every form, across files too: convert the files together and the imports are updated for you.
 
 ```bash
@@ -69,8 +78,7 @@ What is left is the short list below, where even the escape cannot help because 
 | ----- | --- |
 | A cycle that never passes through a named type | The self reference has nothing to point at. Give the inner type a name and it converts. |
 | A symbol-keyed property | The property name is a symbol, and an escape can only carry a type it can write down. |
-| A recursive type reached only inside an embedded type expression | Embedded types are quoted TypeScript, and quoted text cannot point back at the declaration being defined. |
-| A type that loops back through one of its own tuple slots, like `type Pair = [number, Pair]` | Only when converting to type builders. TypeScript works out a tuple's slots straight away rather than on demand, so the builder form cannot close the loop there. Put the recursion behind an object, array, Map, Set or function and it converts. |
+| A recursive type written inline at a call site | The call has no name for the loop to close on. Declare the type with a name and it converts. |
 | A reference to a type whose file is not in the same run | Add that file to the same command. |
 | A Temporal type that resolves to `any` | The Temporal declarations are missing from your project. Add the `ESNext.Temporal` lib or a polyfill's types. Converting would bake the `any` in permanently. |
 

--- a/docs/done/convert-circular-types-to-builders.md
+++ b/docs/done/convert-circular-types-to-builders.md
@@ -1,7 +1,7 @@
 ---
 type: feature
 spec: guidelines
-status: ready
+status: done
 created: 2026-08-20
 ---
 
@@ -107,3 +107,35 @@ Approach picked by the user (option A of two investigated):
   `typeGen.ts` with mutual declaration cycles, hold convert / convertcli /
   elision lanes green. Docs: update the conversion guide's recursion prose and
   refusal table.
+
+## Shipped (2026-08-27)
+
+What actually landed, including a mid-implementation extension the user
+approved:
+
+- **Escape-on-cycle AND tuple-slot recursive declarations both convert now**,
+  through the lazy pair (`printLazyPair` in
+  `ts-go-runtypes/internal/convert/print.go`, pairing in `recognize.go`).
+  The original decision to keep tuple cycles refused was reversed once it was
+  clear the pair sidesteps `Recursive<Body>` entirely: the declaration stays a
+  real deferred alias, so TypeScript never instantiates the tuple eagerly.
+  `type Pair = [number, Pair]` now converts to itself plus
+  `const pairRT = getRunType<Pair>();`.
+- **The "lossy circular payloads" class turned out to be dead code**:
+  `circularLossyPayload`'s walk always returned empty (the `oneOf` payload it
+  described no longer exists in the codebase, and the optional-slot labeled
+  tuple case already converts). The function, its callers and the equally
+  unreachable `reachesCycle` helper were deleted rather than extended.
+- **Still refused, on purpose**: anonymous cycles and recursive types written
+  inline at call sites. A call site has no declaration to keep real, so there
+  is no name for the loop to close on. `RT.circular` + `RT.self()` keeps
+  covering plain-data recursion unchanged.
+- Fuzz: `EXPECTED_REFUSALS` is now empty (both entries retired);
+  `typeGen.ts` grows mutual interface cycles (knot props through optional /
+  array positions); convert, convertcli and elision lanes green at quick tier.
+- Tests: `TestChain_EscapeOnCycleConvertsLazyPair`,
+  `TestCircular_TupleSlotCycleConvertsLazyPair`, `TestPair_*` (hand-written
+  pair fixpoint + const-still-used guard), a CLI e2e pair round-trip, and the
+  refusal rows removed from `unsupported-conversion.test.ts`.
+- Docs: the source-conversion guide's What-converts section documents the
+  pair; the tuple and embedded-recursion rows left the refusal table.

--- a/docs/todos/convert-circular-types-to-builders.md
+++ b/docs/todos/convert-circular-types-to-builders.md
@@ -78,3 +78,32 @@ pointer true as specs move.
   shapes and hold C2 / roundtrip green over them, with `EXPECTED_REFUSALS`
   shrunk to match.
 - Website conversion docs reflect what converts.
+
+## Plan — lazy pair form (approved 2026-08-27)
+
+Approach picked by the user (option A of two investigated):
+
+- **Escape-on-cycle recursive types convert to the "lazy pair"**: keep the
+  declaration a REAL type (real type names resolve lazily, so the cycle stays
+  legal TypeScript) and emit a value handle const beside it:
+  `type TreeNode = {label(): string; kids: Forest};` +
+  `const treeNodeRT = getRunType<TreeNode>();`. Type text cannot hold
+  `RT.self()`, and a converted name resolves through the eager
+  `InferType<typeof constRT>` chain (circular const inference → `any`), so the
+  name has to stay real. Ids cannot move because the type is unchanged (C2 safe
+  by construction).
+- **`recognize.go` learns the pair**: `const xRT = getRunType<Name>()` over a
+  same-file type declaration is recognized as ONE builders-form declaration
+  (type stmt + const stmt), so a second `--to builders` run is a byte no-op
+  (C5) and `--to type` collapses the pair back to the type declaration through
+  the existing alias-drop + CNV003 (const still used) machinery.
+- **`print.go` falls back** to the pair when the builders print of a type-form
+  declaration hits either escape-on-cycle refusal; call sites and the type
+  target keep refusing as before. In a mutual cycle both sides fall back.
+- **Kept refused, by decision**: tuple-slot cycles (TypeScript instantiates
+  mapped tuple slots eagerly, `Recursive<Body>` unrolls — no type-level fix
+  found) and anonymous / call-site cycles (no declaration to keep real).
+- Fuzz: drop the embedded-self-reference entry from `EXPECTED_REFUSALS`, grow
+  `typeGen.ts` with mutual declaration cycles, hold convert / convertcli /
+  elision lanes green. Docs: update the conversion guide's recursion prose and
+  refusal table.

--- a/packages/ts-runtypes-devtools/test/convert-cli.test.ts
+++ b/packages/ts-runtypes-devtools/test/convert-cli.test.ts
@@ -182,6 +182,34 @@ describe('ts-runtypes convert (CLI e2e)', () => {
     }
   });
 
+  register('a recursive type needing a getRunType escape converts to the lazy pair, and back', () => {
+    const dir = makeProject();
+    try {
+      // The method member forces the getRunType escape, and the recursion
+      // means no value spelling exists (type text cannot hold RT.self()), so
+      // the conversion keeps the type REAL and adds a handle const beside it.
+      const treePath = path.join(dir, 'src', 'tree.ts');
+      fs.writeFileSync(treePath, 'export interface TreeNode {label(): string; kids: TreeNode[];}\n');
+      const toBuilders = runConvert(dir, ['--to', 'builders', treePath]);
+      expect(toBuilders.status, toBuilders.report).toBe(0);
+      const pairForm = fs.readFileSync(treePath, 'utf8');
+      expect(pairForm).toContain('export type TreeNode = {label(): string; kids: TreeNode[]};');
+      expect(pairForm).toContain('export const treeNodeRT = getRunType<TreeNode>();');
+      // The pair IS the builders form: a second run is a no-op.
+      const again = runConvert(dir, ['--to', 'builders', treePath]);
+      expect(again.status, again.report).toBe(0);
+      expect(fs.readFileSync(treePath, 'utf8')).toBe(pairForm);
+      // The type target collapses the pair back to the type declaration.
+      const toType = runConvert(dir, ['--to', 'type', treePath]);
+      expect(toType.status, toType.report).toBe(0);
+      const typeForm = fs.readFileSync(treePath, 'utf8');
+      expect(typeForm).toContain('export type TreeNode = {label(): string; kids: TreeNode[]};');
+      expect(typeForm).not.toContain('getRunType<');
+    } finally {
+      fs.rmSync(dir, {recursive: true, force: true});
+    }
+  });
+
   register('a written type name that resolves nowhere refuses with CNV008 (exit 1, source untouched)', () => {
     const dir = makeProject();
     try {

--- a/packages/ts-runtypes/test/features/unsupported-conversion.test.ts
+++ b/packages/ts-runtypes/test/features/unsupported-conversion.test.ts
@@ -90,15 +90,11 @@ const UNSUPPORTED: readonly UnsupportedCase[] = [
     keeps: 'export type Tagged = {[tag]: number};',
   },
 
-  // ── Recursion the value-first form cannot carry ───────────────────────
-  {
-    title: 'a cycle that closes on a tuple slot, converting to builders',
-    files: {'main.ts': 'export type Pair = [number, Pair];\n'},
-    target: 'builders',
-    code: 'CNV001',
-    says: 'cycle that closes on a tuple slot',
-    keeps: 'export type Pair = [number, Pair];',
-  },
+  // NOT listed: recursive declarations. Every named recursive declaration now
+  // converts — plain data shapes through RT.circular/RT.self(), and the
+  // shapes RT.circular cannot carry (a getRunType escape on the cycle, a
+  // cycle closing on a tuple slot) through the LAZY PAIR: the type stays a
+  // real declaration and gains a `getRunType<Name>()` handle const.
 
   // ── Cross-file references the run cannot see ──────────────────────────
   {

--- a/packages/ts-runtypes/test/fuzz/convert/convertRoundtrip.ts
+++ b/packages/ts-runtypes/test/fuzz/convert/convertRoundtrip.ts
@@ -274,17 +274,13 @@ export interface ConvertFuzzReport {
 }
 
 /** The designed CNV001 refusals the generated space can legitimately reach —
- *  each is a documented loud lane, not a bug: recursive types inside embedded
- *  type expressions (no self-reference spelling inside getRunType text).
- *  Anything else is a failure. **/
-const EXPECTED_REFUSALS = [
-  /self-referential type inside an embedded type expression/,
-  // A tuple slot is instantiated EAGERLY, so `RT.circular` cannot tie the
-  // knot there — the type form is the only one that carries
-  // `type Pair = [number, Pair]`
-  // (packages/ts-runtypes/test/features/unsupported-conversion.test.ts).
-  /cycle that closes on a tuple slot/,
-];
+ *  each is a documented loud lane, not a bug. Anything else is a failure.
+ *  The list is EMPTY since every named recursive declaration converts: the
+ *  embedded-self-reference and tuple-slot entries left when those shapes
+ *  started converting to the LAZY PAIR (a kept real type plus a
+ *  `getRunType<Name>()` handle const). Only call-site/unnamed cycles refuse,
+ *  and the generator never writes those. **/
+const EXPECTED_REFUSALS: RegExp[] = [];
 
 function isExpectedRefusal(message: string): boolean {
   return EXPECTED_REFUSALS.some((pattern) => pattern.test(message));

--- a/packages/ts-runtypes/test/fuzz/core/typeGen.ts
+++ b/packages/ts-runtypes/test/fuzz/core/typeGen.ts
@@ -764,6 +764,31 @@ function genDecl(ctx: Ctx): void {
   // unresolved. That dependency-linking bug is tracked as a follow-up; the
   // `calls` plumbing stays so it can be re-enabled once it lands.
   ctx.decls.push({kind: 'interface', name, props, calls: undefined});
+  // Mutual declaration cycle: occasionally tie a knot with an EARLIER
+  // interface. Both legs sit in inhabitable positions (an optional prop, an
+  // array element) so values stay finite, exactly like self-recursion;
+  // isRecursive() reports the knot, so the value-tier oracles keep skipping
+  // recursive draws while the resolver/emit/convert oracles cover them.
+  const partners = ctx.decls.filter(
+    (decl): decl is Extract<Decl, {kind: 'interface'}> => decl.kind === 'interface' && decl.name !== name
+  );
+  if (partners.length && chance(0.25)) {
+    const partner = pick(partners);
+    props.push({
+      name: `knot${props.length}`,
+      optional: true,
+      readonly: false,
+      method: false,
+      shape: {kind: 'ref', name: partner.name},
+    });
+    partner.props.push({
+      name: `knot${partner.props.length}`,
+      optional: false,
+      readonly: false,
+      method: false,
+      shape: {kind: 'array', elem: {kind: 'ref', name}},
+    });
+  }
 }
 
 // Generate object/interface/class members. `selfName`, when set, is in scope as

--- a/ts-go-runtypes/internal/convert/callsites.go
+++ b/ts-go-runtypes/internal/convert/callsites.go
@@ -346,10 +346,6 @@ func printCallSite(
 			return nil, diag
 		}
 		if ctx.usedSelf {
-			if payload := ctx.circularLossyPayload(site.node); payload != "" {
-				return nil, &Diagnostic{Code: CodeUnsupportedKind, Severity: SeverityError, Decl: site.label,
-					Message: payload + " inside a recursive type is not convertible to builders (RT.circular cannot carry it through the self-substitution)"}
-			}
 			if tupleDiag := ctx.eagerTupleCycleDiag(site.node, ctx.decl, "RT.circular"); tupleDiag != nil {
 				return nil, tupleDiag
 			}

--- a/ts-go-runtypes/internal/convert/circular_test.go
+++ b/ts-go-runtypes/internal/convert/circular_test.go
@@ -276,7 +276,6 @@ func TestCircular_TupleSlotCycleConvertsLazyPair(t *testing.T) {
 	}
 }
 
-
 func TestCircular_TupleSlotBehindDeferredContainerConverts(t *testing.T) {
 	// Every OTHER slot defers, so the knot closes and the cycle converts —
 	// only the direct tuple slot refuses above.

--- a/ts-go-runtypes/internal/convert/circular_test.go
+++ b/ts-go-runtypes/internal/convert/circular_test.go
@@ -241,34 +241,41 @@ func TestCircular_SelfStillSubstitutesThroughContainers(t *testing.T) {
 	}
 }
 
-func TestCircular_TupleSlotCycleRefusedOnValueForms(t *testing.T) {
-	// A tuple is the one container the value-first forms cannot tie a knot
-	// through: TypeScript instantiates a mapped tuple's slots up front, so
+func TestCircular_TupleSlotCycleConvertsLazyPair(t *testing.T) {
+	// A tuple is the one container `RT.circular` cannot tie a knot through:
+	// TypeScript instantiates a mapped tuple's slots up front, so
 	// `Recursive<Body>` unrolls itself until the checker gives up rather than
-	// substituting. Converting anyway emitted a declaration whose inferred
-	// type kept a raw `Self` — a silently different id that would not convert
-	// back. The TYPE form carries every one of these, since a hand-written
-	// recursive tuple alias is an ordinary deferred type.
-	for _, source := range []string{
-		"export type Pair = [number, Pair];\n",
-		"export type Tail = [number, Tail?];\n",
-		"export type Rest = [number, ...Rest[]];\n",
-		"export type Labeled = [head: number, tail: Labeled];\n",
+	// substituting. The LAZY PAIR sidesteps the substitution entirely — the
+	// declaration stays a REAL deferred alias (an ordinary recursive tuple
+	// type) and gains a `getRunType<Name>()` handle — so these convert now,
+	// with every leg keeping the declaration's id.
+	for _, testCase := range []struct {
+		source string
+		pair   string
+	}{
+		{"export type Pair = [number, Pair];\n", "export const pairRT = getRunType<Pair>();"},
+		{"export type Tail = [number, Tail?];\n", "export const tailRT = getRunType<Tail>();"},
+		{"export type Rest = [number, ...Rest[]];\n", "export const restRT = getRunType<Rest>();"},
+		{"export type Labeled = [head: number, tail: Labeled];\n", "export const labeledRT = getRunType<Labeled>();"},
 		// A union arm inherits the eagerness (the substitution distributes).
-		"export type Maybe = [number, Maybe | null];\n",
+		{"export type Maybe = [number, Maybe | null];\n", "export const maybeRT = getRunType<Maybe>();"},
 		// Nested tuples chain it.
-		"export type Nest = [number, [string, Nest]];\n",
+		{"export type Nest = [number, [string, Nest]];\n", "export const nestRT = getRunType<Nest>();"},
 	} {
-		_, diags := convertOne(t, source, convert.Options{Target: convert.TargetBuilders})
-		if len(diags) != 1 || diags[0].Code != convert.CodeUnsupportedKind ||
-			!strings.Contains(diags[0].Message, "cycle that closes on a tuple slot") {
-			t.Fatalf("expected the tuple-slot refusal for %q, got %+v", source, diags)
+		builderForm := convertAndCheckIDs(t, testCase.source, convert.TargetBuilders)
+		if !strings.Contains(builderForm, testCase.pair) {
+			t.Errorf("expected the lazy pair %q in:\n%s", testCase.pair, builderForm)
 		}
-		if typeForm := convertAndCheckIDs(t, source, convert.TargetType); typeForm != source {
-			t.Errorf("the type form should be a byte no-op:\n%s", typeForm)
+		if again := convertAndCheckIDs(t, builderForm, convert.TargetBuilders); again != builderForm {
+			t.Errorf("builders target is not a fixpoint over the pair:\n%s\n---\n%s", builderForm, again)
+		}
+		typeForm := convertAndCheckIDs(t, builderForm, convert.TargetType)
+		if strings.Contains(typeForm, "getRunType<") {
+			t.Errorf("type target should drop the handle const:\n%s", typeForm)
 		}
 	}
 }
+
 
 func TestCircular_TupleSlotBehindDeferredContainerConverts(t *testing.T) {
 	// Every OTHER slot defers, so the knot closes and the cycle converts —
@@ -314,34 +321,77 @@ func TestChain_RecursiveIndexPrintsTheLiteralSpelling(t *testing.T) {
 	}
 }
 
-func TestChain_EscapeOnCycleRefuses(t *testing.T) {
+func TestChain_EscapeOnCycleConvertsLazyPair(t *testing.T) {
 	// A cycle whose builders spelling needs a getRunType ESCAPE (a method
-	// forces one) has no sound print: the escape's type text can only reach
-	// its cycle partner by NAME, and after conversion that name resolves
-	// through `InferType<typeof partnerRT>` — an EAGER alias whose const sits
-	// on the same cycle, so TypeScript silently collapses the whole knot to
-	// `any` and the printed code type-erases the schema. Found by the elision
-	// fuzz lane (seed 886383364: a recursive interface under an array root);
-	// the reference must refuse like the direct self-back-edge does.
-	for _, source := range []string{
+	// forces one) has no value print: the escape's type text can only reach
+	// its cycle partner by NAME, and a converted name resolves through
+	// `InferType<typeof partnerRT>` — an EAGER alias whose const sits on the
+	// same cycle, so TypeScript silently collapses the whole knot to `any`
+	// (found by the elision fuzz lane, seed 886383364). The conversion now
+	// prints the LAZY PAIR instead: the declaration stays a REAL type (real
+	// names resolve lazily, so the knot is legal TS) plus a
+	// `getRunType<Name>()` handle const — and the chain oracle proves every
+	// leg keeps the declaration's id.
+	for _, testCase := range []struct {
+		source string
+		pair   string
+	}{
 		// The wild shape: recursion through the partner that names the array.
-		"export interface TreeNode {label(): string; kids: Forest;}\nexport type Forest = TreeNode[];\n",
+		{"export interface TreeNode {label(): string; kids: Forest;}\nexport type Forest = TreeNode[];\n",
+			"export const treeNodeRT = getRunType<TreeNode>();"},
 		// A mutual object cycle with the escape on one side.
-		"export interface Alpha {tag(): string; beta?: Beta;}\nexport type Beta = {alpha?: Alpha};\n",
+		{"export interface Alpha {tag(): string; beta?: Beta;}\nexport type Beta = {alpha?: Alpha};\n",
+			"export const alphaRT = getRunType<Alpha>();"},
+		// The direct self back-edge, no partner involved.
+		{"export interface Node {label(): string; next?: Node;}\n",
+			"export const nodeRT = getRunType<Node>();"},
 	} {
-		_, diags := convertOne(t, source, convert.Options{Target: convert.TargetBuilders})
-		if len(diags) == 0 {
-			t.Fatalf("expected the embedded-cycle refusal for %q, got a clean conversion", source)
+		builderForm := convertAndCheckIDs(t, testCase.source, convert.TargetBuilders)
+		if !strings.Contains(builderForm, testCase.pair) {
+			t.Errorf("expected the lazy pair %q in:\n%s", testCase.pair, builderForm)
 		}
-		for _, diagnostic := range diags {
-			if diagnostic.Code != convert.CodeUnsupportedKind ||
-				!strings.Contains(diagnostic.Message, "self-referential type inside an embedded type expression") {
-				t.Fatalf("expected the embedded self-reference refusal for %q, got %+v", source, diags)
-			}
+		// The pair IS the builders form — converting again is a byte no-op.
+		if again := convertAndCheckIDs(t, builderForm, convert.TargetBuilders); again != builderForm {
+			t.Errorf("builders target is not a fixpoint over the pair:\n%s\n---\n%s", builderForm, again)
 		}
-		// The pure type target keeps every declaration a REAL type, where the
-		// names resolve lazily — the same source must still convert cleanly.
-		convertAndCheckIDs(t, source, convert.TargetType)
+		// The type target collapses the pair back to real declarations only.
+		typeForm := convertAndCheckIDs(t, builderForm, convert.TargetType)
+		if strings.Contains(typeForm, "getRunType<") {
+			t.Errorf("type target should drop the handle const:\n%s", typeForm)
+		}
+	}
+}
+
+func TestPair_HandConstIsTheBuildersForm(t *testing.T) {
+	// A hand-written pair over a NON-recursive type is the same spelling: the
+	// builders target leaves it alone, the type target collapses it.
+	source := "import {getRunType} from '@ts-runtypes/core';\n" +
+		"export type Leaf = {value: string};\n" +
+		"export const leafRT = getRunType<Leaf>();\n"
+	builderForm := convertAndCheckIDs(t, source, convert.TargetBuilders)
+	if builderForm != source {
+		t.Errorf("builders target should be a no-op over a hand-written pair:\n%s", builderForm)
+	}
+	typeForm := convertAndCheckIDs(t, source, convert.TargetType)
+	if strings.Contains(typeForm, "getRunType<") || strings.Contains(typeForm, "leafRT") {
+		t.Errorf("type target should collapse the pair:\n%s", typeForm)
+	}
+	if !strings.Contains(typeForm, "export type Leaf = {value: string};") {
+		t.Errorf("type declaration should survive the collapse:\n%s", typeForm)
+	}
+}
+
+func TestPair_ConstStillUsedRefusesToCollapse(t *testing.T) {
+	// The pair's const referenced OUTSIDE the conversion keeps the pair: the
+	// type target must refuse with the const-still-used diagnostic instead of
+	// breaking the use.
+	source := "import {getRunType} from '@ts-runtypes/core';\n" +
+		"export type Leaf = {value: string};\n" +
+		"export const leafRT = getRunType<Leaf>();\n" +
+		"export const keep = [leafRT];\n"
+	_, diags := convertOne(t, source, convert.Options{Target: convert.TargetType})
+	if len(diags) != 1 || diags[0].Code != convert.CodeConstStillUsed {
+		t.Fatalf("expected the const-still-used refusal, got %+v", diags)
 	}
 }
 

--- a/ts-go-runtypes/internal/convert/convert.go
+++ b/ts-go-runtypes/internal/convert/convert.go
@@ -273,7 +273,7 @@ func constUsedBeyondConversions(set *Set, decl *declaration, currentFile string,
 	if decl.ConstName == "" {
 		return false
 	}
-	constSymbol := set.checker.GetSymbolAtLocation(decl.NameNode)
+	constSymbol := set.checker.GetSymbolAtLocation(constNameNode(decl))
 	if constSymbol == nil {
 		return false
 	}

--- a/ts-go-runtypes/internal/convert/print.go
+++ b/ts-go-runtypes/internal/convert/print.go
@@ -51,6 +51,11 @@ type printContext struct {
 	// usedSelf records that a self back-edge printed (`RT.self()`), so the
 	// builders target wraps the whole expression in `RT.circular(…)`.
 	usedSelf bool
+	// escapeCycle records that a refusal fired because embedded type text
+	// (a getRunType escape) needed to close a cycle — the one refusal class a
+	// type-form declaration recovers from by printing the LAZY PAIR instead
+	// (printLazyPair). Call sites and the type target keep refusing.
+	escapeCycle bool
 	// walking guards the recursive printers: a node already on the walk path
 	// is a back-edge — the root's id closes as a self-reference, anything
 	// else (a cycle through an unnamed intermediate) reports CNV001.
@@ -106,6 +111,7 @@ func (ctx *printContext) declRef(node *reflection.RunType, target Target) (strin
 				// A self back-edge inside an embedded type expression (a
 				// negation embed, an escape) would spell the declaration's own
 				// alias inside its own const initializer — circular in TS.
+				ctx.escapeCycle = true
 				return "", &Diagnostic{Code: CodeUnsupportedKind, Severity: SeverityError, Decl: declLabel(ctx.decl),
 					Message: "self-referential type inside an embedded type expression is not convertible"}, true
 			}
@@ -138,6 +144,7 @@ func (ctx *printContext) declRef(node *reflection.RunType, target Target) (strin
 			// code type-erases the schema (found by the elision fuzz lane).
 			// No spelling closes a cycle inside embedded text, so refuse
 			// loudly like the direct self-back-edge above.
+			ctx.escapeCycle = true
 			return "", &Diagnostic{Code: CodeUnsupportedKind, Severity: SeverityError, Decl: declLabel(ctx.decl),
 				Message: fmt.Sprintf("self-referential type inside an embedded type expression is not convertible (the reference to %s cycles back through this declaration)", entry.TypeName)}, true
 		}
@@ -296,23 +303,31 @@ func printDecl(resolved *resolvedDecl, opts Options, names *nameTable, fileCtx *
 	case TargetBuilders:
 		builderExpr, diag := ctx.builderExpr(resolved.Node)
 		if diag != nil {
+			if ctx.escapeCycle && decl.Form == TargetType && decl.Name != "" {
+				// Embedded type text (a getRunType escape) needed to close a
+				// cycle. No value spelling exists — `RT.self()` cannot appear
+				// inside type text, and a converted name resolves through an
+				// EAGER `InferType<typeof constRT>` chain that collapses the
+				// knot to `any` — so print the LAZY PAIR instead: keep the
+				// declaration a REAL type (real names resolve lazily) and add
+				// a `getRunType<Name>()` handle const beside it.
+				return printLazyPair(resolved, opts, names, fileCtx)
+			}
 			return nil, diag
 		}
 		if ctx.usedSelf {
 			// RT.circular ties the knot through Recursive<Body>, whose Self
-			// substitution walks every container with a homomorphic map —
-			// MERGING container-level sentinel intersections (structural format
-			// brands, contains/pattern/propertyNames/unevaluated checks, tuple
-			// label carriers), so the value-first spelling resolves a DIFFERENT
-			// id than the type-first declaration (found by the FE roundtrip
-			// fuzz lane; the underlying Recursive limitation is filed in
-			// docs/todos/). Primitive and Date brands survive the substitution
-			// untouched, so only container payloads refuse.
-			if payload := ctx.circularLossyPayload(resolved.Node); payload != "" {
-				return nil, &Diagnostic{Code: CodeUnsupportedKind, Severity: SeverityError, Decl: declLabel(decl),
-					Message: fmt.Sprintf("%s inside a recursive type is not convertible to builders (RT.circular cannot carry it through the self-substitution)", payload)}
-			}
+			// substitution instantiates a TUPLE's slots eagerly, so a cycle
+			// closing on a tuple slot has no `RT.circular` spelling (the
+			// substitution unrolls; docs/done/convert-circular-types-to-builders.md).
+			// A NAMED type-form declaration recovers through the LAZY PAIR,
+			// which sidesteps the substitution entirely (the type stays real).
+			// Only call sites still refuse on the shape (their copy lives in
+			// printCallSite).
 			if diag := ctx.eagerTupleCycleDiag(resolved.Node, decl, "RT.circular"); diag != nil {
+				if decl.Form == TargetType && decl.Name != "" {
+					return printLazyPair(resolved, opts, names, fileCtx)
+				}
 				return nil, diag
 			}
 			ctx.needs.useRT = true
@@ -321,6 +336,37 @@ func printDecl(resolved *resolvedDecl, opts Options, names *nameTable, fileCtx *
 		return assembleConstDecl(decl, names, exportPrefix, builderExpr, ctx.needs)
 	}
 	return nil, &Diagnostic{Code: CodeUnsupportedKind, Severity: SeverityError, Decl: declLabel(decl), Message: "unknown target"}
+}
+
+// printLazyPair renders the lazy-pair builders spelling for a type-form
+// declaration whose cycle only closes through embedded type text: the
+// declaration reprinted as a canonical type alias (the recursion closes on its
+// own REAL name, exactly as the type target prints it) plus a
+// `const <name>RT = getRunType<Name>();` value handle. recognizeFile pairs the
+// two statements back into one builders-form declaration, so re-running the
+// builders target is a byte no-op and the type target collapses the pair.
+func printLazyPair(resolved *resolvedDecl, opts Options, names *nameTable, fileCtx *fileContext) (*printedDecl, *Diagnostic) {
+	decl := resolved.Decl
+	ctx := &printContext{names: names, opts: opts, decl: decl, resolve: resolved.Resolve,
+		set: fileCtx.set, bindings: fileCtx.bindings, inScope: fileCtx.inScope,
+		currentFile: fileCtx.path, rootID: resolved.Node.ID, selfName: decl.Name}
+	typeExpr, diag := ctx.typeExpr(resolved.Node)
+	if diag != nil {
+		return nil, diag
+	}
+	constName := names.deriveConstName(decl.Name)
+	if constName == "" {
+		return nil, &Diagnostic{Code: CodeNameCollision, Severity: SeverityError, Decl: declLabel(decl),
+			Message: fmt.Sprintf("no free const name derivable from %q", decl.Name)}
+	}
+	exportPrefix := ""
+	if decl.Exported {
+		exportPrefix = "export "
+	}
+	ctx.needs.useGetRunType = true
+	text := fmt.Sprintf("%stype %s = %s;\n%sconst %s = %s<%s>();",
+		exportPrefix, decl.Name, typeExpr, exportPrefix, constName, names.GetRunType, decl.Name)
+	return &printedDecl{text: text, needs: ctx.needs}, nil
 }
 
 // assembleConstDecl renders `const nameRT = <expr>;` plus, when the source
@@ -531,6 +577,7 @@ func (ctx *printContext) escapeTypeText(node *reflection.RunType) (string, *Diag
 		set: ctx.set, bindings: ctx.bindings, inScope: ctx.inScope, currentFile: ctx.currentFile, rootID: ctx.rootID}
 	text, diag := sub.typeExpr(node)
 	ctx.needs.merge(sub.needs)
+	ctx.escapeCycle = ctx.escapeCycle || sub.escapeCycle
 	return text, diag
 }
 
@@ -606,47 +653,6 @@ func (ctx *printContext) tupleMembers(node *reflection.RunType) (*tupleShape, bo
 		return nil, false
 	}
 	return shape, true
-}
-
-// circularLossyPayload walks a circular declaration's reachable graph for the
-// two payloads the RT.circular spelling still cannot carry across
-// `Recursive<Body>`'s Self substitution. Every other container-level sentinel
-// (structural format brands, contains / patternProperties / propertyNames /
-// unevaluated / negation slots, fixed-arity tuple labels) now survives it: the
-// substitution returns a non-recursing node verbatim and rebuilds a recursing
-// one piece by piece (packages/ts-runtypes/src/builders/static.ts). What
-// remains are the shapes whose BASE TypeScript cannot separate from the
-// sentinel intersection, so the payload cannot be re-attached after
-// substituting inside it:
-//
-//   - a `oneOf` whose branch list reaches the cycle while at least one branch
-//     is a primitive / Date / RegExp: the branch tuple rides EVERY arm, and a
-//     primitive arm passes through the substitution untouched, so that copy
-//     keeps an unsubstituted Self;
-//   - a labeled tuple with an OPTIONAL or REST slot that the cycle runs
-//     through: without a single literal arity there is no slot-by-slot rebuild,
-//     and the homomorphic map folds the label carrier into the tuple.
-//
-// Returns a description of the first offending payload, or "" when the body is
-// convertible.
-func (ctx *printContext) circularLossyPayload(root *reflection.RunType) string {
-	visited := map[string]bool{}
-	var walk func(node *reflection.RunType) string
-	walk = func(node *reflection.RunType) string {
-		node = ctx.deref(node)
-		if node == nil || visited[node.ID] {
-			return ""
-		}
-		visited[node.ID] = true
-		found := ""
-		node.EachRefSlot(func(child *reflection.RunType) {
-			if found == "" {
-				found = walk(child)
-			}
-		})
-		return found
-	}
-	return walk(root)
 }
 
 // unionArms visits a node's arms when it is a union, and nothing otherwise.
@@ -751,32 +757,6 @@ func isSymbolKeyedName(name string) bool {
 		return true
 	}
 	return len(name) >= 2 && name[0] == 0xFE && name[1] == '@'
-}
-
-// reachesCycle reports whether this node's subtree takes part in the
-// declaration's cycle. A carrier sitting entirely OFF the cycle holds no Self
-// after substitution, so it converts unharmed and must not be refused.
-func (ctx *printContext) reachesCycle(node *reflection.RunType) bool {
-	seen := map[string]bool{}
-	var reaches func(current *reflection.RunType) bool
-	reaches = func(current *reflection.RunType) bool {
-		current = ctx.deref(current)
-		if current == nil || seen[current.ID] {
-			return false
-		}
-		seen[current.ID] = true
-		if current.IsCircular {
-			return true
-		}
-		found := false
-		current.EachRefSlot(func(child *reflection.RunType) {
-			if !found {
-				found = reaches(child)
-			}
-		})
-		return found
-	}
-	return reaches(node)
 }
 
 // liveSymbolName resolves the source-level name a node's live symbol (enum /

--- a/ts-go-runtypes/internal/convert/print_coverage_test.go
+++ b/ts-go-runtypes/internal/convert/print_coverage_test.go
@@ -97,7 +97,7 @@ var printerDispositionByField = map[string]string{
 	"Description": "inert: reserved (v2) and never populated yet; populating it must come with printer carriage in the same change",
 
 	// Derived passes' output (canonical.go excludes these too).
-	"IsCircular":          "derived: cycle plumbing (reachesCycle reads it); recomputed by the next resolve",
+	"IsCircular":          "derived: cycle plumbing (the printers track cycles via the walk path); recomputed by the next resolve",
 	"NotSupported":        "derived: recomputed by the next resolve",
 	"Family":              "derived: recomputed by the next resolve",
 	"IsSafeName":          "derived: a function of Name, which is printed",

--- a/ts-go-runtypes/internal/convert/recognize.go
+++ b/ts-go-runtypes/internal/convert/recognize.go
@@ -35,6 +35,15 @@ type declaration struct {
 	Stmt      *ast.Node
 	NameNode  *ast.Node
 	AliasStmt *ast.Node
+	// EscapePair marks the LAZY PAIR spelling: a real type declaration plus a
+	// `const xRT = getRunType<Name>()` handle. The type stays real so a
+	// recursive knot closes lazily (escape type text cannot hold `RT.self()`,
+	// and an `InferType<typeof constRT>` chain would collapse it to `any`).
+	// Stmt is the TYPE statement (NameNode its name — resolution goes through
+	// the declared type), AliasStmt the const statement, ConstNameNode the
+	// const's identifier (the symbol the still-used guard checks).
+	EscapePair    bool
+	ConstNameNode *ast.Node
 }
 
 // recognizeFile walks the file's top-level statements and returns the
@@ -80,7 +89,149 @@ func recognizeFile(sourceFile *ast.SourceFile, typeChecker *checker.Checker, mar
 			decl.AliasExported = isExported(aliasStmt)
 		}
 	}
-	return decls
+	return pairEscapeConsts(decls, typeChecker, markerOpts)
+}
+
+// pairEscapeConsts merges `const xRT = getRunType<Name>()` with the same-file
+// type declaration `Name` into ONE builders-form declaration (see EscapePair).
+// The pair IS the builders spelling of that type: a builders run leaves it
+// alone (fixpoint) and a type run collapses it back to the type declaration,
+// through the same alias-drop and const-still-used machinery the
+// `InferType<typeof c>` pairing rides.
+func pairEscapeConsts(decls []*declaration, typeChecker *checker.Checker, markerOpts marker.Options) []*declaration {
+	typeDeclByName := map[string]*declaration{}
+	for _, decl := range decls {
+		if decl.Form == TargetType && decl.Name != "" {
+			typeDeclByName[decl.Name] = decl
+		}
+	}
+	if len(typeDeclByName) == 0 {
+		return decls
+	}
+	consumed := map[*declaration]bool{}
+	for _, decl := range decls {
+		// Only an alias-less builders const can be the handle half.
+		if decl.ConstName == "" || decl.AliasStmt != nil || decl.Form != TargetBuilders {
+			continue
+		}
+		targetName, ok := getRunTypeEscapeTarget(constInitializer(decl.Stmt), typeChecker, markerOpts)
+		if !ok {
+			continue
+		}
+		typeDecl := typeDeclByName[targetName]
+		if typeDecl == nil || typeDecl.Generic || typeDecl.EscapePair {
+			continue
+		}
+		typeDecl.Form = TargetBuilders
+		typeDecl.EscapePair = true
+		typeDecl.ConstName = decl.ConstName
+		typeDecl.ConstNameNode = decl.NameNode
+		typeDecl.AliasStmt = decl.Stmt
+		consumed[decl] = true
+	}
+	if len(consumed) == 0 {
+		return decls
+	}
+	kept := decls[:0]
+	for _, decl := range decls {
+		if !consumed[decl] {
+			kept = append(kept, decl)
+		}
+	}
+	return kept
+}
+
+// constNameNode returns the identifier the CONST symbol resolves through: a
+// lazy pair's NameNode is the TYPE's name, so the const identifier rides
+// ConstNameNode; every other const form keeps NameNode.
+func constNameNode(decl *declaration) *ast.Node {
+	if decl.ConstNameNode != nil {
+		return decl.ConstNameNode
+	}
+	return decl.NameNode
+}
+
+// constInitializer extracts the single declarator's initializer from a
+// recognized const statement.
+func constInitializer(statement *ast.Node) *ast.Node {
+	variableStatement := statement.AsVariableStatement()
+	if variableStatement == nil || variableStatement.DeclarationList == nil {
+		return nil
+	}
+	declarationList := variableStatement.DeclarationList.AsVariableDeclarationList()
+	if declarationList == nil || len(declarationList.Declarations.Nodes) != 1 {
+		return nil
+	}
+	declarator := declarationList.Declarations.Nodes[0].AsVariableDeclaration()
+	if declarator == nil {
+		return nil
+	}
+	return declarator.Initializer
+}
+
+// getRunTypeEscapeTarget reports whether the initializer is exactly the lazy
+// pair's handle call — the package's `getRunType` with ONE bare-identifier
+// type argument and no value arguments — returning the named type. Any other
+// shape (a value-form call, an inline type argument, a local helper) is not
+// the pair spelling.
+func getRunTypeEscapeTarget(initializer *ast.Node, typeChecker *checker.Checker, markerOpts marker.Options) (string, bool) {
+	if initializer == nil || initializer.Kind != ast.KindCallExpression {
+		return "", false
+	}
+	call := initializer.AsCallExpression()
+	if call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+		return "", false
+	}
+	if call.TypeArguments == nil || len(call.TypeArguments.Nodes) != 1 {
+		return "", false
+	}
+	argument := call.TypeArguments.Nodes[0]
+	if argument.Kind != ast.KindTypeReference {
+		return "", false
+	}
+	typeRef := argument.AsTypeReferenceNode()
+	if typeRef == nil || typeRef.TypeArguments != nil || typeRef.TypeName == nil || !ast.IsIdentifier(typeRef.TypeName) {
+		return "", false
+	}
+	if !builders.IsBuilderLeafCall(typeChecker, initializer, markerOpts) {
+		return "", false
+	}
+	callee := call.Expression
+	if callee == nil {
+		return "", false
+	}
+	nameNode := callee
+	if ast.IsPropertyAccessExpression(callee) {
+		nameNode = callee.AsPropertyAccessExpression().Name()
+	}
+	if nameNode == nil || !ast.IsIdentifier(nameNode) || !referencedThroughPackageImport(typeChecker, nameNode) {
+		return "", false
+	}
+	if importedNameOf(typeChecker, nameNode) != "getRunType" {
+		return "", false
+	}
+	return typeRef.TypeName.Text(), true
+}
+
+// importedNameOf resolves the EXPORTED name behind a callee identifier: the
+// member name for a namespace access, the import specifier's property name for
+// a renamed named import, the identifier's own text otherwise.
+func importedNameOf(typeChecker *checker.Checker, nameNode *ast.Node) string {
+	if nameNode.Parent != nil && ast.IsPropertyAccessExpression(nameNode.Parent) &&
+		nameNode.Parent.AsPropertyAccessExpression().Name() == nameNode {
+		return nameNode.Text()
+	}
+	symbol := typeChecker.GetSymbolAtLocation(nameNode)
+	if symbol == nil || symbol.Flags&ast.SymbolFlagsAlias == 0 {
+		return nameNode.Text()
+	}
+	aliasDecl := checker.Checker_getDeclarationOfAliasSymbol(typeChecker, symbol)
+	if aliasDecl != nil && ast.IsImportSpecifier(aliasDecl) {
+		if propertyName := aliasDecl.AsImportSpecifier().PropertyName; propertyName != nil {
+			return propertyName.Text()
+		}
+	}
+	return nameNode.Text()
 }
 
 // typeFormDeclaration wraps a type alias / interface statement.

--- a/ts-go-runtypes/internal/convert/resolve.go
+++ b/ts-go-runtypes/internal/convert/resolve.go
@@ -31,7 +31,9 @@ func resolveDecl(typeChecker *checker.Checker, cache *runtype.Cache, decl *decla
 		return nil, fmt.Errorf("convert: no symbol for %q", declLabel(decl))
 	}
 	var tsType *checker.Type
-	if decl.Form == TargetType {
+	// A lazy pair resolves like a type form: its NameNode is the real type
+	// declaration's name, and the handle const adds nothing to the graph.
+	if decl.Form == TargetType || decl.EscapePair {
 		tsType = checker.Checker_getDeclaredTypeOfSymbol(typeChecker, symbol)
 	} else {
 		runTypeRef := typeChecker.GetTypeOfSymbol(symbol)

--- a/ts-go-runtypes/internal/convert/set.go
+++ b/ts-go-runtypes/internal/convert/set.go
@@ -133,7 +133,7 @@ func (set *Set) constUseIndex() map[*ast.Symbol][]constUse {
 			if decl.ConstName == "" {
 				continue
 			}
-			if symbol := set.checker.GetSymbolAtLocation(decl.NameNode); symbol != nil {
+			if symbol := set.checker.GetSymbolAtLocation(constNameNode(decl)); symbol != nil {
 				candidates[symbol] = true
 				names[decl.ConstName] = true
 			}


### PR DESCRIPTION
Recursive type declarations that need a `getRunType` escape (method members) or close through tuple slots now convert to builders form via the "lazy pair" spelling: the type declaration stays real (so names resolve lazily and the cycle remains legal TypeScript) plus a `const nameRT = getRunType<Name>()` handle const beside it.

## Summary

Previously, these shapes refused conversion with "self-referential type inside an embedded type expression" or "cycle that closes on a tuple slot" diagnostics. The new approach sidesteps the `Recursive<Body>` substitution entirely by keeping the declaration a real deferred type alias, so TypeScript never instantiates tuple slots eagerly and type text can reference the cycle by name without collapsing to `any`.

## Key changes

- **recognize.go**: Added `pairEscapeConsts()` to merge `const xRT = getRunType<Name>()` with same-file type declarations into one builders-form declaration. Detects the exact spelling (bare-identifier type argument, no value args, package-imported `getRunType`) and marks the type with `EscapePair=true`, `ConstName`, and `ConstNameNode`.

- **print.go**: Added `printLazyPair()` fallback when builders print of a type-form declaration hits escape-on-cycle or tuple-slot-cycle refusals. Renders the type declaration plus the handle const. Tracks `escapeCycle` flag through recursive printing to detect when to apply the fallback.

- **resolve.go**: Lazy pairs resolve through the type declaration (not the const), so `resolveDecl()` checks `EscapePair` to use `NameNode` instead of `ConstNameNode`.

- **convert.go**: `constUsedBeyondConversions()` now checks `ConstNameNode` for lazy pairs (the const identifier lives there, not `NameNode`).

- **callsites.go**: Removed unreachable `circularLossyPayload()` check; the lossy-payload class turned out to be dead code (the `oneOf` case no longer exists, optional-slot labeled tuples already convert).

- **Removed dead code**: `circularLossyPayload()` and `reachesCycle()` helpers deleted from print.go; they were only called from the now-removed callsites check.

- **Tests**: Updated `TestCircular_TupleSlotCycleRefusedOnValueForms` → `TestCircular_TupleSlotCycleConvertsLazyPair` and `TestChain_EscapeOnCycleRefuses` → `TestChain_EscapeOnCycleConvertsLazyPair` to verify the pair converts and round-trips correctly. Added `TestPair_HandConstIsTheBuildersForm` and `TestPair_ConstStillUsedRefusesToCollapse` for hand-written pairs. CLI e2e test added for the round-trip.

- **Fuzz**: `EXPECTED_REFUSALS` is now empty (both embedded-self-reference and tuple-slot entries retired). `typeGen.ts` grows mutual interface cycles to exercise the knot. `unsupported-conversion.test.ts` removes the tuple-slot refusal row.

- **Docs**: Updated conversion guide to document the lazy pair; tuple and embedded-recursion rows removed from the refusal table. Feature spec marked done.

## Implementation notes

- The pair IS the builders form: a second `--to builders` run is a byte no-op (C5 fixpoint).
- The type target collapses the pair back to the type declaration through existing alias-drop + const-still-used machinery.
- Call sites and anonymous cycles still refuse (no declaration to keep real).
- Hand-written pairs over non-recursive types are recognized and left alone by builders, collapsed by type target.

https://claude.ai/code/session_015gNCbuinQfL4tVcmtZ8Efa