### PR TITLE
Drizzle type-road runtime callbacks and marker forms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ This is the rule broken most often, so it comes first!! Any issue or blocker you
 ## JS monorepo (`packages/`)
 
 One pnpm workspace holding BOTH families: the `@ts-runtypes/*` packages (the type system) and the `@mionjs/*` framework packages (which consume them via `workspace:*`). 
-All `dependencies` / `devDependencies` are exact-pinned. THREE peerDeps exceptions stay as ranges: `ts-runtypes-devtools` (so consumers can dedupe Vite) and, on the `@mionjs/drizzle-orm-*-core` packages, BOTH their `drizzle-orm` peer (the range IS the compatibility promise of their drizzle-aligned version line) and their `@ts-runtypes/core` peer (type-only, so the consumer's single copy must supply the format types; an exact pin would also force a republish every release).
+All `dependencies` / `devDependencies` are exact-pinned. THREE peerDeps exceptions stay as ranges: `ts-runtypes-devtools` (so consumers can dedupe Vite) and, on the `@mionjs/drizzle-orm-*-core` packages, BOTH their `drizzle-orm` peer (the range IS the compatibility promise of their drizzle-aligned version line) and their `@ts-runtypes/core` peer (the consumer's single copy must supply both the format types and the runtime `getRunType` the tableFromType/toDrizzle marker overloads forward to; an exact pin would also force a republish every release).
 Cross-package deps use the `workspace:*` protocol. All devDependencies live root-level, never per-package, with ONE exception: each drizzle dialect package carries `@ts-runtypes/core: workspace:*` as a devDependency to satisfy its own peer in the workspace (dev deps never reach a consumer). 
 
 - [ts-runtypes](packages/ts-runtypes/) — public marker + runtime helpers (`InjectRunTypeId<T>`, `InjectTypeFnArgs<T,Fn>`, `getRunTypeId`, runtime family bodies).

--- a/container/website/sites/mion/content/03.drizzle-orm/00.drizzle-overview.md
+++ b/container/website/sites/mion/content/03.drizzle-orm/00.drizzle-overview.md
@@ -35,7 +35,7 @@ Because routes and tables share the same model types, a route typed with the inf
 
 ## The same table as a pure type
 
-Every table can also be written as a type instead of builder calls. Each column builder has a column type with the same name and the first letter uppercased, whose type parameters mirror the builder arguments one to one: `Varchar<'name', {length: 100}>` matches `varchar('name', {length: 100})`, and modifiers join with `&` (`NotNull`, `PrimaryKey`, `Default<21>` and friends, matching `.notNull()`, `.primaryKey()`, `.default(21)`). The two forms are interchangeable: same inferred models, same validators, and `tableFromType` gives you back the exact recorded table the builders would have produced. Here is the trio above, written as types:
+Every table can also be written as a type instead of builder calls. Each column builder has a column type with the same name and the first letter uppercased, whose type parameters mirror the builder arguments one to one: `Varchar<'name', {length: 100}>` matches `varchar('name', {length: 100})`, and modifiers join with `&` (`NotNull`, `PrimaryKey`, `Default<21>` and friends, matching `.notNull()`, `.primaryKey()`, `.default(21)`). The two forms are interchangeable: same inferred models, same validators, and the same recorded table behind them, without repeating the type name anywhere. Here is the trio above, written as types:
 
 ::code-group
 <code-import path="packages/examples/src/drizzle/drizzle-types-pg-example.ts" lang="ts [PostgreSQL]" />
@@ -53,11 +53,13 @@ What pgTable returns is a recorded table, not drizzle's own table type. It captu
 
 <code-import path="packages/examples/src/drizzle/drizzle-to-drizzle-example.ts" lang="ts" />
 
-A table written as a pure type gets there the same way: `tableFromType` rebuilds the recorded table from the type, and toDrizzle takes it from there.
+A table written as a pure type gets there in one step: toDrizzle takes the table type directly and builds the same memoized drizzle table, so a query file needs nothing from the schema file except the type itself.
 
 <code-import path="packages/examples/src/drizzle/drizzle-types-to-drizzle-example.ts" lang="ts" />
 
-The same call feeds migrations: a drizzle-kit schema file exports `toDrizzle(usersRT)` (and the materialized enums, for `pgEnum`). Everything on the query side of drizzle (operators, relations, getTableConfig) works on the `toDrizzle` result as usual.
+The same call feeds migrations: a drizzle-kit schema file exports `toDrizzle(users)` on the builders road, or `toDrizzle<UsersTable>()` on the types road (and the materialized enums, for `pgEnum`). Everything on the query side of drizzle (operators, relations, getTableConfig) works on the `toDrizzle` result as usual.
+
+For files that need the recorded table without drizzle (models, refinement, mion routes), `tableFromType<UsersTable>()` from the package root is the same bridge without the drizzle import. Its options object also carries the two runtime inputs a type cannot: the tables a column References (`{tables: {parents: parents}}`) and the runtime callbacks described below.
 
 ## Refine tables for your API
 
@@ -68,6 +70,15 @@ Your API often needs stricter rules than the database column: a name column can 
 The same refinement over a table written as a pure type:
 
 <code-import path="packages/examples/src/drizzle/drizzle-types-refine-example.ts" lang="ts" />
+
+On the types road the same refinement is a type, no table value needed: `RefinedTable` takes the table type and the per-column rules, so a types-only file can export the API view of a table.
+
+```ts
+import type {RefinedTable} from '@mionjs/drizzle-orm';
+import type {UsersTable} from './schema.ts';
+
+type ApiUsersTable = RefinedTable<UsersTable, {name: {minLength: 10}; age: {min: 18}}>;
+```
 
 A refinement that does not fit the column is a compile error, never a silent override: you cannot put a number rule on a string column, invent an unknown parameter, or change whether a column accepts null (that stays with notNull in the table itself). Columns without a format (booleans, JSON, enums) are not refinable.
 
@@ -93,6 +104,14 @@ The same payloads derive straight from a table written as a pure type, with no t
 
 <code-import path="packages/examples/src/drizzle/drizzle-types-model-types.ts" lang="ts" />
 
+## Runtime column callbacks
+
+Drizzle's `$default`, `$defaultFn`, `$onUpdate` and `$onUpdateFn` take a function the application runs on insert or update. On the builders road they chain as usual. On the types road a function cannot live inside a type, so the column carries a marker with the same name (`$DefaultFn` for `.$defaultFn(...)`, and so on) and the callback itself goes into the options object of tableFromType or toDrizzle. The markers keep the model types right everywhere: a column with any of them counts as having a default, so it turns optional on insert even in files that only import the type.
+
+<code-import path="packages/examples/src/drizzle/drizzle-types-runtime-example.ts" lang="ts" />
+
+The `ts-runtypes convert` command moves the callbacks between the two spellings for you, text intact, in both directions.
+
 ## Semantic types by hand
 
 Columns whose values have no matching format (geometry, vectors, MAC addresses, binary data, plain booleans and JSON) keep their plain data type. For JSON columns, `.$type<T>()` stays the escape hatch to declare a semantic type by hand, exactly as in drizzle:
@@ -100,7 +119,7 @@ Columns whose values have no matching format (geometry, vectors, MAC addresses, 
 ```ts
 import * as DB from '@mionjs/drizzle-orm-pg-core';
 
-const eventsRT = DB.pgTable('events', {
+const events = DB.pgTable('events', {
   id: DB.uuid('id').primaryKey(),
   payload: DB.jsonb('payload').$type<{kind: string; at: number}>().notNull(),
 });
@@ -111,7 +130,7 @@ The same override on the types road is the `$Type` marker:
 ```ts
 import * as DB from '@mionjs/drizzle-orm-pg-core';
 
-type EventsRT = DB.PgTable<
+type EventsTable = DB.PgTable<
   'events',
   {
     id: DB.Uuid<'id'> & DB.PrimaryKey;

--- a/docs/done/drizzle-type-defined-tables.md
+++ b/docs/done/drizzle-type-defined-tables.md
@@ -13,7 +13,7 @@ Give mion users a pure-type way to define a TABLE, not just a row, mirroring the
 column builders as closely as the type system allows:
 
 ```ts
-const usersRT = DB.pgTable('users', {
+const users = DB.pgTable('users', {
   id: DB.uuid('id').primaryKey().defaultRandom(),
   name: DB.varchar('name', {length: 100}).notNull(),
   age: DB.integer('age').notNull(),
@@ -121,7 +121,10 @@ Decisions taken with the developer, all implemented:
   foreignKey, composite primaryKey) and literal sql values have type spellings.
 - No runtime import of @ts-runtypes/core outside core: tableFromType(runType, deps?)
   takes a resolved RunType<T> (callers write tableFromType(getRunType<UsersRT>())).
-  Dialect core peers stay type-only.
+  Dialect core peers stay type-only. (Revised in the follow-up ergonomics rework,
+  docs/done/drizzle-type-road-ergonomics.md: the dialect roots now carry marker
+  overloads and a runtime getRunType import; the explicit form stays as the
+  low-level escape hatch.)
 - HORIZONTAL implementation: the full pipeline (types, bridge, fuzz, convert) landed
   first on a thin pg slice, then widened batch by batch with every oracle green.
 
@@ -153,13 +156,13 @@ What landed:
   by the resolved type's sentinel members; vocabulary = the upperFirst rule checked
   against the imported module's exports via a syntactic export walker (named
   re-exports from bare specifiers count); canonical pair value + type name preserved
-  both directions (const usersRT + type UsersRT); extras print as the canonical
+  both directions (later renamed to const users + type UsersTable by the
+  ergonomics rework); extras print as the canonical
   TableEntry spelling type-side and the (t) => [...] callback builder-side; drizzle
   decls are exempt from the generic id/canonical oracles (model ids pinned JS-side).
-  CNV009 refuses what has no twin: runtime-function modifiers ($-methods, $type
-  included; the $Type marker still works in the type road and bridge), interpolated
-  sql, references to consts outside the file, chain decorators on column refs in
-  extras (t.name.desc()).
+  CNV009 refuses what has no twin: interpolated sql, $type, references to consts
+  outside the file, chain decorators on column refs in extras (t.name.desc()).
+  (The other $-methods gained a translation in the ergonomics rework.)
 - gen-drizzle-manifest records per-column modifiers (chainable builder methods
   only, so sqlite's public build(table) materializer drops out structurally) and
   the typeAlias derived per the upperFirst rule against the proxy's type exports;

--- a/docs/done/drizzle-type-defined-tables.md
+++ b/docs/done/drizzle-type-defined-tables.md
@@ -122,9 +122,9 @@ Decisions taken with the developer, all implemented:
 - No runtime import of @ts-runtypes/core outside core: tableFromType(runType, deps?)
   takes a resolved RunType<T> (callers write tableFromType(getRunType<UsersRT>())).
   Dialect core peers stay type-only. (Revised in the follow-up ergonomics rework,
-  docs/done/drizzle-type-road-ergonomics.md: the dialect roots now carry marker
-  overloads and a runtime getRunType import; the explicit form stays as the
-  low-level escape hatch.)
+  docs/done/drizzle-type-road-ergonomics.md: tableFromType is now the marker
+  form `tableFromType<T>(options?)` only, with a runtime getRunType import in
+  the dialect roots; dynamic callers use buildRtTableFromGraph.)
 - HORIZONTAL implementation: the full pipeline (types, bridge, fuzz, convert) landed
   first on a thin pg slice, then widened batch by batch with every oracle green.
 

--- a/docs/done/drizzle-type-road-ergonomics.md
+++ b/docs/done/drizzle-type-road-ergonomics.md
@@ -165,6 +165,9 @@ found during implementation:
   message) whose eagerly-evaluated option would hit a temporal dead zone.
 - Naming in the examples: the slim table const is `users`; a materialized
   drizzle table exported next to it is `usersDb`.
-- The explicit tableFromType(getRunType<T>(), options?) form stays recognized
-  by convert and documented as the low-level escape hatch; converting a
-  builders file always emits the marker form.
+- Post-review amendment: the explicit tableFromType(runType, options?)
+  overload was DROPPED entirely — tableFromType has one signature,
+  `tableFromType<T>(options?)`. Dynamic callers holding a resolved graph use
+  the exported buildRtTableFromGraph instead; convert's pairing still ignores
+  value arguments, and converting a builders file always emits the marker
+  form.

--- a/docs/done/drizzle-type-road-ergonomics.md
+++ b/docs/done/drizzle-type-road-ergonomics.md
@@ -1,7 +1,7 @@
 ---
 type: feature
 spec: guidelines
-status: ready
+status: done
 created: 2026-08-28
 ---
 
@@ -141,3 +141,30 @@ TableRefinements · S4 Go marker-form template + tables deps + naming ·
 S5 Go runtime-fn translation · S6 naming/docs sweep and spec move. Each slice
 lands with its tests (paired marker call shapes per the Marker rule); fuzzing =
 extending the existing convert/convertcli/drizzletypes corpora, no new suite.
+
+## Shipped (2026-08-29)
+
+All six directions landed in one PR on the plan above, with these refinements
+found during implementation:
+
+- The marker naming is $Default/$DefaultFn/$OnUpdate/$OnUpdateFn (the
+  upperFirst-after-$ rule $Type already used), not RuntimeDefault/RuntimeOnUpdate:
+  zero mapping tables in convert, and the $default vs $defaultFn alias survives
+  the byte fixpoint in the type itself.
+- PgTable's extras meta member stays REQUIRED (an optional member reflects as a
+  union and would silently drop indexes/checks/FKs). The factories declare the
+  dialect table types via a lazily-defaulted NormalizedCols fast-path parameter,
+  so a builder table never evaluates the TypedCols conditional.
+- Type budgets came out LOWER, not just unchanged: RefineCols reads the brand in
+  one conditional and the flat RtTableMetaWithExtras replaced the meta
+  intersection; budgets ratcheted down (step1 493->478, step2 1245->1198,
+  consumer 1841->1785).
+- Related bug fixed in scope: the emitted type-form pair for References tables
+  never emitted its deps, so it threw at import time. Convert now emits
+  {tables: {parent: parents}} and refuses backward references (CNV009 reorder
+  message) whose eagerly-evaluated option would hit a temporal dead zone.
+- Naming in the examples: the slim table const is `users`; a materialized
+  drizzle table exported next to it is `usersDb`.
+- The explicit tableFromType(getRunType<T>(), options?) form stays recognized
+  by convert and documented as the low-level escape hatch; converting a
+  builders file always emits the marker form.

--- a/docs/todos/drizzle-code-translator.md
+++ b/docs/todos/drizzle-code-translator.md
@@ -26,7 +26,7 @@ Verified against drizzle-team/drizzle-orm at tag 0.45.2 (integration-tests/tests
   @mionjs/drizzle-orm; operators and everything query-side stay on drizzle-orm.
 - Wrap declarations keeping the original name, so downstream references need no
   edits: `const users = pgTable(...)` becomes
-  `const usersRT = MD.pgTable(...); const users = toDrizzle(usersRT);`
+  `const users = MD.pgTable(...); const usersDb = toDrizzle(users);`
   (same for pgEnum, pgSchema, sequences; local declarations inside test bodies
   too).
 - Out-of-scope authoring surface (views, RLS helpers) is reported, not translated;

--- a/docs/todos/drizzle-schema-helpers-test-coverage.md
+++ b/docs/todos/drizzle-schema-helpers-test-coverage.md
@@ -1,0 +1,66 @@
+---
+type: fix
+spec: guidelines
+status: ready
+created: 2026-08-29
+---
+
+# Test coverage for the schema / creator / sequence authoring helpers
+
+## Intent
+
+Six authoring helpers of the drizzle dialect packages are marked `migrated` in
+the manifests but have ZERO spec coverage: nothing pins that the recorded
+value materializes into the correct drizzle object through toDrizzle.
+
+- pg: `pgSchema` (and its `.table` / `.enum` / `.sequence` members),
+  `pgSequence`, `pgTableCreator`
+- mysql: `mysqlSchema`, `mysqlTableCreator`
+- sqlite: `sqliteTableCreator`
+
+The drizzle-proxy-migration rules say a `migrated` manifest entry lands with
+paired tests; these landed without them (predates the type-road ergonomics
+rework, found while auditing that surface on PR #166).
+
+## Evidence
+
+- `packages/drizzle-orm-*-core/manifests/*.manifest.json` list all six as
+  `status: "migrated"`.
+- `grep -rn "pgSchema\|pgTableCreator\|pgSequence\|mysqlSchema\|mysqlTableCreator\|sqliteTableCreator" packages/*/src/*.spec.ts`
+  returns nothing.
+- Implementations: `packages/drizzle-orm-pg-core/src/table.ts` (pgSchema,
+  pgTableCreator, PgSequence), `packages/drizzle-orm-pg-core/src/helpers.ts`
+  (pgSequence, pgEnum), and the mysql/sqlite twins.
+
+## Direction
+
+Add specs beside the existing per-dialect suites (e.g. in each package's
+`src/index.spec.ts` or a new `src/valueHelpers.spec.ts`) that compare the
+materialized result against building the same thing with raw drizzle:
+
+- pgSchema: a table declared via `schema.table(...)` materializes into a
+  drizzle table whose schema matches `dzPg.pgSchema('...').table(...)`
+  (compare getTableConfig, including the schema); the schema handle itself
+  materializes to drizzle's PgSchema; `schema.enum` and `schema.sequence`
+  round through toDrizzle.
+- pgTableCreator / mysqlTableCreator / sqliteTableCreator: the name-mapper is
+  applied (a table declared as 'users' materializes with the mapped name),
+  equal to raw drizzle's tableCreator result.
+- pgSequence / mysqlSchema: toDrizzle returns the drizzle object with the
+  recorded name and options.
+- Model derivation still works on creator/schema tables (InferSelectModel over
+  a creator table equals the plain-table model).
+- Any test exercising the marker API must follow the Marker test coverage
+  rule (both getRunTypeId call shapes) per ts-go-runtypes/CLAUDE.md; if these
+  specs stay purely value-level, say so in the spec header instead.
+
+## Out of scope
+
+New helper functionality, manifest regeneration, and the type road (these
+helpers are builders-only by design).
+
+## Done when
+
+Each of the six helpers has a spec pinning its materialized drizzle object
+against the raw drizzle equivalent, `pnpm test` is green, and the specs live
+in the dialect packages beside the existing suites.

--- a/docs/todos/drizzle-type-road-ergonomics.md
+++ b/docs/todos/drizzle-type-road-ergonomics.md
@@ -89,3 +89,55 @@ the dialect table factories declare their dialect table types as returns; no
 RT-suffixed table names remain in examples, docs or canonical pairs; type
 budgets are unchanged or lower; all landed in one follow-up PR to #165 with no
 compatibility layers for the old spellings.
+
+## Plan — approved 2026-08-29
+
+Target spelling:
+
+```ts
+export type UsersTable = DB.PgTable<'users', {...}>;
+export const users = DB.toDrizzle<UsersTable>();     // ./drizzle subpath, happy path
+export const users = DB.tableFromType<UsersTable>(); // package root, general bridge
+// escape hatch stays: tableFromType(getRunType<UsersTable>(), options?)
+```
+
+Decisions refined during planning (they adjust the Direction sketches):
+
+1. The runtime-modifier markers are `$Default` / `$DefaultFn` / `$OnUpdate` /
+   `$OnUpdateFn`, not RuntimeDefault/RuntimeOnUpdate: they follow the existing
+   `method ↔ upperFirst(method)` rule `$Type` already uses, so convert needs no
+   mapping tables and the $default vs $defaultFn alias survives the byte
+   fixpoint in the type itself. All four set HasDefault.
+2. The options object is `TableFromTypeOptions<T> = {tables?, runtime?}` (full
+   rename of TableFromTypeDeps). It must stay all-optional (weak type) forever:
+   that is what keeps the `(runType, options?)` / `(options?, id?)` overload
+   pair disjoint. The bridge validates marker↔callback both ways in applyMods
+   and replays via the existing recorder methods; the memo stays
+   first-call-wins (now covering options), documented in the jsdoc.
+3. The dialect package ROOT gains a runtime import of @ts-runtypes/core
+   (getRunType only); @mionjs/drizzle-orm stays runtime-core-free.
+4. `PgTable`'s `extras` meta member stays REQUIRED (making it optional would
+   reflect as a union and silently drop indexes/checks/FKs). The builders
+   declare `PgTable<TName, Cols>` returns via a NormalizeCol pass-through
+   branch for already-branded builder columns; no assignability work needed
+   because the impl signatures declare no return.
+5. Go naming: drizzle-only derivations `UsersTable ⇄ users` (fallback
+   usersTable, then digits) at drizzle.go's two call sites; the generic
+   RT-suffix derivation stays for runtype pairs.
+6. Convert emits the marker-form pair (no getRunType); the recognizer keeps
+   accepting the explicit form and canonicalizes it. CNV009 narrows: the four
+   `$` runtime methods translate (callback text moved verbatim between chain
+   and options literal); `$type` gets a dedicated refusal; interpolated sql,
+   non-literal args and out-of-file references stay refused.
+7. Related bug fixed in-scope: the emitted type-form pair for references
+   tables never emitted `tables` deps, so it threw at import time. Convert now
+   emits `{tables: {...}}` and refuses (CNV009) backward references whose deps
+   object would hit a temporal dead zone.
+
+Slices, in order (Go fixture tests mount the real JS packages, so JS first):
+S1 runtime markers + options bridge (explicit form) · S2 marker overloads for
+tableFromType/toDrizzle · S3 builder return types + RefinedTable constrained to
+TableRefinements · S4 Go marker-form template + tables deps + naming ·
+S5 Go runtime-fn translation · S6 naming/docs sweep and spec move. Each slice
+lands with its tests (paired marker call shapes per the Marker rule); fuzzing =
+extending the existing convert/convertcli/drizzletypes corpora, no new suite.

--- a/packages/drizzle-orm-mysql-core/src/drizzle.ts
+++ b/packages/drizzle-orm-mysql-core/src/drizzle.ts
@@ -24,8 +24,10 @@ import type {
   DrizzleContext,
   TableNameOf,
 } from '@mionjs/drizzle-orm';
+import type {TableFromTypeOptions} from '@mionjs/drizzle-orm';
 import {materializeRtTable, RtValueRecorder, rtTableKey, rtValueKey} from '@mionjs/drizzle-orm';
-import type {MySqlSchema} from './table.ts';
+import type {InjectRunTypeId} from '@ts-runtypes/core';
+import {tableFromType, type MySqlSchema} from './table.ts';
 
 const context: DrizzleContext = {
   ns: dzMy as unknown as DrizzleContext['ns'],
@@ -70,11 +72,24 @@ export type ToDrizzleTable<T extends AnyRtTable> = MySqlTableWithColumns<{
 
 export function toDrizzle<T extends AnyRtTable>(table: T): ToDrizzleTable<T>;
 export function toDrizzle(handle: MySqlSchema): unknown;
-export function toDrizzle(value: object): unknown {
-  const attached = (value as Record<symbol, unknown>)[rtValueKey];
-  if (attached instanceof RtValueRecorder) return attached.toDrizzleValue(context);
-  if ((value as Record<symbol, unknown>)[rtTableKey] === undefined) {
-    throw new Error('@mionjs/drizzle-orm-mysql-core: toDrizzle() takes a slim table or a mysqlSchema handle');
+export function toDrizzle<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
+export function toDrizzle(value?: object, id?: unknown): unknown {
+  if (value !== undefined) {
+    const attached = (value as Record<symbol, unknown>)[rtValueKey];
+    if (attached instanceof RtValueRecorder) return attached.toDrizzleValue(context);
+    if ((value as Record<symbol, unknown>)[rtTableKey] !== undefined) return materializeRtTable(value, context);
+    if (id === undefined && !isTableOptions(value)) {
+      throw new Error(
+        '@mionjs/drizzle-orm-mysql-core: toDrizzle() takes a slim table, a mysqlSchema handle, ' +
+          'or the marker form toDrizzle<UsersTable>(options?)'
+      );
+    }
   }
-  return materializeRtTable(value, context);
+  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyRtTable> | undefined);
+  return materializeRtTable(slim, context);
+}
+
+/** A non-table object arg is only valid as the marker form's options bag. */
+function isTableOptions(value: object): boolean {
+  return Object.keys(value).every((key) => key === 'tables' || key === 'runtime');
 }

--- a/packages/drizzle-orm-mysql-core/src/index.ts
+++ b/packages/drizzle-orm-mysql-core/src/index.ts
@@ -34,6 +34,10 @@ export type {
 // The pure-types road: the modifier markers applicable to mysql columns. The
 // column types (Varchar, Int, ...) live beside their builders in ./columns.ts.
 export type {
+  $Default,
+  $DefaultFn,
+  $OnUpdate,
+  $OnUpdateFn,
   $Type,
   Autoincrement,
   Default,

--- a/packages/drizzle-orm-mysql-core/src/table.ts
+++ b/packages/drizzle-orm-mysql-core/src/table.ts
@@ -21,7 +21,7 @@ import type {
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
 import {buildRtTableFromGraph, createRtTable, RtValueRecorder, rtTableKey, rtValueKey} from '@mionjs/drizzle-orm';
-import type {InjectRunTypeId, RunType} from '@ts-runtypes/core';
+import type {InjectRunTypeId} from '@ts-runtypes/core';
 import {getRunType} from '@ts-runtypes/core';
 import {mysqlColumnHelpers, type MySqlColumnHelpers} from './columns.ts';
 import type {MyEntryBrand} from './helpers.ts';
@@ -81,25 +81,17 @@ const fromTypeTables = new Map<string, object>();
 
 /** Runtime twin of a TYPE-defined table: rebuild the slim table from the
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
- *  and refineTableType treat it exactly like a mysqlTable() result. The marker
- *  form `tableFromType<UsersTable>(options?)` resolves the graph itself
- *  (ts-runtypes-devtools must be active); the explicit form
- *  `tableFromType(getRunType<UsersTable>(), options?)` stays as the low-level
- *  escape hatch. A table whose columns use References needs the referenced
- *  tables in options.tables; runtime-callback markers take theirs from
- *  options.runtime. One slim table exists per type id: the FIRST call's
- *  options win (a later call with different tables or callbacks returns the
- *  first table, options unvalidated). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T;
-export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T;
-export function tableFromType<T extends AnyRtTable>(
-  first?: RunType<T> | TableFromTypeOptions<T>,
-  second?: TableFromTypeOptions<T> | InjectRunTypeId<T>
-): T {
-  // only a RunType carries a string id member; options are a plain weak bag
-  const isRunType = typeof (first as {id?: unknown} | undefined)?.id === 'string';
-  const runType = isRunType ? (first as RunType<T>) : getRunType<T>(undefined, second as InjectRunTypeId<T> | undefined);
-  const options = isRunType ? (second as TableFromTypeOptions<T> | undefined) : (first as TableFromTypeOptions<T> | undefined);
+ *  and refineTableType treat it exactly like a mysqlTable() result. The type
+ *  argument is resolved by the build (ts-runtypes-devtools must be active);
+ *  dynamic callers holding a resolved RunType graph use the lower-level
+ *  buildRtTableFromGraph from @mionjs/drizzle-orm instead. A table whose
+ *  columns use References needs the referenced tables in options.tables;
+ *  runtime-callback markers take theirs from options.runtime. One slim table
+ *  exists per type id: the FIRST call's options win (a later call with
+ *  different tables or callbacks returns the first table, options
+ *  unvalidated). */
+export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
+  const runType = getRunType<T>(undefined, id);
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
     slimTable = buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable, options);

--- a/packages/drizzle-orm-mysql-core/src/table.ts
+++ b/packages/drizzle-orm-mysql-core/src/table.ts
@@ -22,7 +22,8 @@ import type {
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
 import {buildRtTableFromGraph, createRtTable, RtValueRecorder, rtTableKey, rtValueKey} from '@mionjs/drizzle-orm';
-import type {RunType} from '@ts-runtypes/core';
+import type {InjectRunTypeId, RunType} from '@ts-runtypes/core';
+import {getRunType} from '@ts-runtypes/core';
 import {mysqlColumnHelpers, type MySqlColumnHelpers} from './columns.ts';
 import type {MyEntryBrand} from './helpers.ts';
 
@@ -77,14 +78,25 @@ const fromTypeTables = new Map<string, object>();
 
 /** Runtime twin of a TYPE-defined table: rebuild the slim table from the
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
- *  and refineTableType treat it exactly like a mysqlTable() result. Resolve
- *  the graph at the call site: `tableFromType(getRunType<UsersTable>())`. A
- *  table whose columns use References needs the referenced tables in
- *  options.tables; runtime-callback markers take theirs from options.runtime.
- *  One slim table exists per type id: the FIRST call's options win (a later
- *  call with different tables or callbacks returns the first table, options
- *  unvalidated). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T {
+ *  and refineTableType treat it exactly like a mysqlTable() result. The marker
+ *  form `tableFromType<UsersTable>(options?)` resolves the graph itself
+ *  (ts-runtypes-devtools must be active); the explicit form
+ *  `tableFromType(getRunType<UsersTable>(), options?)` stays as the low-level
+ *  escape hatch. A table whose columns use References needs the referenced
+ *  tables in options.tables; runtime-callback markers take theirs from
+ *  options.runtime. One slim table exists per type id: the FIRST call's
+ *  options win (a later call with different tables or callbacks returns the
+ *  first table, options unvalidated). */
+export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T;
+export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T;
+export function tableFromType<T extends AnyRtTable>(
+  first?: RunType<T> | TableFromTypeOptions<T>,
+  second?: TableFromTypeOptions<T> | InjectRunTypeId<T>
+): T {
+  // only a RunType carries a string id member; options are a plain weak bag
+  const isRunType = typeof (first as {id?: unknown} | undefined)?.id === 'string';
+  const runType = isRunType ? (first as RunType<T>) : getRunType<T>(undefined, second as InjectRunTypeId<T> | undefined);
+  const options = isRunType ? (second as TableFromTypeOptions<T> | undefined) : (first as TableFromTypeOptions<T> | undefined);
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
     slimTable = buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable, options);

--- a/packages/drizzle-orm-mysql-core/src/table.ts
+++ b/packages/drizzle-orm-mysql-core/src/table.ts
@@ -10,13 +10,12 @@
 // injected context at materialization (toDrizzle, in ./drizzle.ts).
 
 import type {
-  AnyRtColType,
   AnyRtColumn,
   AnyRtTable,
   DrizzleContext,
   ReflectedNode,
   RtExtraColumn,
-  RtTable,
+  RtTableMetaWithExtras,
   TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
@@ -35,9 +34,13 @@ import type {MyEntryBrand} from './helpers.ts';
  *  models and refinement work unchanged; materialize with tableFromType. */
 export type MysqlTable<
   TName extends string,
-  Cols extends Record<string, AnyRtColType>,
+  Cols extends object,
   Extras extends readonly object[] = [],
-> = RtTable<TName, TypedCols<Cols>> & {readonly [rtTableKey]: {extras: Extras}};
+  // Internal fast path: the factories pass their already-branded Cols here so
+  // a builder table never evaluates the TypedCols conditional (type-budget
+  // sensitive); authored type-road tables omit it and get normalized.
+  NormalizedCols extends object = TypedCols<Cols>,
+> = NormalizedCols & {readonly [rtTableKey]: RtTableMetaWithExtras<TName, NormalizedCols, Extras>};
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -127,18 +130,19 @@ export function mysqlBuildTable(
     : context.ns.mysqlTable(name as never, builders as never);
 }
 
-/** Records the table; returns a slim RtTable, NOT drizzle's MySqlTable. The real
- *  drizzle table is built on demand by toDrizzle() from the ./drizzle subpath. */
+/** Records the table; returns the slim table typed as MysqlTable (one public
+ *  name for both roads), NOT drizzle's own table. The real drizzle table is
+ *  built on demand by toDrizzle() from the ./drizzle subpath. */
 export function mysqlTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: Cols,
   extraConfig?: MyExtraConfigFn<Cols>
-): RtTable<TName, Cols>;
+): MysqlTable<TName, Cols, [], Cols>;
 export function mysqlTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: MySqlColumnHelpers) => Cols,
   extraConfig?: MyExtraConfigFn<Cols>
-): RtTable<TName, Cols>;
+): MysqlTable<TName, Cols, [], Cols>;
 export function mysqlTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, mysqlBuildTable);
 }
@@ -150,12 +154,12 @@ export function mysqlTableCreator(customizeTableName: (name: string) => string) 
     name: TName,
     columns: Cols,
     extraConfig?: MyExtraConfigFn<Cols>
-  ): RtTable<TName, Cols>;
+  ): MysqlTable<TName, Cols, [], Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: MySqlColumnHelpers) => Cols,
     extraConfig?: MyExtraConfigFn<Cols>
-  ): RtTable<TName, Cols>;
+  ): MysqlTable<TName, Cols, [], Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-mysql-core/src/table.ts
+++ b/packages/drizzle-orm-mysql-core/src/table.ts
@@ -17,7 +17,7 @@ import type {
   ReflectedNode,
   RtExtraColumn,
   RtTable,
-  TableFromTypeDeps,
+  TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
@@ -79,12 +79,15 @@ const fromTypeTables = new Map<string, object>();
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
  *  and refineTableType treat it exactly like a mysqlTable() result. Resolve
  *  the graph at the call site: `tableFromType(getRunType<UsersTable>())`. A
- *  table whose columns use References needs the referenced tables in deps; one
- *  slim table exists per type id (the first call's deps win). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, deps?: TableFromTypeDeps): T {
+ *  table whose columns use References needs the referenced tables in
+ *  options.tables; runtime-callback markers take theirs from options.runtime.
+ *  One slim table exists per type id: the FIRST call's options win (a later
+ *  call with different tables or callbacks returns the first table, options
+ *  unvalidated). */
+export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T {
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
-    slimTable = buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable, deps);
+    slimTable = buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable, options);
     fromTypeTables.set(runType.id, slimTable);
   }
   return slimTable as T;

--- a/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
@@ -90,6 +90,12 @@ describe('mysql type-defined tables — same drizzle table', () => {
     expect(first).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
     expect(toDrizzle(first)).toBe(toDrizzle(first));
   });
+
+  it('marker forms: tableFromType<T>() and toDrizzle<T>() share the explicit road objects', () => {
+    expect(tableFromType<TwinType>()).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+    expect(toDrizzle<TwinType>()).toBe(toDrizzle(tableFromType<TwinType>()));
+    expect(project(toDrizzle<TwinType>())).toEqual(project(toDrizzle(twinBuilders)));
+  });
 });
 
 describe('mysql type-defined tables — same model runtype id', () => {

--- a/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
@@ -18,6 +18,8 @@ import {getTableConfig} from 'drizzle-orm/mysql-core';
 import {createValidateFn, getRunType, getRunTypeId} from '@ts-runtypes/core';
 import type {InferInsertModel, InferSelectModel} from '@mionjs/drizzle-orm';
 import type {
+  $DefaultFn,
+  $OnUpdate,
   Autoincrement,
   Default,
   DefaultNow,
@@ -122,5 +124,46 @@ describe('mysql type-defined tables — same model runtype id', () => {
     const row = {id: 1, seq: null, name: 'n', age: 30, plan: 'free', createdAt: new Date(), touchedAt: null};
     expect(validate(row)).toBe(true);
     expect(validate({...row, plan: 'enterprise'})).toBe(false); // not in the enum tuple
+  });
+});
+
+// Runtime-callback modifiers: $ markers in the type, callbacks via
+// options.runtime; same table AND same callback behavior on both roads.
+const runtimeBuilders = mysqlTable('runtime_t', {
+  id: int('id').primaryKey(),
+  slug: varchar('slug', {length: 80})
+    .notNull()
+    .$defaultFn(() => 'slug-1'),
+  counter: int('counter').$onUpdate(() => 7),
+});
+type RuntimeType = MysqlTable<
+  'runtime_t',
+  {
+    id: Int<'id'> & PrimaryKey;
+    slug: Varchar<'slug', {length: 80}> & NotNull & $DefaultFn;
+    counter: Int<'counter'> & $OnUpdate;
+  }
+>;
+
+describe('mysql type-defined tables — runtime-callback modifiers', () => {
+  it('materializes the same table as the builder road, callbacks included', () => {
+    const fromType = tableFromType<RuntimeType>(getRunType<RuntimeType>(), {
+      runtime: {slug: {$defaultFn: () => 'slug-1'}, counter: {$onUpdate: () => 7}},
+    });
+    const bridge = toDrizzle(fromType);
+    expect(project(bridge)).toEqual(project(toDrizzle(runtimeBuilders)));
+    const hooks = (table: unknown) =>
+      getTableConfig(table as never).columns.map((column) => {
+        const c = column as unknown as {defaultFn?: () => unknown; onUpdateFn?: () => unknown};
+        return [column.name, c.defaultFn?.(), c.onUpdateFn?.()];
+      });
+    expect(hooks(bridge)).toEqual(hooks(toDrizzle(runtimeBuilders)));
+    expect(hooks(bridge)).toContainEqual(['slug', 'slug-1', undefined]);
+  });
+  it('runtime models share one id across roads (static + reflection forms)', () => {
+    type TypeInsertRuntime = InferInsertModel<RuntimeType>;
+    const minimal: TypeInsertRuntime = {id: 1}; // slug is notNull but $DefaultFn makes it optional
+    expect(getRunTypeId<TypeInsertRuntime>()).toBe(getRunTypeId<InferInsertModel<typeof runtimeBuilders>>());
+    expect(getRunTypeId(minimal)).toBe(getRunTypeId<TypeInsertRuntime>());
   });
 });

--- a/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
@@ -15,7 +15,7 @@
 
 import {describe, it, expect} from 'vitest';
 import {getTableConfig} from 'drizzle-orm/mysql-core';
-import {createValidateFn, getRunType, getRunTypeId} from '@ts-runtypes/core';
+import {createValidateFn, getRunTypeId} from '@ts-runtypes/core';
 import type {InferInsertModel, InferSelectModel} from '@mionjs/drizzle-orm';
 import type {
   $DefaultFn,
@@ -82,17 +82,16 @@ function project(table: unknown) {
 
 describe('mysql type-defined tables — same drizzle table', () => {
   it('toDrizzle(tableFromType(...)) materializes the same table as the builder road', () => {
-    expect(project(toDrizzle(tableFromType<TwinType>(getRunType<TwinType>())))).toEqual(project(toDrizzle(twinBuilders)));
+    expect(project(toDrizzle(tableFromType<TwinType>()))).toEqual(project(toDrizzle(twinBuilders)));
   });
 
   it('tableFromType returns the same slim table per type id (one materialization)', () => {
-    const first = tableFromType<TwinType>(getRunType<TwinType>());
-    expect(first).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+    const first = tableFromType<TwinType>();
+    expect(first).toBe(tableFromType<TwinType>());
     expect(toDrizzle(first)).toBe(toDrizzle(first));
   });
 
-  it('marker forms: tableFromType<T>() and toDrizzle<T>() share the explicit road objects', () => {
-    expect(tableFromType<TwinType>()).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+  it('toDrizzle<T>() is the happy path: same drizzle table object as the two-step road', () => {
     expect(toDrizzle<TwinType>()).toBe(toDrizzle(tableFromType<TwinType>()));
     expect(project(toDrizzle<TwinType>())).toEqual(project(toDrizzle(twinBuilders)));
   });
@@ -153,7 +152,7 @@ type RuntimeType = MysqlTable<
 
 describe('mysql type-defined tables — runtime-callback modifiers', () => {
   it('materializes the same table as the builder road, callbacks included', () => {
-    const fromType = tableFromType<RuntimeType>(getRunType<RuntimeType>(), {
+    const fromType = tableFromType<RuntimeType>({
       runtime: {slug: {$defaultFn: () => 'slug-1'}, counter: {$onUpdate: () => 7}},
     });
     const bridge = toDrizzle(fromType);

--- a/packages/drizzle-orm-pg-core/src/drizzle.ts
+++ b/packages/drizzle-orm-pg-core/src/drizzle.ts
@@ -29,9 +29,11 @@ import type {
   DrizzleContext,
   TableNameOf,
 } from '@mionjs/drizzle-orm';
+import type {TableFromTypeOptions} from '@mionjs/drizzle-orm';
 import {materializeRtTable, RtValueRecorder, rtTableKey, rtValueKey} from '@mionjs/drizzle-orm';
+import type {InjectRunTypeId} from '@ts-runtypes/core';
 import type {PgEnum} from './helpers.ts';
-import type {PgSchema, PgSequence} from './table.ts';
+import {tableFromType, type PgSchema, type PgSequence} from './table.ts';
 
 const context: DrizzleContext = {
   ns: dzPg as unknown as DrizzleContext['ns'],
@@ -80,16 +82,32 @@ export type ToDrizzleTable<T extends AnyRtTable> = PgTableWithColumns<{
 /** Materialize a slim table into the real drizzle table (memoized: every call
  *  returns the same object), or a recorded pgEnum / pgSchema / pgSequence
  *  handle into its drizzle counterpart (export those from a drizzle-kit schema
- *  file alongside the tables). */
+ *  file alongside the tables). The marker form `toDrizzle<UsersTable>(options?)`
+ *  is the type road's happy path: it resolves the table type itself
+ *  (ts-runtypes-devtools must be active) and shares tableFromType's per-type
+ *  slim table. */
 export function toDrizzle<T extends AnyRtTable>(table: T): ToDrizzleTable<T>;
 export function toDrizzle<T extends readonly [string, ...string[]]>(handle: PgEnum<T>): dzPg.PgEnum<[T[0], ...string[]]>;
 export function toDrizzle(handle: PgSchema): dzPg.PgSchema;
 export function toDrizzle(handle: PgSequence): dzPg.PgSequence;
-export function toDrizzle(value: object): unknown {
-  const attached = (value as Record<symbol, unknown>)[rtValueKey];
-  if (attached instanceof RtValueRecorder) return attached.toDrizzleValue(context);
-  if ((value as Record<symbol, unknown>)[rtTableKey] === undefined) {
-    throw new Error('@mionjs/drizzle-orm-pg-core: toDrizzle() takes a slim table or a pgEnum/pgSchema/pgSequence handle');
+export function toDrizzle<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
+export function toDrizzle(value?: object, id?: unknown): unknown {
+  if (value !== undefined) {
+    const attached = (value as Record<symbol, unknown>)[rtValueKey];
+    if (attached instanceof RtValueRecorder) return attached.toDrizzleValue(context);
+    if ((value as Record<symbol, unknown>)[rtTableKey] !== undefined) return materializeRtTable(value, context);
+    if (id === undefined && !isTableOptions(value)) {
+      throw new Error(
+        '@mionjs/drizzle-orm-pg-core: toDrizzle() takes a slim table, a pgEnum/pgSchema/pgSequence handle, ' +
+          'or the marker form toDrizzle<UsersTable>(options?)'
+      );
+    }
   }
-  return materializeRtTable(value, context);
+  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyRtTable> | undefined);
+  return materializeRtTable(slim, context);
+}
+
+/** A non-table object arg is only valid as the marker form's options bag. */
+function isTableOptions(value: object): boolean {
+  return Object.keys(value).every((key) => key === 'tables' || key === 'runtime');
 }

--- a/packages/drizzle-orm-pg-core/src/drizzleConvert.integration.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/drizzleConvert.integration.spec.ts
@@ -81,6 +81,24 @@ register('drizzle convert CLI round trip', () => {
     fs.rmSync(projectDir, {recursive: true, force: true});
   });
 
+  it('runtime-callback modifiers ride options.runtime through the round trip', () => {
+    const runtimeSource =
+      "import * as DB from '@mionjs/drizzle-orm-pg-core';\n" +
+      "export const jobs = DB.pgTable('jobs', {\n" +
+      "  id: DB.uuid('id').primaryKey(),\n" +
+      "  slug: DB.varchar('slug', {length: 80}).notNull().$defaultFn(() => 'slug-1'),\n" +
+      '});\n' +
+      'export type JobsTable = typeof jobs;\n';
+    const typeForm = convertTo(runtimeSource, 'type');
+    expect(typeForm).toContain("  slug: DB.Varchar<'slug', {length: 80}> & DB.NotNull & DB.$DefaultFn;");
+    expect(typeForm).toContain(
+      "export const jobs = DB.tableFromType<JobsTable>({runtime: {slug: {$defaultFn: () => 'slug-1'}}});"
+    );
+    const buildersForm = convertTo(typeForm, 'builders');
+    expect(buildersForm).toContain(".notNull().$defaultFn(() => 'slug-1'),");
+    expect(convertTo(buildersForm, 'type')).toBe(typeForm);
+  });
+
   it('builders → type emits the canonical pair, and back, landing on a byte fixpoint', () => {
     const typeForm = convertTo(BUILDERS_SOURCE, 'type');
     expect(typeForm).toContain("export type UsersTable = DB.PgTable<'users', {");

--- a/packages/drizzle-orm-pg-core/src/drizzleConvert.integration.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/drizzleConvert.integration.spec.ts
@@ -33,12 +33,12 @@ const TSCONFIG = `{
 
 const BUILDERS_SOURCE =
   "import * as DB from '@mionjs/drizzle-orm-pg-core';\n" +
-  "export const usersRT = DB.pgTable('users', {\n" +
+  "export const users = DB.pgTable('users', {\n" +
   "  id: DB.uuid('id').primaryKey().defaultRandom(),\n" +
   "  name: DB.varchar('name', {length: 100}).notNull(),\n" +
   "  age: DB.integer('age').notNull().default(21),\n" +
   '});\n' +
-  'export type UsersRT = typeof usersRT;\n';
+  'export type UsersTable = typeof users;\n';
 
 let projectDir = '';
 let mainPath = '';
@@ -83,12 +83,14 @@ register('drizzle convert CLI round trip', () => {
 
   it('builders → type emits the canonical pair, and back, landing on a byte fixpoint', () => {
     const typeForm = convertTo(BUILDERS_SOURCE, 'type');
-    expect(typeForm).toContain("export type UsersRT = DB.PgTable<'users', {");
+    expect(typeForm).toContain("export type UsersTable = DB.PgTable<'users', {");
     expect(typeForm).toContain("  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;");
-    expect(typeForm).toContain('export const usersRT = DB.tableFromType<UsersRT>(getRunType<UsersRT>());');
+    // The marker form: no repeated type name, no getRunType call.
+    expect(typeForm).toContain('export const users = DB.tableFromType<UsersTable>();');
+    expect(typeForm).not.toContain('getRunType');
     const buildersForm = convertTo(typeForm, 'builders');
-    expect(buildersForm).toContain("export const usersRT = DB.pgTable('users', {");
-    expect(buildersForm).toContain('export type UsersRT = typeof usersRT;');
+    expect(buildersForm).toContain("export const users = DB.pgTable('users', {");
+    expect(buildersForm).toContain('export type UsersTable = typeof users;');
     const typeAgain = convertTo(buildersForm, 'type');
     expect(typeAgain).toBe(typeForm);
     expect(convertTo(typeForm, 'type')).toBe(typeForm);

--- a/packages/drizzle-orm-pg-core/src/drizzleTypeSource.integration.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/drizzleTypeSource.integration.spec.ts
@@ -37,7 +37,8 @@ import {
   type Surface,
   type TableSpec,
 } from '../test/tableSpecShared.ts';
-import {tableFromType} from './table.ts';
+import {buildRtTableFromGraph} from '@mionjs/drizzle-orm';
+import {pgBuildTable} from './table.ts';
 import {integer, pgTable} from './index.ts';
 import {toDrizzle} from './drizzle.ts';
 
@@ -111,7 +112,12 @@ describe('pg type-road fuzz: authored type source through the real resolver', ()
           for (let i = 0; i < fixture.specs.length; i++) {
             const node = registered[reflectionSites[i].id];
             expect(node, `graph for table ${i}\n${detail}`).toBeTruthy();
-            const bridge = toDrizzle(tableFromType(node as never, {tables: {[FUZZ_PARENT_NAME]: slimParent as object}}));
+            // The graph was loaded dynamically, so this uses the low-level
+            // bridge (tableFromType's marker form needs a static type argument).
+            const slim = buildRtTableFromGraph(node as never, pgBuildTable, {
+              tables: {[FUZZ_PARENT_NAME]: slimParent as object},
+            });
+            const bridge = toDrizzle(slim as never);
             const raw = buildTable(rawSurface, fixture.specs[i], fixture.names[i]);
             expect(project(bridge), `table ${i}\n${detail}`).toEqual(project(raw));
           }

--- a/packages/drizzle-orm-pg-core/src/index.ts
+++ b/packages/drizzle-orm-pg-core/src/index.ts
@@ -45,6 +45,10 @@ export type {
 // rule (upperFirst) lands on the global-shadowing convention the runtype
 // formats already use for String/Number/Date.
 export type {
+  $Default,
+  $DefaultFn,
+  $OnUpdate,
+  $OnUpdateFn,
   $Type,
   ColArray as Array,
   Default,

--- a/packages/drizzle-orm-pg-core/src/table.ts
+++ b/packages/drizzle-orm-pg-core/src/table.ts
@@ -12,13 +12,12 @@
 // materialization (toDrizzle, in ./drizzle.ts).
 
 import type {
-  AnyRtColType,
   AnyRtColumn,
   AnyRtTable,
   DrizzleContext,
   ReflectedNode,
   RtExtraColumn,
-  RtTable,
+  RtTableMetaWithExtras,
   TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
@@ -44,9 +43,13 @@ import type {PgEntryBrand} from './helpers.ts';
  *  models and refinement work unchanged; materialize with tableFromType. */
 export type PgTable<
   TName extends string,
-  Cols extends Record<string, AnyRtColType>,
+  Cols extends object,
   Extras extends readonly object[] = [],
-> = RtTable<TName, TypedCols<Cols>> & {readonly [rtTableKey]: {extras: Extras}};
+  // Internal fast path: the factories pass their already-branded Cols here so
+  // a builder table never evaluates the TypedCols conditional (type-budget
+  // sensitive); authored type-road tables omit it and get normalized.
+  NormalizedCols extends object = TypedCols<Cols>,
+> = NormalizedCols & {readonly [rtTableKey]: RtTableMetaWithExtras<TName, NormalizedCols, Extras>};
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -138,18 +141,19 @@ export function pgBuildTable(
     : context.ns.pgTable(name as never, builders as never);
 }
 
-/** Records the table; returns a slim RtTable, NOT drizzle's PgTable. The real
- *  drizzle table is built on demand by toDrizzle() from the ./drizzle subpath. */
+/** Records the table; returns the slim table typed as PgTable (one public
+ *  name for both roads), NOT drizzle's own table. The real drizzle table is
+ *  built on demand by toDrizzle() from the ./drizzle subpath. */
 export function pgTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: Cols,
   extraConfig?: PgExtraConfigFn<Cols>
-): RtTable<TName, Cols>;
+): PgTable<TName, Cols, [], Cols>;
 export function pgTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: PgColumnHelpers) => Cols,
   extraConfig?: PgExtraConfigFn<Cols>
-): RtTable<TName, Cols>;
+): PgTable<TName, Cols, [], Cols>;
 export function pgTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, pgBuildTable);
 }
@@ -161,12 +165,12 @@ export function pgTableCreator(customizeTableName: (name: string) => string) {
     name: TName,
     columns: Cols,
     extraConfig?: PgExtraConfigFn<Cols>
-  ): RtTable<TName, Cols>;
+  ): PgTable<TName, Cols, [], Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: PgColumnHelpers) => Cols,
     extraConfig?: PgExtraConfigFn<Cols>
-  ): RtTable<TName, Cols>;
+  ): PgTable<TName, Cols, [], Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-pg-core/src/table.ts
+++ b/packages/drizzle-orm-pg-core/src/table.ts
@@ -30,7 +30,7 @@ import {
   rtTableKey,
   rtValueKey,
 } from '@mionjs/drizzle-orm';
-import type {InjectRunTypeId, RunType} from '@ts-runtypes/core';
+import type {InjectRunTypeId} from '@ts-runtypes/core';
 import {getRunType} from '@ts-runtypes/core';
 import {pgColumnHelpers, type PgColumnHelpers} from './columns.ts';
 import type {PgEntryBrand} from './helpers.ts';
@@ -90,25 +90,17 @@ const fromTypeTables = new Map<string, object>();
 
 /** Runtime twin of a TYPE-defined table: rebuild the slim table from the
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
- *  and refineTableType treat it exactly like a pgTable() result. The marker
- *  form `tableFromType<UsersTable>(options?)` resolves the graph itself
- *  (ts-runtypes-devtools must be active); the explicit form
- *  `tableFromType(getRunType<UsersTable>(), options?)` stays as the low-level
- *  escape hatch. A table whose columns use References needs the referenced
- *  tables in options.tables; runtime-callback markers take theirs from
- *  options.runtime. One slim table exists per type id: the FIRST call's
- *  options win (a later call with different tables or callbacks returns the
- *  first table, options unvalidated). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T;
-export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T;
-export function tableFromType<T extends AnyRtTable>(
-  first?: RunType<T> | TableFromTypeOptions<T>,
-  second?: TableFromTypeOptions<T> | InjectRunTypeId<T>
-): T {
-  // only a RunType carries a string id member; options are a plain weak bag
-  const isRunType = typeof (first as {id?: unknown} | undefined)?.id === 'string';
-  const runType = isRunType ? (first as RunType<T>) : getRunType<T>(undefined, second as InjectRunTypeId<T> | undefined);
-  const options = isRunType ? (second as TableFromTypeOptions<T> | undefined) : (first as TableFromTypeOptions<T> | undefined);
+ *  and refineTableType treat it exactly like a pgTable() result. The type
+ *  argument is resolved by the build (ts-runtypes-devtools must be active);
+ *  dynamic callers holding a resolved RunType graph use the lower-level
+ *  buildRtTableFromGraph from @mionjs/drizzle-orm instead. A table whose
+ *  columns use References needs the referenced tables in options.tables;
+ *  runtime-callback markers take theirs from options.runtime. One slim table
+ *  exists per type id: the FIRST call's options win (a later call with
+ *  different tables or callbacks returns the first table, options
+ *  unvalidated). */
+export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
+  const runType = getRunType<T>(undefined, id);
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
     slimTable = buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable, options);

--- a/packages/drizzle-orm-pg-core/src/table.ts
+++ b/packages/drizzle-orm-pg-core/src/table.ts
@@ -19,7 +19,7 @@ import type {
   ReflectedNode,
   RtExtraColumn,
   RtTable,
-  TableFromTypeDeps,
+  TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
@@ -88,12 +88,15 @@ const fromTypeTables = new Map<string, object>();
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
  *  and refineTableType treat it exactly like a pgTable() result. Resolve the
  *  graph at the call site: `tableFromType(getRunType<UsersTable>())`. A table
- *  whose columns use References needs the referenced tables in deps; one slim
- *  table exists per type id (the first call's deps win). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, deps?: TableFromTypeDeps): T {
+ *  whose columns use References needs the referenced tables in
+ *  options.tables; runtime-callback markers take theirs from options.runtime.
+ *  One slim table exists per type id: the FIRST call's options win (a later
+ *  call with different tables or callbacks returns the first table, options
+ *  unvalidated). */
+export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T {
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
-    slimTable = buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable, deps);
+    slimTable = buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable, options);
     fromTypeTables.set(runType.id, slimTable);
   }
   return slimTable as T;

--- a/packages/drizzle-orm-pg-core/src/table.ts
+++ b/packages/drizzle-orm-pg-core/src/table.ts
@@ -31,7 +31,8 @@ import {
   rtTableKey,
   rtValueKey,
 } from '@mionjs/drizzle-orm';
-import type {RunType} from '@ts-runtypes/core';
+import type {InjectRunTypeId, RunType} from '@ts-runtypes/core';
+import {getRunType} from '@ts-runtypes/core';
 import {pgColumnHelpers, type PgColumnHelpers} from './columns.ts';
 import type {PgEntryBrand} from './helpers.ts';
 
@@ -86,14 +87,25 @@ const fromTypeTables = new Map<string, object>();
 
 /** Runtime twin of a TYPE-defined table: rebuild the slim table from the
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
- *  and refineTableType treat it exactly like a pgTable() result. Resolve the
- *  graph at the call site: `tableFromType(getRunType<UsersTable>())`. A table
- *  whose columns use References needs the referenced tables in
- *  options.tables; runtime-callback markers take theirs from options.runtime.
- *  One slim table exists per type id: the FIRST call's options win (a later
- *  call with different tables or callbacks returns the first table, options
- *  unvalidated). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T {
+ *  and refineTableType treat it exactly like a pgTable() result. The marker
+ *  form `tableFromType<UsersTable>(options?)` resolves the graph itself
+ *  (ts-runtypes-devtools must be active); the explicit form
+ *  `tableFromType(getRunType<UsersTable>(), options?)` stays as the low-level
+ *  escape hatch. A table whose columns use References needs the referenced
+ *  tables in options.tables; runtime-callback markers take theirs from
+ *  options.runtime. One slim table exists per type id: the FIRST call's
+ *  options win (a later call with different tables or callbacks returns the
+ *  first table, options unvalidated). */
+export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T;
+export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T;
+export function tableFromType<T extends AnyRtTable>(
+  first?: RunType<T> | TableFromTypeOptions<T>,
+  second?: TableFromTypeOptions<T> | InjectRunTypeId<T>
+): T {
+  // only a RunType carries a string id member; options are a plain weak bag
+  const isRunType = typeof (first as {id?: unknown} | undefined)?.id === 'string';
+  const runType = isRunType ? (first as RunType<T>) : getRunType<T>(undefined, second as InjectRunTypeId<T> | undefined);
+  const options = isRunType ? (second as TableFromTypeOptions<T> | undefined) : (first as TableFromTypeOptions<T> | undefined);
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
     slimTable = buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable, options);

--- a/packages/drizzle-orm-pg-core/src/type-pins.stub.ts
+++ b/packages/drizzle-orm-pg-core/src/type-pins.stub.ts
@@ -192,9 +192,19 @@ type _twinWideUpdate = Expect<Equal<InferUpdateModel<typeof twinWideBuilders>, I
 type _twinSelect = Expect<Equal<InferSelectModel<typeof twinBuilders>, InferSelectModel<TwinType>>>;
 type _twinInsert = Expect<Equal<InferInsertModel<typeof twinBuilders>, InferInsertModel<TwinType>>>;
 type _twinUpdate = Expect<Equal<InferUpdateModel<typeof twinBuilders>, InferUpdateModel<TwinType>>>;
+// One public name describes both roads: the factories declare PgTable as their
+// return, and a builder table is assignable to the type-road spelling.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- the assignment IS the pin
+const _twinAsPgTable: TwinType = twinBuilders;
 // Refinement works on a type-road table through the RefinedTable type.
 type RefinedTwin = RefinedTable<TwinType, {name: {minLength: 2}}>;
 type _twinRefined = Expect<Equal<InferSelectModel<RefinedTwin>['name'], RTString<{maxLength: 100; minLength: 2}>>>;
+// The R parameter is constrained to TableRefinements<T>: a typo'd column or a
+// wrong-family param is a compile error at the TYPE level too.
+// @ts-expect-error "nam" is not a column of TwinType
+type _refinedBadKey = RefinedTable<TwinType, {nam: {minLength: 2}}>;
+// @ts-expect-error a string column takes no numeric refinement
+type _refinedBadParam = RefinedTable<TwinType, {name: {min: 2}}>;
 
 // ── refinement ───────────────────────────────────────────────────────────────
 
@@ -259,4 +269,6 @@ export type _PgTypePins = [
   _refinedName,
   _refinedAge,
   _refineKeepsOthers,
+  _refinedBadKey,
+  _refinedBadParam,
 ];

--- a/packages/drizzle-orm-pg-core/src/type-pins.stub.ts
+++ b/packages/drizzle-orm-pg-core/src/type-pins.stub.ts
@@ -143,7 +143,6 @@ type _patchExcluded = Expect<Equal<'seq' extends keyof UserPatch ? true : false,
 
 // The same table written both ways yields byte-identical models. This is the
 // core interchangeability promise of the pure-types road.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- consumed as a type by the pins
 const twinBuilders = pgTable('twins', {
   id: uuid('id').primaryKey().defaultRandom(),
   name: varchar('name', {length: 100}).notNull(),

--- a/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
@@ -14,7 +14,7 @@
 
 import {describe, it, expect} from 'vitest';
 import {getTableConfig} from 'drizzle-orm/pg-core';
-import {getRunType, getRunTypeId} from '@ts-runtypes/core';
+import {getRunTypeId} from '@ts-runtypes/core';
 import type {InferInsertModel, InferSelectModel, References, Sql} from '@mionjs/drizzle-orm';
 import {sql as slimSql} from '@mionjs/drizzle-orm';
 import {project as sharedProject} from '../test/tableSpecShared.ts';
@@ -131,22 +131,17 @@ type WideSelectType = InferSelectModel<WideType>;
 
 describe('pg type-defined tables — same drizzle table', () => {
   it('toDrizzle(tableFromType(...)) materializes the same table as the builder road', () => {
-    expect(project(toDrizzle(tableFromType<TwinType>(getRunType<TwinType>())))).toEqual(project(toDrizzle(twinBuilders)));
+    expect(project(toDrizzle(tableFromType<TwinType>()))).toEqual(project(toDrizzle(twinBuilders)));
   });
 
   it('tableFromType returns the same slim table per type id (one materialization)', () => {
-    const first = tableFromType<TwinType>(getRunType<TwinType>());
-    expect(first).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+    const first = tableFromType<TwinType>();
+    expect(first).toBe(tableFromType<TwinType>());
     expect(toDrizzle(first)).toBe(toDrizzle(first));
   });
 });
 
 describe('pg type-defined tables — marker forms', () => {
-  it('tableFromType<T>() shares the explicit form slim table (same object)', () => {
-    const marker = tableFromType<TwinType>();
-    expect(marker).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
-    expect(project(toDrizzle(marker))).toEqual(project(toDrizzle(twinBuilders)));
-  });
   it('toDrizzle<T>() is the happy path: same drizzle table object as the two-step road', () => {
     expect(toDrizzle<TwinType>()).toBe(toDrizzle(tableFromType<TwinType>()));
     expect(project(toDrizzle<TwinType>())).toEqual(project(toDrizzle(twinBuilders)));
@@ -201,8 +196,8 @@ type ChildrenType = PgTable<
 
 describe('pg type-defined tables — references and literal sql', () => {
   it('References resolves through deps and sql defaults rebuild, matching the builder road', () => {
-    const parentsFromType = tableFromType<ParentsType>(getRunType<ParentsType>());
-    const childrenFromType = tableFromType<ChildrenType>(getRunType<ChildrenType>(), {
+    const parentsFromType = tableFromType<ParentsType>();
+    const childrenFromType = tableFromType<ChildrenType>({
       tables: {parents: parentsFromType as object},
     });
     expect(sharedProject(toDrizzle(childrenFromType))).toEqual(sharedProject(toDrizzle(childrenBuilders)));
@@ -211,7 +206,7 @@ describe('pg type-defined tables — references and literal sql', () => {
 
   it('a missing References dep fails with an actionable error', () => {
     type Lonely = PgTable<'lonely', {pid: Integer<'pid'> & References<'nowhere', 'id'>}>;
-    expect(() => tableFromType<Lonely>(getRunType<Lonely>())).toThrowError(/references table "nowhere".*options/);
+    expect(() => tableFromType<Lonely>()).toThrowError(/references table "nowhere".*options/);
   });
 });
 
@@ -249,8 +244,8 @@ type ExtrasType = PgTable<
 
 describe('pg type-defined tables — table-level extras', () => {
   it('the extras tuple materializes the same indexes, checks and foreign keys', () => {
-    const parentsFromType = tableFromType<ParentsType>(getRunType<ParentsType>());
-    const extrasFromType = tableFromType<ExtrasType>(getRunType<ExtrasType>(), {tables: {parents: parentsFromType as object}});
+    const parentsFromType = tableFromType<ParentsType>();
+    const extrasFromType = tableFromType<ExtrasType>({tables: {parents: parentsFromType as object}});
     expect(sharedProject(toDrizzle(extrasFromType))).toEqual(sharedProject(toDrizzle(extrasBuilders)));
   });
   it('extras models ignore the extras tuple (same id as the builder road)', () => {
@@ -285,7 +280,7 @@ type RuntimeType = PgTable<
   }
 >;
 const runtimeFromType = () =>
-  tableFromType<RuntimeType>(getRunType<RuntimeType>(), {
+  tableFromType<RuntimeType>({
     runtime: {
       slug: {$defaultFn: () => 'slug-1'},
       counter: {$default: () => 7},
@@ -321,11 +316,11 @@ describe('pg type-defined tables — runtime-callback modifiers', () => {
   });
   it('a $ marker without its options.runtime callback fails naming column and method', () => {
     type Bare = PgTable<'bare_runtime', {slug: Varchar<'slug', {length: 5}> & $DefaultFn}>;
-    expect(() => tableFromType<Bare>(getRunType<Bare>())).toThrowError(/column "slug" carries the \$defaultFn marker/);
+    expect(() => tableFromType<Bare>()).toThrowError(/column "slug" carries the \$defaultFn marker/);
   });
   it('an options.runtime callback without its marker fails', () => {
     type NoMarker = PgTable<'no_marker_runtime', {n: Integer<'n'>}>;
-    expect(() => tableFromType<NoMarker>(getRunType<NoMarker>(), {runtime: {n: {$onUpdate: () => 1}}})).toThrowError(
+    expect(() => tableFromType<NoMarker>({runtime: {n: {$onUpdate: () => 1}}})).toThrowError(
       /options\.runtime\.n\.\$onUpdate has no matching/
     );
   });
@@ -333,7 +328,7 @@ describe('pg type-defined tables — runtime-callback modifiers', () => {
 
 describe('pg type-defined tables — widened vocabulary twin', () => {
   it('toDrizzle(tableFromType(...)) equals the builder road for the wide table', () => {
-    expect(project(toDrizzle(tableFromType<WideType>(getRunType<WideType>())))).toEqual(project(toDrizzle(wideBuilders)));
+    expect(project(toDrizzle(tableFromType<WideType>()))).toEqual(project(toDrizzle(wideBuilders)));
   });
   it('wide models share one id across roads (static + reflection forms)', () => {
     const row: WideSelectType = {} as WideSelectType;

--- a/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
@@ -141,6 +141,26 @@ describe('pg type-defined tables — same drizzle table', () => {
   });
 });
 
+describe('pg type-defined tables — marker forms', () => {
+  it('tableFromType<T>() shares the explicit form slim table (same object)', () => {
+    const marker = tableFromType<TwinType>();
+    expect(marker).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+    expect(project(toDrizzle(marker))).toEqual(project(toDrizzle(twinBuilders)));
+  });
+  it('toDrizzle<T>() is the happy path: same drizzle table object as the two-step road', () => {
+    expect(toDrizzle<TwinType>()).toBe(toDrizzle(tableFromType<TwinType>()));
+    expect(project(toDrizzle<TwinType>())).toEqual(project(toDrizzle(twinBuilders)));
+  });
+  it('marker forms carry options (References through toDrizzle<T>({tables}))', () => {
+    const parents = tableFromType<ParentsType>();
+    const children = toDrizzle<ChildrenType>({tables: {parents: parents as object}});
+    expect(sharedProject(children)).toEqual(sharedProject(toDrizzle(childrenBuilders)));
+  });
+  it('toDrizzle still rejects a value that is neither table, handle nor options', () => {
+    expect(() => toDrizzle({bogus: true} as never)).toThrowError(/takes a slim table/);
+  });
+});
+
 describe('pg type-defined tables — same model runtype id', () => {
   // Marker test coverage rule: both getRunTypeId call shapes, paired.
   it('getRunTypeId static form: both roads resolve the select model to one id', () => {

--- a/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
@@ -19,6 +19,10 @@ import type {InferInsertModel, InferSelectModel, References, Sql} from '@mionjs/
 import {sql as slimSql} from '@mionjs/drizzle-orm';
 import {project as sharedProject} from '../test/tableSpecShared.ts';
 import type {
+  $Default,
+  $DefaultFn,
+  $OnUpdate,
+  $OnUpdateFn,
   $Type,
   Array as PgArray,
   CheckEntry,
@@ -187,7 +191,7 @@ describe('pg type-defined tables — references and literal sql', () => {
 
   it('a missing References dep fails with an actionable error', () => {
     type Lonely = PgTable<'lonely', {pid: Integer<'pid'> & References<'nowhere', 'id'>}>;
-    expect(() => tableFromType<Lonely>(getRunType<Lonely>())).toThrowError(/references table "nowhere".*deps/);
+    expect(() => tableFromType<Lonely>(getRunType<Lonely>())).toThrowError(/references table "nowhere".*options/);
   });
 });
 
@@ -235,6 +239,75 @@ describe('pg type-defined tables — table-level extras', () => {
     const row: A = {} as A;
     expect(getRunTypeId<A>()).toBe(getRunTypeId<B>());
     expect(getRunTypeId(row)).toBe(getRunTypeId<A>());
+  });
+});
+
+// Runtime-callback modifiers: the type carries the $ markers, the callbacks
+// ride options.runtime, and both roads must materialize the same table AND
+// the same runtime behavior (the callbacks themselves).
+const runtimeBuilders = pgTable('runtime_t', {
+  id: uuid('id').primaryKey(),
+  slug: varchar('slug', {length: 80})
+    .notNull()
+    .$defaultFn(() => 'slug-1'),
+  counter: integer('counter').$default(() => 7),
+  updatedAt: timestamp('updated_at', {mode: 'string'}).$onUpdate(() => 'updated-now'),
+  touched: integer('touched').$onUpdateFn(() => 1),
+});
+type RuntimeType = PgTable<
+  'runtime_t',
+  {
+    id: Uuid<'id'> & PrimaryKey;
+    slug: Varchar<'slug', {length: 80}> & NotNull & $DefaultFn;
+    counter: Integer<'counter'> & $Default;
+    updatedAt: Timestamp<'updated_at', {mode: 'string'}> & $OnUpdate;
+    touched: Integer<'touched'> & $OnUpdateFn;
+  }
+>;
+const runtimeFromType = () =>
+  tableFromType<RuntimeType>(getRunType<RuntimeType>(), {
+    runtime: {
+      slug: {$defaultFn: () => 'slug-1'},
+      counter: {$default: () => 7},
+      updatedAt: {$onUpdate: () => 'updated-now'},
+      touched: {$onUpdateFn: () => 1},
+    },
+  });
+/** Invoke each drizzle column's runtime hooks (set by the $ modifiers) so the
+ *  oracle compares callback BEHAVIOR, not function identity. */
+function runtimeHooks(table: unknown) {
+  const config = getTableConfig(table as never);
+  return Object.fromEntries(
+    config.columns.map((column) => {
+      const hooks = column as unknown as {defaultFn?: () => unknown; onUpdateFn?: () => unknown};
+      return [column.name, {defaultFn: hooks.defaultFn?.(), onUpdateFn: hooks.onUpdateFn?.()}];
+    })
+  );
+}
+
+describe('pg type-defined tables — runtime-callback modifiers', () => {
+  it('materializes the same table as the builder road, callbacks included', () => {
+    const bridge = toDrizzle(runtimeFromType());
+    expect(project(bridge)).toEqual(project(toDrizzle(runtimeBuilders)));
+    expect(runtimeHooks(bridge)).toEqual(runtimeHooks(toDrizzle(runtimeBuilders)));
+    expect(runtimeHooks(bridge).slug).toEqual({defaultFn: 'slug-1', onUpdateFn: undefined});
+    expect(runtimeHooks(bridge).updated_at).toEqual({defaultFn: undefined, onUpdateFn: 'updated-now'});
+  });
+  it('runtime models share one id across roads (static + reflection forms)', () => {
+    type TypeInsertRuntime = InferInsertModel<RuntimeType>;
+    const minimal: TypeInsertRuntime = {id: 'x'}; // slug is notNull but $DefaultFn makes it optional
+    expect(getRunTypeId<TypeInsertRuntime>()).toBe(getRunTypeId<InferInsertModel<typeof runtimeBuilders>>());
+    expect(getRunTypeId(minimal)).toBe(getRunTypeId<TypeInsertRuntime>());
+  });
+  it('a $ marker without its options.runtime callback fails naming column and method', () => {
+    type Bare = PgTable<'bare_runtime', {slug: Varchar<'slug', {length: 5}> & $DefaultFn}>;
+    expect(() => tableFromType<Bare>(getRunType<Bare>())).toThrowError(/column "slug" carries the \$defaultFn marker/);
+  });
+  it('an options.runtime callback without its marker fails', () => {
+    type NoMarker = PgTable<'no_marker_runtime', {n: Integer<'n'>}>;
+    expect(() => tableFromType<NoMarker>(getRunType<NoMarker>(), {runtime: {n: {$onUpdate: () => 1}}})).toThrowError(
+      /options\.runtime\.n\.\$onUpdate has no matching/
+    );
   });
 });
 

--- a/packages/drizzle-orm-sqlite-core/src/drizzle.ts
+++ b/packages/drizzle-orm-sqlite-core/src/drizzle.ts
@@ -25,7 +25,10 @@ import type {
   DrizzleContext,
   TableNameOf,
 } from '@mionjs/drizzle-orm';
+import type {TableFromTypeOptions} from '@mionjs/drizzle-orm';
 import {materializeRtTable, RtValueRecorder, rtTableKey, rtValueKey} from '@mionjs/drizzle-orm';
+import type {InjectRunTypeId} from '@ts-runtypes/core';
+import {tableFromType} from './table.ts';
 
 const context: DrizzleContext = {
   ns: dzSqlite as unknown as DrizzleContext['ns'],
@@ -69,11 +72,23 @@ export type ToDrizzleTable<T extends AnyRtTable> = SQLiteTableWithColumns<{
 }>;
 
 export function toDrizzle<T extends AnyRtTable>(table: T): ToDrizzleTable<T>;
-export function toDrizzle(value: object): unknown {
-  const attached = (value as Record<symbol, unknown>)[rtValueKey];
-  if (attached instanceof RtValueRecorder) return attached.toDrizzleValue(context);
-  if ((value as Record<symbol, unknown>)[rtTableKey] === undefined) {
-    throw new Error('@mionjs/drizzle-orm-sqlite-core: toDrizzle() takes a slim table');
+export function toDrizzle<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
+export function toDrizzle(value?: object, id?: unknown): unknown {
+  if (value !== undefined) {
+    const attached = (value as Record<symbol, unknown>)[rtValueKey];
+    if (attached instanceof RtValueRecorder) return attached.toDrizzleValue(context);
+    if ((value as Record<symbol, unknown>)[rtTableKey] !== undefined) return materializeRtTable(value, context);
+    if (id === undefined && !isTableOptions(value)) {
+      throw new Error(
+        '@mionjs/drizzle-orm-sqlite-core: toDrizzle() takes a slim table or the marker form toDrizzle<NotesTable>(options?)'
+      );
+    }
   }
-  return materializeRtTable(value, context);
+  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyRtTable> | undefined);
+  return materializeRtTable(slim, context);
+}
+
+/** A non-table object arg is only valid as the marker form's options bag. */
+function isTableOptions(value: object): boolean {
+  return Object.keys(value).every((key) => key === 'tables' || key === 'runtime');
 }

--- a/packages/drizzle-orm-sqlite-core/src/index.ts
+++ b/packages/drizzle-orm-sqlite-core/src/index.ts
@@ -33,6 +33,10 @@ export type {
 // The pure-types road: the modifier markers applicable to sqlite columns. The
 // column types (Integer, Text, ...) live beside their builders in ./columns.ts.
 export type {
+  $Default,
+  $DefaultFn,
+  $OnUpdate,
+  $OnUpdateFn,
   $Type,
   Default,
   GeneratedAlwaysAs,

--- a/packages/drizzle-orm-sqlite-core/src/table.ts
+++ b/packages/drizzle-orm-sqlite-core/src/table.ts
@@ -10,13 +10,12 @@
 // injected context at materialization (toDrizzle, in ./drizzle.ts).
 
 import type {
-  AnyRtColType,
   AnyRtColumn,
   AnyRtTable,
   DrizzleContext,
   ReflectedNode,
   RtExtraColumn,
-  RtTable,
+  RtTableMetaWithExtras,
   TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
@@ -35,9 +34,13 @@ import type {SqliteEntryBrand} from './helpers.ts';
  *  models and refinement work unchanged; materialize with tableFromType. */
 export type SqliteTable<
   TName extends string,
-  Cols extends Record<string, AnyRtColType>,
+  Cols extends object,
   Extras extends readonly object[] = [],
-> = RtTable<TName, TypedCols<Cols>> & {readonly [rtTableKey]: {extras: Extras}};
+  // Internal fast path: the factories pass their already-branded Cols here so
+  // a builder table never evaluates the TypedCols conditional (type-budget
+  // sensitive); authored type-road tables omit it and get normalized.
+  NormalizedCols extends object = TypedCols<Cols>,
+> = NormalizedCols & {readonly [rtTableKey]: RtTableMetaWithExtras<TName, NormalizedCols, Extras>};
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -127,18 +130,19 @@ export function sqliteBuildTable(
     : context.ns.sqliteTable(name as never, builders as never);
 }
 
-/** Records the table; returns a slim RtTable, NOT drizzle's SQLiteTable. The real
- *  drizzle table is built on demand by toDrizzle() from the ./drizzle subpath. */
+/** Records the table; returns the slim table typed as SqliteTable (one public
+ *  name for both roads), NOT drizzle's own table. The real drizzle table is
+ *  built on demand by toDrizzle() from the ./drizzle subpath. */
 export function sqliteTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: Cols,
   extraConfig?: SqliteExtraConfigFn<Cols>
-): RtTable<TName, Cols>;
+): SqliteTable<TName, Cols, [], Cols>;
 export function sqliteTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: SQLiteColumnHelpers) => Cols,
   extraConfig?: SqliteExtraConfigFn<Cols>
-): RtTable<TName, Cols>;
+): SqliteTable<TName, Cols, [], Cols>;
 export function sqliteTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, sqliteBuildTable);
 }
@@ -150,12 +154,12 @@ export function sqliteTableCreator(customizeTableName: (name: string) => string)
     name: TName,
     columns: Cols,
     extraConfig?: SqliteExtraConfigFn<Cols>
-  ): RtTable<TName, Cols>;
+  ): SqliteTable<TName, Cols, [], Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: SQLiteColumnHelpers) => Cols,
     extraConfig?: SqliteExtraConfigFn<Cols>
-  ): RtTable<TName, Cols>;
+  ): SqliteTable<TName, Cols, [], Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-sqlite-core/src/table.ts
+++ b/packages/drizzle-orm-sqlite-core/src/table.ts
@@ -21,7 +21,7 @@ import type {
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
 import {buildRtTableFromGraph, createRtTable, RtValueRecorder, rtTableKey} from '@mionjs/drizzle-orm';
-import type {InjectRunTypeId, RunType} from '@ts-runtypes/core';
+import type {InjectRunTypeId} from '@ts-runtypes/core';
 import {getRunType} from '@ts-runtypes/core';
 import {sqliteColumnHelpers, type SQLiteColumnHelpers} from './columns.ts';
 import type {SqliteEntryBrand} from './helpers.ts';
@@ -82,24 +82,16 @@ const fromTypeTables = new Map<string, object>();
 /** Runtime twin of a TYPE-defined table: rebuild the slim table from the
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
  *  and refineTableType treat it exactly like a sqliteTable() result. The
- *  marker form `tableFromType<NotesTable>(options?)` resolves the graph itself
- *  (ts-runtypes-devtools must be active); the explicit form
- *  `tableFromType(getRunType<NotesTable>(), options?)` stays as the low-level
- *  escape hatch. A table whose columns use References needs the referenced
- *  tables in options.tables; runtime-callback markers take theirs from
- *  options.runtime. One slim table exists per type id: the FIRST call's
- *  options win (a later call with different tables or callbacks returns the
- *  first table, options unvalidated). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T;
-export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T;
-export function tableFromType<T extends AnyRtTable>(
-  first?: RunType<T> | TableFromTypeOptions<T>,
-  second?: TableFromTypeOptions<T> | InjectRunTypeId<T>
-): T {
-  // only a RunType carries a string id member; options are a plain weak bag
-  const isRunType = typeof (first as {id?: unknown} | undefined)?.id === 'string';
-  const runType = isRunType ? (first as RunType<T>) : getRunType<T>(undefined, second as InjectRunTypeId<T> | undefined);
-  const options = isRunType ? (second as TableFromTypeOptions<T> | undefined) : (first as TableFromTypeOptions<T> | undefined);
+ *  type argument is resolved by the build (ts-runtypes-devtools must be
+ *  active); dynamic callers holding a resolved RunType graph use the
+ *  lower-level buildRtTableFromGraph from @mionjs/drizzle-orm instead. A
+ *  table whose columns use References needs the referenced tables in
+ *  options.tables; runtime-callback markers take theirs from options.runtime.
+ *  One slim table exists per type id: the FIRST call's options win (a later
+ *  call with different tables or callbacks returns the first table, options
+ *  unvalidated). */
+export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
+  const runType = getRunType<T>(undefined, id);
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
     slimTable = buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable, options);

--- a/packages/drizzle-orm-sqlite-core/src/table.ts
+++ b/packages/drizzle-orm-sqlite-core/src/table.ts
@@ -22,7 +22,8 @@ import type {
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
 import {buildRtTableFromGraph, createRtTable, RtValueRecorder, rtTableKey} from '@mionjs/drizzle-orm';
-import type {RunType} from '@ts-runtypes/core';
+import type {InjectRunTypeId, RunType} from '@ts-runtypes/core';
+import {getRunType} from '@ts-runtypes/core';
 import {sqliteColumnHelpers, type SQLiteColumnHelpers} from './columns.ts';
 import type {SqliteEntryBrand} from './helpers.ts';
 
@@ -77,14 +78,25 @@ const fromTypeTables = new Map<string, object>();
 
 /** Runtime twin of a TYPE-defined table: rebuild the slim table from the
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
- *  and refineTableType treat it exactly like a sqliteTable() result. Resolve
- *  the graph at the call site: `tableFromType(getRunType<NotesTable>())`. A
- *  table whose columns use References needs the referenced tables in
- *  options.tables; runtime-callback markers take theirs from options.runtime.
- *  One slim table exists per type id: the FIRST call's options win (a later
- *  call with different tables or callbacks returns the first table, options
- *  unvalidated). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T {
+ *  and refineTableType treat it exactly like a sqliteTable() result. The
+ *  marker form `tableFromType<NotesTable>(options?)` resolves the graph itself
+ *  (ts-runtypes-devtools must be active); the explicit form
+ *  `tableFromType(getRunType<NotesTable>(), options?)` stays as the low-level
+ *  escape hatch. A table whose columns use References needs the referenced
+ *  tables in options.tables; runtime-callback markers take theirs from
+ *  options.runtime. One slim table exists per type id: the FIRST call's
+ *  options win (a later call with different tables or callbacks returns the
+ *  first table, options unvalidated). */
+export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T;
+export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T;
+export function tableFromType<T extends AnyRtTable>(
+  first?: RunType<T> | TableFromTypeOptions<T>,
+  second?: TableFromTypeOptions<T> | InjectRunTypeId<T>
+): T {
+  // only a RunType carries a string id member; options are a plain weak bag
+  const isRunType = typeof (first as {id?: unknown} | undefined)?.id === 'string';
+  const runType = isRunType ? (first as RunType<T>) : getRunType<T>(undefined, second as InjectRunTypeId<T> | undefined);
+  const options = isRunType ? (second as TableFromTypeOptions<T> | undefined) : (first as TableFromTypeOptions<T> | undefined);
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
     slimTable = buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable, options);

--- a/packages/drizzle-orm-sqlite-core/src/table.ts
+++ b/packages/drizzle-orm-sqlite-core/src/table.ts
@@ -17,7 +17,7 @@ import type {
   ReflectedNode,
   RtExtraColumn,
   RtTable,
-  TableFromTypeDeps,
+  TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
@@ -79,12 +79,15 @@ const fromTypeTables = new Map<string, object>();
  *  reflected graph, typed as the table type itself — so toDrizzle, the models
  *  and refineTableType treat it exactly like a sqliteTable() result. Resolve
  *  the graph at the call site: `tableFromType(getRunType<NotesTable>())`. A
- *  table whose columns use References needs the referenced tables in deps; one
- *  slim table exists per type id (the first call's deps win). */
-export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, deps?: TableFromTypeDeps): T {
+ *  table whose columns use References needs the referenced tables in
+ *  options.tables; runtime-callback markers take theirs from options.runtime.
+ *  One slim table exists per type id: the FIRST call's options win (a later
+ *  call with different tables or callbacks returns the first table, options
+ *  unvalidated). */
+export function tableFromType<T extends AnyRtTable>(runType: RunType<T>, options?: TableFromTypeOptions<T>): T {
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
-    slimTable = buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable, deps);
+    slimTable = buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable, options);
     fromTypeTables.set(runType.id, slimTable);
   }
   return slimTable as T;

--- a/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
@@ -72,6 +72,12 @@ describe('sqlite type-defined tables — same drizzle table', () => {
     expect(first).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
     expect(toDrizzle(first)).toBe(toDrizzle(first));
   });
+
+  it('marker forms: tableFromType<T>() and toDrizzle<T>() share the explicit road objects', () => {
+    expect(tableFromType<TwinType>()).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+    expect(toDrizzle<TwinType>()).toBe(toDrizzle(tableFromType<TwinType>()));
+    expect(project(toDrizzle<TwinType>())).toEqual(project(toDrizzle(twinBuilders)));
+  });
 });
 
 describe('sqlite type-defined tables — same model runtype id', () => {

--- a/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
@@ -14,7 +14,7 @@
 
 import {describe, it, expect} from 'vitest';
 import {getTableConfig} from 'drizzle-orm/sqlite-core';
-import {getRunType, getRunTypeId} from '@ts-runtypes/core';
+import {getRunTypeId} from '@ts-runtypes/core';
 import type {InferInsertModel, InferSelectModel} from '@mionjs/drizzle-orm';
 import type {$DefaultFn, $OnUpdateFn, Default, Integer, NotNull, PrimaryKey, Real, SqliteTable, Text} from './index.ts';
 import {integer, real, sqliteTable, tableFromType, text} from './index.ts';
@@ -64,17 +64,16 @@ function project(table: unknown) {
 
 describe('sqlite type-defined tables — same drizzle table', () => {
   it('toDrizzle(tableFromType(...)) materializes the same table as the builder road', () => {
-    expect(project(toDrizzle(tableFromType<TwinType>(getRunType<TwinType>())))).toEqual(project(toDrizzle(twinBuilders)));
+    expect(project(toDrizzle(tableFromType<TwinType>()))).toEqual(project(toDrizzle(twinBuilders)));
   });
 
   it('tableFromType returns the same slim table per type id (one materialization)', () => {
-    const first = tableFromType<TwinType>(getRunType<TwinType>());
-    expect(first).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+    const first = tableFromType<TwinType>();
+    expect(first).toBe(tableFromType<TwinType>());
     expect(toDrizzle(first)).toBe(toDrizzle(first));
   });
 
-  it('marker forms: tableFromType<T>() and toDrizzle<T>() share the explicit road objects', () => {
-    expect(tableFromType<TwinType>()).toBe(tableFromType<TwinType>(getRunType<TwinType>()));
+  it('toDrizzle<T>() is the happy path: same drizzle table object as the two-step road', () => {
     expect(toDrizzle<TwinType>()).toBe(toDrizzle(tableFromType<TwinType>()));
     expect(project(toDrizzle<TwinType>())).toEqual(project(toDrizzle(twinBuilders)));
   });
@@ -122,7 +121,7 @@ type RuntimeType = SqliteTable<
 
 describe('sqlite type-defined tables — runtime-callback modifiers', () => {
   it('materializes the same table as the builder road, callbacks included', () => {
-    const fromType = tableFromType<RuntimeType>(getRunType<RuntimeType>(), {
+    const fromType = tableFromType<RuntimeType>({
       runtime: {slug: {$defaultFn: () => 'slug-1'}, counter: {$onUpdateFn: () => 7}},
     });
     const bridge = toDrizzle(fromType);

--- a/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
@@ -16,7 +16,7 @@ import {describe, it, expect} from 'vitest';
 import {getTableConfig} from 'drizzle-orm/sqlite-core';
 import {getRunType, getRunTypeId} from '@ts-runtypes/core';
 import type {InferInsertModel, InferSelectModel} from '@mionjs/drizzle-orm';
-import type {Default, Integer, NotNull, PrimaryKey, Real, SqliteTable, Text} from './index.ts';
+import type {$DefaultFn, $OnUpdateFn, Default, Integer, NotNull, PrimaryKey, Real, SqliteTable, Text} from './index.ts';
 import {integer, real, sqliteTable, tableFromType, text} from './index.ts';
 import {toDrizzle} from './drizzle.ts';
 
@@ -93,5 +93,46 @@ describe('sqlite type-defined tables — same model runtype id', () => {
     const insert: TypeInsert = {title: 't', rating: 1.5, createdAt: new Date()} as TypeInsert;
     expect(getRunTypeId<TypeInsert>()).toBe(getRunTypeId<BuilderInsert>());
     expect(getRunTypeId(insert)).toBe(getRunTypeId<TypeInsert>());
+  });
+});
+
+// Runtime-callback modifiers: $ markers in the type, callbacks via
+// options.runtime; same table AND same callback behavior on both roads.
+const runtimeBuilders = sqliteTable('runtime_t', {
+  id: integer('id').primaryKey(),
+  slug: text('slug', {length: 80})
+    .notNull()
+    .$defaultFn(() => 'slug-1'),
+  counter: integer('counter').$onUpdateFn(() => 7),
+});
+type RuntimeType = SqliteTable<
+  'runtime_t',
+  {
+    id: Integer<'id'> & PrimaryKey;
+    slug: Text<'slug', {length: 80}> & NotNull & $DefaultFn;
+    counter: Integer<'counter'> & $OnUpdateFn;
+  }
+>;
+
+describe('sqlite type-defined tables — runtime-callback modifiers', () => {
+  it('materializes the same table as the builder road, callbacks included', () => {
+    const fromType = tableFromType<RuntimeType>(getRunType<RuntimeType>(), {
+      runtime: {slug: {$defaultFn: () => 'slug-1'}, counter: {$onUpdateFn: () => 7}},
+    });
+    const bridge = toDrizzle(fromType);
+    expect(project(bridge)).toEqual(project(toDrizzle(runtimeBuilders)));
+    const hooks = (table: unknown) =>
+      getTableConfig(table as never).columns.map((column) => {
+        const c = column as unknown as {defaultFn?: () => unknown; onUpdateFn?: () => unknown};
+        return [column.name, c.defaultFn?.(), c.onUpdateFn?.()];
+      });
+    expect(hooks(bridge)).toEqual(hooks(toDrizzle(runtimeBuilders)));
+    expect(hooks(bridge)).toContainEqual(['slug', 'slug-1', undefined]);
+  });
+  it('runtime models share one id across roads (static + reflection forms)', () => {
+    type TypeInsertRuntime = InferInsertModel<RuntimeType>;
+    const minimal: TypeInsertRuntime = {id: 1}; // slug is notNull but $DefaultFn makes it optional
+    expect(getRunTypeId<TypeInsertRuntime>()).toBe(getRunTypeId<InferInsertModel<typeof runtimeBuilders>>());
+    expect(getRunTypeId(minimal)).toBe(getRunTypeId<TypeInsertRuntime>());
   });
 });

--- a/packages/drizzle-orm/src/fromType.spec.ts
+++ b/packages/drizzle-orm/src/fromType.spec.ts
@@ -126,6 +126,55 @@ describe('buildRtTableFromGraph', () => {
     expect(fake.calls[0]).toEqual(['ns', 'varchar', {length: 5}]);
   });
 
+  it('replays a runtime-callback marker with the options.runtime callback, in mods order', () => {
+    const fake = makeFake();
+    const callback = () => 'generated';
+    const graph = tableNode('users', {
+      slug: colNode({fn: 'varchar', name: 'slug'}, {notNull: lit(true), $defaultFn: lit(true), unique: tuple()}),
+    });
+    const slim = buildRtTableFromGraph(graph, fake.buildTable, {runtime: {slug: {$defaultFn: callback}}});
+    materializeRtTable(slim, fake.context);
+    // the replay wraps top-level function args lazily (mapReplayArgs), so the
+    // replayed arg is a wrapper: assert it forwards to the options callback.
+    expect(fake.calls).toEqual([
+      ['ns', 'varchar', 'slug'],
+      ['ns.varchar', 'notNull'],
+      ['ns.varchar', '$defaultFn', expect.any(Function)],
+      ['ns.varchar', 'unique'],
+      ['buildTable', 'users', ['slug']],
+    ]);
+    const replayed = fake.calls[2][2] as () => unknown;
+    expect(replayed()).toBe('generated');
+  });
+
+  it('replays each runtime method under its own name ($default vs $onUpdateFn)', () => {
+    const fake = makeFake();
+    const onUpdate = () => 0;
+    const graph = tableNode('t', {c: colNode({fn: 'integer'}, {$default: lit(true), $onUpdateFn: lit(true)})});
+    const slim = buildRtTableFromGraph(graph, fake.buildTable, {runtime: {c: {$default: onUpdate, $onUpdateFn: onUpdate}}});
+    materializeRtTable(slim, fake.context);
+    expect(fake.calls.map((call) => call[1])).toEqual(['integer', '$default', '$onUpdateFn', 't']);
+  });
+
+  it('rejects a runtime marker without its options.runtime callback, naming column and method', () => {
+    const graph = tableNode('t', {c: colNode({fn: 'uuid'}, {$defaultFn: lit(true)})});
+    expect(() => buildRtTableFromGraph(graph, makeFake().buildTable)).toThrowError(/column "c" carries the \$defaultFn marker/);
+    expect(() => buildRtTableFromGraph(graph, makeFake().buildTable, {runtime: {c: {$onUpdate: () => 1}}})).toThrowError(
+      /column "c" carries the \$defaultFn marker/
+    );
+  });
+
+  it('rejects an options.runtime callback with no matching marker (and unknown columns)', () => {
+    const graph = tableNode('t', {c: colNode({fn: 'uuid'}, {$defaultFn: lit(true)})});
+    const runtime = {c: {$defaultFn: () => 1, $onUpdate: () => 2}};
+    expect(() => buildRtTableFromGraph(graph, makeFake().buildTable, {runtime})).toThrowError(
+      /options\.runtime\.c\.\$onUpdate has no matching/
+    );
+    expect(() =>
+      buildRtTableFromGraph(graph, makeFake().buildTable, {runtime: {c: {$defaultFn: () => 1}, ghost: {$default: () => 2}}})
+    ).toThrowError(/options\.runtime\.ghost\.\$default has no matching/);
+  });
+
   it('rejects a graph that is not a table', () => {
     expect(() => buildRtTableFromGraph(obj({a: lit(1)}), makeFake().buildTable)).toThrowError(/not a table/);
   });

--- a/packages/drizzle-orm/src/fromType.ts
+++ b/packages/drizzle-orm/src/fromType.ts
@@ -12,20 +12,38 @@
 // the rtColSpec/rtColMods sentinels as literal types — so the rebuilt table
 // materializes into exactly the drizzle table the builder road produces.
 //
-// This module imports NOTHING from @ts-runtypes/core at runtime (the dialect
-// packages' core peer is type-only): callers resolve the graph themselves
-// (tableFromType(getRunType<UsersTable>()) in the dialect's ./drizzle module)
-// and the walker reads the plain node objects structurally.
+// This module imports NOTHING from @ts-runtypes/core at runtime: callers
+// resolve the graph (the dialects' tableFromType marker overload, or an
+// explicit getRunType<UsersTable>() call) and the walker reads the plain node
+// objects structurally, so @mionjs/drizzle-orm itself stays core-free.
 
 import {RtColumnRecorder, RtEntryRecorder, sql} from './recorder.ts';
-import type {AnyRtColumn} from './recorder.ts';
-import type {BuildTableFn} from './table.ts';
+import type {AnyRtColumn, ColDataOf} from './recorder.ts';
+import type {AnyRtTable, BuildTableFn, ColsOf} from './table.ts';
 import {createRtTable} from './table.ts';
 
+/** Per-column runtime callbacks a type cannot carry ($default/$defaultFn and
+ *  $onUpdate/$onUpdateFn, drizzle's alias pairs). Each key must match the
+ *  same-named $ marker on the column type; the bridge throws on a mismatch in
+ *  either direction. */
+export type RuntimeCallbacks<T extends AnyRtTable> = {
+  [K in keyof ColsOf<T>]?: {
+    $default?: () => ColDataOf<ColsOf<T>[K]>;
+    $defaultFn?: () => ColDataOf<ColsOf<T>[K]>;
+    $onUpdate?: () => ColDataOf<ColsOf<T>[K]>;
+    $onUpdateFn?: () => ColDataOf<ColsOf<T>[K]>;
+  };
+};
+
 /** Runtime inputs a type-defined table cannot carry in the type: the tables
- *  its References modifiers point at, keyed by DB table name. */
-export interface TableFromTypeDeps {
+ *  its References modifiers point at (keyed by DB table name) and the
+ *  runtime-callback modifiers. ⚠ Every member MUST stay optional: the weak-type
+ *  check is what keeps the `(runType, options?)` and `(options?, id?)`
+ *  tableFromType overloads disjoint — a required member would silently break
+ *  overload resolution at every marker call site. */
+export interface TableFromTypeOptions<T extends AnyRtTable = AnyRtTable> {
   tables?: Record<string, object>;
+  runtime?: RuntimeCallbacks<T>;
 }
 
 /** Minimal structural view of a reflected RunType node (the walker's whole
@@ -138,15 +156,23 @@ function readColumnSpec(columnNode: ReflectedNode, key: string): ColumnSpec {
   return {fn, name: nameValue, config};
 }
 
+/** The runtime-callback modifiers: the type carries only the $ marker flag,
+ *  the callback itself rides options.runtime. */
+const runtimeModMethods = new Set(['$default', '$defaultFn', '$onUpdate', '$onUpdateFn']);
+
 /** Replay one column's modifier calls onto its recorder: `true` = no-arg flag,
  *  a tuple = the call args. Order is the mods object's member order.
- *  References resolves its target through deps.tables lazily (the referenced
- *  table may still be materializing), validated eagerly here. */
+ *  References resolves its target through options.tables lazily (the
+ *  referenced table may still be materializing), validated eagerly here. A
+ *  $ runtime marker replays the matching options.runtime callback (missing
+ *  callback = throw) and records the pair in consumedRuntime so the caller
+ *  can flag callbacks without a marker. */
 function applyMods(
   recorder: RtColumnRecorder,
   columnNode: ReflectedNode,
   key: string,
-  deps: TableFromTypeDeps | undefined
+  options: TableFromTypeOptions | undefined,
+  consumedRuntime: Set<string>
 ): void {
   const modsMember = memberNamed(columnNode, '@rtColModsKey');
   if (!modsMember?.child) return;
@@ -155,13 +181,26 @@ function applyMods(
     const method = modMember.name;
     if (typeof method !== 'string' || modMember.child === undefined) fail(`column "${key}" has a malformed modifier`);
     if (method === '$type') continue;
+    if (runtimeModMethods.has(method)) {
+      const callback = options?.runtime?.[key]?.[method as '$default'];
+      if (typeof callback !== 'function') {
+        fail(
+          `column "${key}" carries the ${method} marker — pass the callback via options: {runtime: {${key}: {${method}: () => ...}}}`
+        );
+      }
+      methods[method](callback);
+      consumedRuntime.add(`${key}.${method}`);
+      continue;
+    }
     if (typeof methods[method] !== 'function') fail(`column "${key}" carries an unknown modifier "${method}"`);
     const value = literalValueOf(modMember.child, `${key}.${method}`);
     if (method === 'references') {
       const [ref, actions] = value as [{table: string; column: string}, object | undefined];
-      const target = deps?.tables?.[ref.table];
+      const target = options?.tables?.[ref.table];
       if (target === undefined) {
-        fail(`column "${key}" references table "${ref.table}" — pass it via tableFromType deps: {tables: {${ref.table}: ...}}`);
+        fail(
+          `column "${key}" references table "${ref.table}" — pass it via tableFromType options: {tables: {${ref.table}: ...}}`
+        );
       }
       recorder.references(() => (target as Record<string, AnyRtColumn>)[ref.column], actions);
       continue;
@@ -172,6 +211,21 @@ function applyMods(
       methods[method](...value);
     } else {
       fail(`column "${key}" modifier "${method}" carries neither a flag nor an args tuple`);
+    }
+  }
+}
+
+/** Every options.runtime callback must have been consumed by a matching $
+ *  marker on the same column — an unmatched callback would silently never run
+ *  (and the value-free model types would disagree about HasDefault). */
+function checkRuntimeLeftovers(options: TableFromTypeOptions | undefined, consumedRuntime: Set<string>): void {
+  for (const [key, callbacks] of Object.entries(options?.runtime ?? {})) {
+    for (const [method, callback] of Object.entries(callbacks ?? {})) {
+      if (callback === undefined) continue;
+      if (!runtimeModMethods.has(method)) fail(`options.runtime.${key}.${method} is not a runtime modifier`);
+      if (!consumedRuntime.has(`${key}.${method}`)) {
+        fail(`options.runtime.${key}.${method} has no matching ${method} marker on the column type (or no such column)`);
+      }
     }
   }
 }
@@ -214,15 +268,16 @@ function readEntries(meta: ReflectedNode, tableName: string): EntrySpec[] {
 }
 
 /** Deep-swap the reserved ref shapes for live column objects: `{col}` → this
- *  table's column (from the extraConfig self record), `{table, col}` → a deps
- *  table's column. Everything else passes through (sql recorders included). */
+ *  table's column (from the extraConfig self record), `{table, col}` → an
+ *  options.tables column. Everything else passes through (sql recorders
+ *  included). */
 function resolveEntryRefs(
   value: unknown,
   self: Record<string, unknown>,
-  deps: TableFromTypeDeps | undefined,
+  options: TableFromTypeOptions | undefined,
   where: string
 ): unknown {
-  if (Array.isArray(value)) return value.map((item, i) => resolveEntryRefs(item, self, deps, `${where}[${i}]`));
+  if (Array.isArray(value)) return value.map((item, i) => resolveEntryRefs(item, self, options, `${where}[${i}]`));
   if (value === null || typeof value !== 'object') return value;
   const record = value as Record<string, unknown>;
   const keys = Object.keys(record);
@@ -232,23 +287,26 @@ function resolveEntryRefs(
     return column;
   }
   if (keys.length === 2 && typeof record.col === 'string' && typeof record.table === 'string') {
-    const target = deps?.tables?.[record.table];
-    if (target === undefined) fail(`${where}: references table "${record.table}" — pass it via tableFromType deps`);
+    const target = options?.tables?.[record.table];
+    if (target === undefined) fail(`${where}: references table "${record.table}" — pass it via tableFromType options`);
     return (target as Record<string, unknown>)[record.col];
   }
   if (Object.getPrototypeOf(value) !== Object.prototype) return value;
   const mapped: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(record)) mapped[key] = resolveEntryRefs(item, self, deps, `${where}.${key}`);
+  for (const [key, item] of Object.entries(record)) mapped[key] = resolveEntryRefs(item, self, options, `${where}.${key}`);
   return mapped;
 }
 
 /** Rebuild the slim table from a reflected type-road table graph. The result
  *  is a normal slim table: hand it to materializeRtTable (which is what the
  *  dialect tableFromType wrappers do). */
-export function buildRtTableFromGraph(graph: ReflectedNode, buildTable: BuildTableFn, deps?: TableFromTypeDeps): object {
+export function buildRtTableFromGraph(graph: ReflectedNode, buildTable: BuildTableFn, options?: TableFromTypeOptions): object {
   const metaMember = memberNamed(graph, '@rtTableKey');
   if (!metaMember?.child) {
-    fail('the reflected type is not a table — declare it with the dialect table type (PgTable<Name, Cols>, ...)');
+    fail(
+      'the reflected type is not a table — declare it with the dialect table type (PgTable<Name, Cols>, ...); ' +
+        'on a marker call, did you forget the explicit type argument (tableFromType<UsersTable>(...))?'
+    );
   }
   const meta = metaMember.child;
   const nameNode = plainMember(meta, 'name')?.child;
@@ -258,6 +316,7 @@ export function buildRtTableFromGraph(graph: ReflectedNode, buildTable: BuildTab
   if (columnsNode?.children === undefined) fail(`table "${tableName}" has no columns record`);
 
   const columns: Record<string, unknown> = {};
+  const consumedRuntime = new Set<string>();
   for (const columnMember of columnsNode.children) {
     const key = columnMember.name;
     if (typeof key !== 'string' || columnMember.child === undefined) continue;
@@ -266,9 +325,10 @@ export function buildRtTableFromGraph(graph: ReflectedNode, buildTable: BuildTab
     if (spec.name !== undefined) args.push(spec.name);
     if (spec.config !== undefined) args.push(spec.config);
     const recorder = new RtColumnRecorder((context) => context.ns[spec.fn](...(args as never[])));
-    applyMods(recorder, columnMember.child, key, deps);
+    applyMods(recorder, columnMember.child, key, options, consumedRuntime);
     columns[key] = recorder;
   }
+  checkRuntimeLeftovers(options, consumedRuntime);
   const entries = readEntries(meta, tableName);
   const extraConfig =
     entries.length === 0
@@ -276,12 +336,12 @@ export function buildRtTableFromGraph(graph: ReflectedNode, buildTable: BuildTab
       : (self: Record<string, unknown>) =>
           entries.map((entry, index) => {
             const where = `table "${tableName}" extras[${index}]`;
-            const recorder = new RtEntryRecorder(entry.fn, resolveEntryRefs(entry.args, self, deps, where) as unknown[]);
+            const recorder = new RtEntryRecorder(entry.fn, resolveEntryRefs(entry.args, self, options, where) as unknown[]);
             const chainable = recorder as unknown as Record<string, (...chainArgs: unknown[]) => unknown>;
             for (const {method, args: chainArgs} of entry.chain) {
               if (typeof chainable[method] !== 'function') fail(`${where}: unknown chain method "${method}"`);
               if (chainArgs === true) chainable[method]();
-              else chainable[method](...(resolveEntryRefs(chainArgs, self, deps, `${where}.${method}`) as unknown[]));
+              else chainable[method](...(resolveEntryRefs(chainArgs, self, options, `${where}.${method}`) as unknown[]));
             }
             return recorder;
           });

--- a/packages/drizzle-orm/src/fromType.ts
+++ b/packages/drizzle-orm/src/fromType.ts
@@ -12,10 +12,10 @@
 // the rtColSpec/rtColMods sentinels as literal types — so the rebuilt table
 // materializes into exactly the drizzle table the builder road produces.
 //
-// This module imports NOTHING from @ts-runtypes/core at runtime: callers
-// resolve the graph (the dialects' tableFromType marker overload, or an
-// explicit getRunType<UsersTable>() call) and the walker reads the plain node
-// objects structurally, so @mionjs/drizzle-orm itself stays core-free.
+// This module imports NOTHING from @ts-runtypes/core at runtime: the
+// dialects' tableFromType resolves the graph (via its injected type argument)
+// and the walker reads the plain node objects structurally, so
+// @mionjs/drizzle-orm itself stays core-free.
 
 import {RtColumnRecorder, RtEntryRecorder, sql} from './recorder.ts';
 import type {AnyRtColumn, ColDataOf} from './recorder.ts';
@@ -37,10 +37,8 @@ export type RuntimeCallbacks<T extends AnyRtTable> = {
 
 /** Runtime inputs a type-defined table cannot carry in the type: the tables
  *  its References modifiers point at (keyed by DB table name) and the
- *  runtime-callback modifiers. ⚠ Every member MUST stay optional: the weak-type
- *  check is what keeps the `(runType, options?)` and `(options?, id?)`
- *  tableFromType overloads disjoint — a required member would silently break
- *  overload resolution at every marker call site. */
+ *  runtime-callback modifiers. Every member stays optional: a plain
+ *  tableFromType<T>() call with no options is the common case. */
 export interface TableFromTypeOptions<T extends AnyRtTable = AnyRtTable> {
   tables?: Record<string, object>;
   runtime?: RuntimeCallbacks<T>;

--- a/packages/drizzle-orm/src/index.ts
+++ b/packages/drizzle-orm/src/index.ts
@@ -44,7 +44,7 @@ export {
 } from './recorder.ts';
 
 // Table core.
-export type {AnyRtTable, BuildTableFn, ColsOf, RtTable, RtTableMeta, TableNameOf} from './table.ts';
+export type {AnyRtTable, BuildTableFn, ColsOf, RtTable, RtTableMeta, RtTableMetaWithExtras, TableNameOf} from './table.ts';
 export {createRtTable, materializeRtTable} from './table.ts';
 
 // Pure-types vocabulary core: the column spec/modifier sentinels and the

--- a/packages/drizzle-orm/src/index.ts
+++ b/packages/drizzle-orm/src/index.ts
@@ -50,6 +50,10 @@ export {createRtTable, materializeRtTable} from './table.ts';
 // Pure-types vocabulary core: the column spec/modifier sentinels and the
 // normalization the dialect table wrappers (PgTable, ...) apply.
 export type {
+  $Default,
+  $DefaultFn,
+  $OnUpdate,
+  $OnUpdateFn,
   $Type,
   AnyRtColType,
   Autoincrement,
@@ -81,7 +85,7 @@ export {rtColModsKey, rtColSpecKey, rtEntrySpecKey, rtSqlTextKey} from './typeCo
 
 // Pure-types runtime bridge: rebuilds a slim table from a reflected type-road
 // table graph (the dialect packages' tableFromType wrappers build on it).
-export type {ReflectedNode, TableFromTypeDeps} from './fromType.ts';
+export type {ReflectedNode, RuntimeCallbacks, TableFromTypeOptions} from './fromType.ts';
 export {buildRtTableFromGraph} from './fromType.ts';
 
 // Flat models.

--- a/packages/drizzle-orm/src/refine.ts
+++ b/packages/drizzle-orm/src/refine.ts
@@ -37,7 +37,9 @@ export type RtRefinedColumn<
 type RefineCols<Cols, R> = {
   [K in keyof Cols]: K extends keyof R
     ? R[K] extends object
-      ? RtRefinedColumn<
+      ? // RtColumnBrand spelled directly (not the RtRefinedColumn alias): one
+        // fewer alias instantiation per refined column, type-budget sensitive.
+        RtColumnBrand<
           MergeFormat<ColDataOf<Cols[K]>, R[K]>,
           ColNotNullOf<Cols[K]>,
           ColHasDefaultOf<Cols[K]>,
@@ -46,8 +48,11 @@ type RefineCols<Cols, R> = {
       : Cols[K]
     : Cols[K];
 };
-/** The same table retyped: refined columns carry the merged format params. */
-export type RefinedTable<T extends AnyRtTable, R> = RtTable<TableNameOf<T>, RefineCols<ColsOf<T>, R>>;
+/** The same table retyped: refined columns carry the merged format params.
+ *  This is the type road's refine — `type ApiUsersTable =
+ *  RefinedTable<UsersTable, {name: {maxLength: 50}}>` — with R constrained so
+ *  a typo'd column or an unrefinable param is a compile error. */
+export type RefinedTable<T extends AnyRtTable, R extends TableRefinements<T>> = RtTable<TableNameOf<T>, RefineCols<ColsOf<T>, R>>;
 
 /** Tighten a table's column types for the API (stricter than the database):
  *  plain per-column format params, merged into the captured ones (refinement

--- a/packages/drizzle-orm/src/table.ts
+++ b/packages/drizzle-orm/src/table.ts
@@ -28,6 +28,15 @@ export interface RtTableMeta<TName extends string, Cols> {
   name: TName;
   columns: Cols;
 }
+/** The meta of a dialect table wrapper (PgTable, ...): RtTableMeta plus the
+ *  extras tuple of the extraConfig road. One flat interface rather than
+ *  `RtTableMeta & {extras}` so a declared table pays a single object at the
+ *  meta key instead of an intersection (type-budget sensitive). */
+export interface RtTableMetaWithExtras<TName extends string, Cols, Extras extends readonly object[]> {
+  name: TName;
+  columns: Cols;
+  extras: Extras;
+}
 /** A slim table: the columns as properties plus the metadata brand. */
 export type RtTable<TName extends string, Cols> = Cols & {readonly [rtTableKey]: RtTableMeta<TName, Cols>};
 export type AnyRtTable = {readonly [rtTableKey]: RtTableMeta<string, Record<string, AnyRtColumn>>};

--- a/packages/drizzle-orm/src/typeColumns.ts
+++ b/packages/drizzle-orm/src/typeColumns.ts
@@ -142,6 +142,29 @@ export interface References<
 export interface $Type<Override> {
   readonly [rtColModsKey]?: {$type: [Override]};
 }
+// The runtime-callback modifiers ($default/$defaultFn and $onUpdate/$onUpdateFn
+// are drizzle aliases; the marker keeps the exact method so convert round-trips
+// byte-identically). A callback has no type spelling, so the marker stores only
+// the flag; the callback itself rides tableFromType's options
+// (`{runtime: {colKey: {$defaultFn: () => ...}}}`) and the bridge validates
+// marker and callback match both ways. All four set HasDefault, mirroring the
+// builder recorders.
+/** `.$default(cb)`. */
+export interface $Default {
+  readonly [rtColModsKey]?: {$default: true};
+}
+/** `.$defaultFn(cb)`. */
+export interface $DefaultFn {
+  readonly [rtColModsKey]?: {$defaultFn: true};
+}
+/** `.$onUpdate(cb)`. */
+export interface $OnUpdate {
+  readonly [rtColModsKey]?: {$onUpdate: true};
+}
+/** `.$onUpdateFn(cb)`. */
+export interface $OnUpdateFn {
+  readonly [rtColModsKey]?: {$onUpdateFn: true};
+}
 
 // ── Table-level entries (the extraConfig road) ───────────────────────────────
 
@@ -186,12 +209,22 @@ type ModNotNull<C, Mods> =
     : HasAnyKey<Mods, 'notNull' | 'primaryKey' | 'generatedAlwaysAsIdentity' | 'generatedByDefaultAsIdentity'>;
 // onUpdateNow mirrors the mysql builder (`.onUpdateNow()` sets HasDefault);
 // sqlite's `.primaryKey({autoIncrement: true})` gains a database default too.
+// The four $-runtime markers mirror the recorder kinds: all set HasDefault.
 type ModHasDefault<C, Mods> =
   BaseFlag<C, 'hasDefault'> extends true
     ? true
     : HasAnyKey<
           Mods,
-          'default' | 'defaultNow' | 'defaultRandom' | 'generatedByDefaultAsIdentity' | 'autoincrement' | 'onUpdateNow'
+          | 'default'
+          | 'defaultNow'
+          | 'defaultRandom'
+          | 'generatedByDefaultAsIdentity'
+          | 'autoincrement'
+          | 'onUpdateNow'
+          | '$default'
+          | '$defaultFn'
+          | '$onUpdate'
+          | '$onUpdateFn'
         > extends true
       ? true
       : Mods extends {primaryKey: [{autoIncrement: true}]}

--- a/packages/drizzle-orm/src/typeColumns.ts
+++ b/packages/drizzle-orm/src/typeColumns.ts
@@ -18,7 +18,7 @@
 // (builder fn, db column name, config, modifiers) and tableFromType / the Go
 // convert program can rebuild the builder calls from the type alone.
 
-import type {RtColumnBrand} from './recorder.ts';
+import type {AnyRtColumn, RtColumnBrand} from './recorder.ts';
 
 /** Sentinel key of the column spec (builder fn, db name, config, data). */
 export const rtColSpecKey: unique symbol = Symbol('rtColSpec');
@@ -261,5 +261,11 @@ export type NormalizeCol<C> = RtTypedColumn<
 >;
 
 /** Normalize a whole authored columns record; what the dialect table wrappers
- *  (PgTable, MysqlTable, SqliteTable) feed into RtTable. */
-export type TypedCols<Cols> = {[K in keyof Cols]: NormalizeCol<Cols[K]>};
+ *  (PgTable, MysqlTable, SqliteTable) feed into RtTable. A record of
+ *  already-branded builder columns passes through WHOLESALE (one record-level
+ *  check, no per-column mapping) — that is what lets the builder factories
+ *  declare the dialect table types as their returns without paying the
+ *  normalization on every declared table. The probe works because only
+ *  builder columns carry the rtColumnKey brand as a common property; a
+ *  type-road record fails the weak-type check and takes the mapped branch. */
+export type TypedCols<Cols> = Cols extends Record<string, AnyRtColumn> ? Cols : {[K in keyof Cols]: NormalizeCol<Cols[K]>};

--- a/packages/examples/src/_homepage/home-drizzle.ts
+++ b/packages/examples/src/_homepage/home-drizzle.ts
@@ -3,7 +3,7 @@ import type {InferSelectModel} from '@mionjs/drizzle-orm';
 import {createValidateFn} from '@ts-runtypes/core';
 // @annotate: Declare drizzle tables as usual, with the column builders from @mionjs/drizzle-orm-pg-core
 
-const usersRT = DB.pgTable('users', {
+const users = DB.pgTable('users', {
   id: DB.uuid('id').primaryKey().defaultRandom(),
   name: DB.varchar('name', {length: 100}).notNull(),
   age: DB.integer('age').notNull(),
@@ -11,7 +11,7 @@ const usersRT = DB.pgTable('users', {
 });
 // @annotate: The inferred model carries formats, not plain primitives: UUID, String<{maxLength: 100}>, Int32
 
-type User = InferSelectModel<typeof usersRT>;
+type User = InferSelectModel<typeof users>;
 // @annotate: The compiled validator enforces every captured param with no runtime guards
 
 export const validateUser = createValidateFn<User>();

--- a/packages/examples/src/drizzle/drizzle-model-types.ts
+++ b/packages/examples/src/drizzle/drizzle-model-types.ts
@@ -3,7 +3,7 @@
 import * as DB from '@mionjs/drizzle-orm-pg-core';
 import type {InferInsertModel, InferSelectModel, InferUpdateModel} from '@mionjs/drizzle-orm';
 
-export const usersRT = DB.pgTable('users', {
+export const users = DB.pgTable('users', {
   id: DB.uuid('id').primaryKey().defaultRandom(),
   email: DB.varchar('email', {length: 254}).notNull(),
   name: DB.varchar('name', {length: 100}).notNull(),
@@ -12,13 +12,13 @@ export const usersRT = DB.pgTable('users', {
 });
 
 // What a select returns: every key present, bio comes back as value | null:
-export type User = InferSelectModel<typeof usersRT>;
+export type User = InferSelectModel<typeof users>;
 
 // id and createdAt have DB defaults, so inserts may omit them:
-export type NewUser = InferInsertModel<typeof usersRT>;
+export type NewUser = InferInsertModel<typeof users>;
 
 // Update payloads accept any subset of the insert payload:
-export type UserPatch = InferUpdateModel<typeof usersRT>;
+export type UserPatch = InferUpdateModel<typeof users>;
 
 // A route input typed NewUser enforces the captured varchar lengths, and the
 // payload flows straight into db.insert(...).values(payload) with no casting.

--- a/packages/examples/src/drizzle/drizzle-proxy-mysql-example.ts
+++ b/packages/examples/src/drizzle/drizzle-proxy-mysql-example.ts
@@ -5,14 +5,14 @@ import type {InferSelectModel} from '@mionjs/drizzle-orm';
 import {createValidateFn} from '@ts-runtypes/core';
 
 // A recorded table, NOT drizzle's MySqlTable type: toDrizzle() builds that on demand.
-export const devicesRT = DB.mysqlTable('devices', {
+export const devices = DB.mysqlTable('devices', {
   serialNo: DB.varchar('serial_no', {length: 12}).notNull(),
   views: DB.int('views', {unsigned: true}).notNull(), // UInt32: 0 to 4294967295
   offsetC: DB.tinyint('offset_c').notNull(), // Int8: -128 to 127
   builtIn: DB.year('built_in').notNull(), // 1901 to 2155
 });
 
-export type Device = InferSelectModel<typeof devicesRT>;
+export type Device = InferSelectModel<typeof devices>;
 
 export const validateDevice = createValidateFn<Device>();
 

--- a/packages/examples/src/drizzle/drizzle-proxy-pg-example.ts
+++ b/packages/examples/src/drizzle/drizzle-proxy-pg-example.ts
@@ -6,7 +6,7 @@ import {createValidateFn} from '@ts-runtypes/core';
 
 // A recorded table, NOT drizzle's PgTable type: DB.pgTable records the calls,
 // and toDrizzle() builds the real drizzle table from them on demand.
-export const usersRT = DB.pgTable('users', {
+export const users = DB.pgTable('users', {
   id: DB.uuid('id').primaryKey(),
   name: DB.varchar('name', {length: 100}).notNull(),
   age: DB.integer('age').notNull(),
@@ -16,7 +16,7 @@ export const usersRT = DB.pgTable('users', {
 
 // The inferred model carries format types, not plain string/number:
 // { id: UUID; name: String<{maxLength: 100}>; age: Int32; role: 'admin' | 'user'; createdAt: Date }
-export type User = InferSelectModel<typeof usersRT>;
+export type User = InferSelectModel<typeof users>;
 
 // The compiled validator enforces every captured param with no runtime guards
 export const validateUser = createValidateFn<User>();

--- a/packages/examples/src/drizzle/drizzle-proxy-sqlite-example.ts
+++ b/packages/examples/src/drizzle/drizzle-proxy-sqlite-example.ts
@@ -5,14 +5,14 @@ import type {InferSelectModel} from '@mionjs/drizzle-orm';
 import {createValidateFn} from '@ts-runtypes/core';
 
 // A recorded table, NOT drizzle's SQLiteTable type: toDrizzle() builds that on demand.
-export const notesRT = DB.sqliteTable('notes', {
+export const notes = DB.sqliteTable('notes', {
   id: DB.integer('id').primaryKey(),
   title: DB.text('title', {length: 80}).notNull(),
   rating: DB.real('rating').notNull(),
   createdAt: DB.integer('created_at', {mode: 'timestamp'}).notNull(),
 });
 
-export type Note = InferSelectModel<typeof notesRT>;
+export type Note = InferSelectModel<typeof notes>;
 
 export const validateNote = createValidateFn<Note>();
 

--- a/packages/examples/src/drizzle/drizzle-refine-example.ts
+++ b/packages/examples/src/drizzle/drizzle-refine-example.ts
@@ -8,7 +8,7 @@ import type {InferInsertModel, InferSelectModel, InferUpdateModel} from '@mionjs
 import {createJsonDecoderFn, createJsonEncoderFn, createMockDataFn, createValidateFn} from '@ts-runtypes/core';
 
 // A recorded table, NOT drizzle's PgTable type: toDrizzle() builds that on demand.
-export const usersRT = DB.pgTable('users', {
+export const users = DB.pgTable('users', {
   id: DB.uuid('id').primaryKey().defaultRandom(),
   name: DB.varchar('name', {length: 100}).notNull(), // captured as String<{maxLength: 100}>
   age: DB.integer('age').notNull(),
@@ -16,11 +16,11 @@ export const usersRT = DB.pgTable('users', {
 });
 
 // Same table object back, types tightened: the API asks for more than the DB.
-export const apiUsersRT = refineTableType(usersRT, {name: {minLength: 10}, age: {min: 18}});
+export const apiUsers = refineTableType(users, {name: {minLength: 10}, age: {min: 18}});
 
-export type User = InferSelectModel<typeof apiUsersRT>; // name: String<{maxLength: 100, minLength: 10}>
-export type NewUser = InferInsertModel<typeof apiUsersRT>; // id and createdAt optional (DB defaults)
-export type UserPatch = InferUpdateModel<typeof apiUsersRT>; // any subset of the insert payload
+export type User = InferSelectModel<typeof apiUsers>; // name: String<{maxLength: 100, minLength: 10}>
+export type NewUser = InferInsertModel<typeof apiUsers>; // id and createdAt optional (DB defaults)
+export type UserPatch = InferUpdateModel<typeof apiUsers>; // any subset of the insert payload
 
 // Validate, mock, serialize, deserialize: all compiled from the types.
 export const validateUser = createValidateFn<User>();

--- a/packages/examples/src/drizzle/drizzle-to-drizzle-example.ts
+++ b/packages/examples/src/drizzle/drizzle-to-drizzle-example.ts
@@ -5,11 +5,11 @@
 import {gte} from 'drizzle-orm';
 import {drizzle} from 'drizzle-orm/pg-proxy';
 import {toDrizzle} from '@mionjs/drizzle-orm-pg-core/drizzle';
-import {usersRT, type User} from './drizzle-proxy-pg-example.ts';
+import {users, type User} from './drizzle-proxy-pg-example.ts';
 
 // A genuine drizzle table: queries, relations, getTableConfig and drizzle-kit
 // migrations all work on it. A drizzle-kit schema file just exports this.
-export const users = toDrizzle(usersRT);
+export const usersDb = toDrizzle(users);
 
 // Any drizzle driver works here; the callback driver keeps the example
 // self-contained (swap in node-postgres, pglite, neon... in a real app).
@@ -17,5 +17,5 @@ const db = drizzle(async () => ({rows: []}));
 
 export async function listAdults(): Promise<User[]> {
   // Fully typed rows with the formats intact: the same User the routes use.
-  return db.select().from(users).where(gte(users.age, 18));
+  return db.select().from(usersDb).where(gte(usersDb.age, 18));
 }

--- a/packages/examples/src/drizzle/drizzle-types-model-types.ts
+++ b/packages/examples/src/drizzle/drizzle-types-model-types.ts
@@ -3,7 +3,7 @@
 import * as DB from '@mionjs/drizzle-orm-pg-core';
 import type {InferInsertModel, InferSelectModel, InferUpdateModel} from '@mionjs/drizzle-orm';
 
-export type UsersRT = DB.PgTable<
+export type UsersTable = DB.PgTable<
   'users',
   {
     id: DB.Uuid<'id'> & DB.PrimaryKey & DB.DefaultRandom;
@@ -15,13 +15,13 @@ export type UsersRT = DB.PgTable<
 >;
 
 // What a select returns: every key present, bio comes back as value | null:
-export type User = InferSelectModel<UsersRT>;
+export type User = InferSelectModel<UsersTable>;
 
 // id and createdAt have DB defaults, so inserts may omit them:
-export type NewUser = InferInsertModel<UsersRT>;
+export type NewUser = InferInsertModel<UsersTable>;
 
 // Update payloads accept any subset of the insert payload:
-export type UserPatch = InferUpdateModel<UsersRT>;
+export type UserPatch = InferUpdateModel<UsersTable>;
 
 // A route input typed NewUser enforces the captured varchar lengths, and the
 // payload flows straight into db.insert(...).values(payload) with no casting.

--- a/packages/examples/src/drizzle/drizzle-types-mysql-example.ts
+++ b/packages/examples/src/drizzle/drizzle-types-mysql-example.ts
@@ -3,9 +3,9 @@
 // length, unsigned) live in the type itself and reach the validators.
 import * as DB from '@mionjs/drizzle-orm-mysql-core';
 import type {InferSelectModel} from '@mionjs/drizzle-orm';
-import {createValidateFn, getRunType} from '@ts-runtypes/core';
+import {createValidateFn} from '@ts-runtypes/core';
 
-export type DevicesRT = DB.MysqlTable<
+export type DevicesTable = DB.MysqlTable<
   'devices',
   {
     serialNo: DB.Varchar<'serial_no', {length: 12}> & DB.NotNull;
@@ -16,9 +16,9 @@ export type DevicesRT = DB.MysqlTable<
 >;
 
 // The recorded table back from the type: toDrizzle works on it unchanged.
-export const devicesRT = DB.tableFromType<DevicesRT>(getRunType<DevicesRT>());
+export const devices = DB.tableFromType<DevicesTable>();
 
-export type Device = InferSelectModel<DevicesRT>;
+export type Device = InferSelectModel<DevicesTable>;
 
 export const validateDevice = createValidateFn<Device>();
 

--- a/packages/examples/src/drizzle/drizzle-types-pg-example.ts
+++ b/packages/examples/src/drizzle/drizzle-types-pg-example.ts
@@ -4,10 +4,10 @@
 // varchar('name', {length: 100})) and modifiers intersect in.
 import * as DB from '@mionjs/drizzle-orm-pg-core';
 import type {InferSelectModel} from '@mionjs/drizzle-orm';
-import {createValidateFn, getRunType} from '@ts-runtypes/core';
+import {createValidateFn} from '@ts-runtypes/core';
 
 // The whole table is a type: nothing runs where it is declared.
-export type UsersRT = DB.PgTable<
+export type UsersTable = DB.PgTable<
   'users',
   {
     id: DB.Uuid<'id'> & DB.PrimaryKey;
@@ -19,12 +19,14 @@ export type UsersRT = DB.PgTable<
 >;
 
 // The recorded table back from the type: the same object pgTable returns, so
-// toDrizzle, drizzle-kit and refineTableType work on it unchanged.
-export const usersRT = DB.tableFromType<UsersRT>(getRunType<UsersRT>());
+// toDrizzle, drizzle-kit and refineTableType work on it unchanged. The build
+// resolves the type argument, so nothing is repeated and nothing else is
+// imported.
+export const users = DB.tableFromType<UsersTable>();
 
 // The inferred model is identical to the builder road, formats included, and
 // carries the exact same runtype id.
-export type User = InferSelectModel<UsersRT>;
+export type User = InferSelectModel<UsersTable>;
 
 // The compiled validator enforces every captured param with no runtime guards
 export const validateUser = createValidateFn<User>();

--- a/packages/examples/src/drizzle/drizzle-types-refine-example.ts
+++ b/packages/examples/src/drizzle/drizzle-types-refine-example.ts
@@ -5,9 +5,9 @@
 import * as DB from '@mionjs/drizzle-orm-pg-core';
 import {refineTableType} from '@mionjs/drizzle-orm';
 import type {InferInsertModel, InferSelectModel, InferUpdateModel} from '@mionjs/drizzle-orm';
-import {createJsonDecoderFn, createJsonEncoderFn, createMockDataFn, createValidateFn, getRunType} from '@ts-runtypes/core';
+import {createJsonDecoderFn, createJsonEncoderFn, createMockDataFn, createValidateFn} from '@ts-runtypes/core';
 
-export type UsersRT = DB.PgTable<
+export type UsersTable = DB.PgTable<
   'users',
   {
     id: DB.Uuid<'id'> & DB.PrimaryKey & DB.DefaultRandom;
@@ -16,14 +16,14 @@ export type UsersRT = DB.PgTable<
     createdAt: DB.Timestamp<'created_at', {mode: 'date'}> & DB.NotNull & DB.DefaultNow;
   }
 >;
-export const usersRT = DB.tableFromType<UsersRT>(getRunType<UsersRT>());
+export const users = DB.tableFromType<UsersTable>();
 
 // Same table object back, types tightened: the API asks for more than the DB.
-export const apiUsersRT = refineTableType(usersRT, {name: {minLength: 10}, age: {min: 18}});
+export const apiUsers = refineTableType(users, {name: {minLength: 10}, age: {min: 18}});
 
-export type User = InferSelectModel<typeof apiUsersRT>; // name: String<{maxLength: 100, minLength: 10}>
-export type NewUser = InferInsertModel<typeof apiUsersRT>; // id and createdAt optional (DB defaults)
-export type UserPatch = InferUpdateModel<typeof apiUsersRT>; // any subset of the insert payload
+export type User = InferSelectModel<typeof apiUsers>; // name: String<{maxLength: 100, minLength: 10}>
+export type NewUser = InferInsertModel<typeof apiUsers>; // id and createdAt optional (DB defaults)
+export type UserPatch = InferUpdateModel<typeof apiUsers>; // any subset of the insert payload
 
 // Validate, mock, serialize, deserialize: all compiled from the types.
 export const validateUser = createValidateFn<User>();

--- a/packages/examples/src/drizzle/drizzle-types-runtime-example.ts
+++ b/packages/examples/src/drizzle/drizzle-types-runtime-example.ts
@@ -1,0 +1,29 @@
+// Runtime column callbacks on the types road: a callback has no type spelling,
+// so the column carries a $ marker ($Default, $DefaultFn, $OnUpdate,
+// $OnUpdateFn) and the callback itself rides tableFromType's options. Model
+// types stay correct even in type-only files: every $ marker counts as a
+// database default, so the column turns optional on insert.
+import * as DB from '@mionjs/drizzle-orm-pg-core';
+import type {InferInsertModel} from '@mionjs/drizzle-orm';
+
+export type JobsTable = DB.PgTable<
+  'jobs',
+  {
+    id: DB.Uuid<'id'> & DB.PrimaryKey;
+    slug: DB.Varchar<'slug', {length: 80}> & DB.NotNull & DB.$DefaultFn;
+    updatedAt: DB.Timestamp<'updated_at', {mode: 'string'}> & DB.$OnUpdate;
+  }
+>;
+
+// The callbacks pair with the markers by column and name; a missing or extra
+// callback throws at startup naming the column, never silently.
+export const jobs = DB.tableFromType<JobsTable>({
+  runtime: {
+    slug: {$defaultFn: () => crypto.randomUUID().slice(0, 8)},
+    updatedAt: {$onUpdate: () => new Date().toISOString()},
+  },
+});
+
+// slug is notNull, but the $DefaultFn marker makes it optional on insert:
+export type NewJob = InferInsertModel<JobsTable>;
+export const minimalInsert: NewJob = {id: crypto.randomUUID()};

--- a/packages/examples/src/drizzle/drizzle-types-sqlite-example.ts
+++ b/packages/examples/src/drizzle/drizzle-types-sqlite-example.ts
@@ -3,9 +3,9 @@
 // modes map to the right formats (timestamp mode hydrates real Dates).
 import * as DB from '@mionjs/drizzle-orm-sqlite-core';
 import type {InferSelectModel} from '@mionjs/drizzle-orm';
-import {createValidateFn, getRunType} from '@ts-runtypes/core';
+import {createValidateFn} from '@ts-runtypes/core';
 
-export type NotesRT = DB.SqliteTable<
+export type NotesTable = DB.SqliteTable<
   'notes',
   {
     id: DB.Integer<'id'> & DB.PrimaryKey;
@@ -16,9 +16,9 @@ export type NotesRT = DB.SqliteTable<
 >;
 
 // The recorded table back from the type: toDrizzle works on it unchanged.
-export const notesRT = DB.tableFromType<NotesRT>(getRunType<NotesRT>());
+export const notes = DB.tableFromType<NotesTable>();
 
-export type Note = InferSelectModel<NotesRT>;
+export type Note = InferSelectModel<NotesTable>;
 
 export const validateNote = createValidateFn<Note>();
 

--- a/packages/examples/src/drizzle/drizzle-types-to-drizzle-example.ts
+++ b/packages/examples/src/drizzle/drizzle-types-to-drizzle-example.ts
@@ -1,15 +1,16 @@
-// The real drizzle table from a table written as a pure type: tableFromType
-// already rebuilt the recorded table (in drizzle-types-pg-example.ts), and
-// toDrizzle() replays it through drizzle itself exactly as on the builder
-// road. This is the ONE place drizzle-orm runs.
+// The real drizzle table straight from the table TYPE: toDrizzle<UsersTable>()
+// is the happy path for query and migration files. Only the type is imported,
+// so this file loads no code from the schema file, and the result is the same
+// memoized drizzle table the rest of the app shares. This is the ONE place
+// drizzle-orm runs.
 import {gte} from 'drizzle-orm';
 import {drizzle} from 'drizzle-orm/pg-proxy';
 import {toDrizzle} from '@mionjs/drizzle-orm-pg-core/drizzle';
-import {usersRT, type User} from './drizzle-types-pg-example.ts';
+import type {UsersTable, User} from './drizzle-types-pg-example.ts';
 
 // A genuine drizzle table: queries, relations, getTableConfig and drizzle-kit
 // migrations all work on it. A drizzle-kit schema file just exports this.
-export const users = toDrizzle(usersRT);
+export const usersDb = toDrizzle<UsersTable>();
 
 // Any drizzle driver works here; the callback driver keeps the example
 // self-contained (swap in node-postgres, pglite, neon... in a real app).
@@ -17,5 +18,5 @@ const db = drizzle(async () => ({rows: []}));
 
 export async function listAdults(): Promise<User[]> {
   // Fully typed rows with the formats intact: the same User the routes use.
-  return db.select().from(users).where(gte(users.age, 18));
+  return db.select().from(usersDb).where(gte(usersDb.age, 18));
 }

--- a/packages/type-budget/reports/lane-comparison.json
+++ b/packages/type-budget/reports/lane-comparison.json
@@ -8,14 +8,14 @@
         {
           "step": 1,
           "label": "slim table + row",
-          "delta": 487,
-          "budget": 493
+          "delta": 478,
+          "budget": 478
         },
         {
           "step": 2,
           "label": "refineTableType",
-          "delta": 1245,
-          "budget": 1245
+          "delta": 1198,
+          "budget": 1198
         },
         {
           "step": 3,
@@ -36,7 +36,7 @@
           "budget": 2541
         }
       ],
-      "total": 5527
+      "total": 5471
     },
     {
       "name": "type-only",

--- a/packages/type-budget/reports/lane-comparison.md
+++ b/packages/type-budget/reports/lane-comparison.md
@@ -20,12 +20,12 @@ report, paid only in the files that run queries.
 
 | Step | Layer | slim | type-only | builder |
 | ---: | ----- | ---: | ---: | ---: |
-| 1 | declare the formatted row | 487 | 47 | 576 |
-| 2 | refine two columns | 1245 | 393 | 384 |
+| 1 | declare the formatted row | 478 | 47 | 576 |
+| 2 | refine two columns | 1198 | 393 | 384 |
 | 3 | select / insert / update models | 673 | 254 | 262 |
 | 4 | mion route api | 581 | 510 | 506 |
 | 5 | initClient | 2541 | 2601 | 2817 |
-| | **Total** | **5527** | **3805** | **4545** |
+| | **Total** | **5471** | **3805** | **4545** |
 
 ## Reading this
 

--- a/packages/type-budget/reports/model-pipeline.json
+++ b/packages/type-budget/reports/model-pipeline.json
@@ -5,50 +5,50 @@
     {
       "step": 1,
       "label": "slim table + row",
-      "delta": 487,
-      "budget": 493,
-      "cumulative": 487
+      "delta": 478,
+      "budget": 478,
+      "cumulative": 478
     },
     {
       "step": 2,
       "label": "refineTableType",
-      "delta": 1245,
-      "budget": 1245,
-      "cumulative": 1732
+      "delta": 1198,
+      "budget": 1198,
+      "cumulative": 1676
     },
     {
       "step": 3,
       "label": "Infer* models",
       "delta": 673,
       "budget": 673,
-      "cumulative": 2405
+      "cumulative": 2349
     },
     {
       "step": 4,
       "label": "mion route api",
       "delta": 581,
       "budget": 581,
-      "cumulative": 2986
+      "cumulative": 2930
     },
     {
       "step": 5,
       "label": "initClient",
       "delta": 2541,
       "budget": 2541,
-      "cumulative": 5527
+      "cumulative": 5471
     },
     {
       "step": 6,
       "label": "db query (toDrizzle)",
       "delta": 7676,
       "budget": 7676,
-      "cumulative": 13203
+      "cumulative": 13147
     }
   ],
   "consumer": {
-    "budget": 1841,
-    "netInstantiations": 1841,
+    "budget": 1785,
+    "netInstantiations": 1785,
     "keepsGenericAlias": true,
-    "dtsBytes": 909
+    "dtsBytes": 1338
   }
 }

--- a/packages/type-budget/reports/model-pipeline.md
+++ b/packages/type-budget/reports/model-pipeline.md
@@ -11,14 +11,14 @@ carries no signal on its own. Budgets may only ever be lowered.
 
 | Step | Layer | Net instantiations added | Budget | Cumulative |
 | ---: | ----- | -----------------------: | -----: | ---------: |
-| 1 | slim table + row | 487 | 493 | 487 |
-| 2 | refineTableType | 1245 | 1245 | 1732 |
-| 3 | Infer* models | 673 | 673 | 2405 |
-| 4 | mion route api | 581 | 581 | 2986 |
-| 5 | initClient | 2541 | 2541 | 5527 |
-| 6 | db query (toDrizzle) | 7676 | 7676 | 13203 |
+| 1 | slim table + row | 478 | 478 | 478 |
+| 2 | refineTableType | 1198 | 1198 | 1676 |
+| 3 | Infer* models | 673 | 673 | 2349 |
+| 4 | mion route api | 581 | 581 | 2930 |
+| 5 | initClient | 2541 | 2541 | 5471 |
+| 6 | db query (toDrizzle) | 7676 | 7676 | 13147 |
 
-Total for the whole chain: **13203**.
+Total for the whole chain: **13147**.
 
 Every one of these is paid again on every keystroke. TypeScript memoises type
 instantiations within a single check, but each edit builds a new checker, so the
@@ -28,9 +28,9 @@ work is redone. Parsing is reused across edits; type instantiation is not.
 
 | What | Value |
 | ---- | ----: |
-| Consumer net instantiations | 1841 |
-| Budget | 1841 |
-| Emitted declaration size (bytes) | 909 |
+| Consumer net instantiations | 1785 |
+| Budget | 1785 |
+| Emitted declaration size (bytes) | 1338 |
 | Declaration keeps the generic alias unresolved | yes |
 
 Declaration emit prints the type alias as it was written, never the type it

--- a/packages/type-budget/test/modelPipelineHarness.ts
+++ b/packages/type-budget/test/modelPipelineHarness.ts
@@ -91,7 +91,7 @@ export interface PipelineStep {
 export const PIPELINE_STEPS: PipelineStep[] = [
   {
     label: '1 slim table + row',
-    budget: 493,
+    budget: 478,
     body: `
 const users = pgTable('users', {
   name: varchar('name', {length: 100}).notNull(),
@@ -107,7 +107,7 @@ export const plainWhen: Date = slimRow.createdAt;
   },
   {
     label: '2 + refineTableType',
-    budget: 1245,
+    budget: 1198,
     body: `
 const apiUsers = refineTableType(users, {name: {minLength: 10}, age: {min: 18}});
 type RefinedUser = InferSelectModel<typeof apiUsers>;
@@ -375,4 +375,4 @@ export function measureConsumerLane(): ConsumerLaneResult {
  *  emitted `.d.ts`. ONE-WAY DOWNWARD, same rule as the step budgets. The first
  *  seed (166) was an artifact: @mionjs/drizzle-orm did not resolve from this
  *  package, so the lane measured InferSelectModel<any>. **/
-export const CONSUMER_BUDGET = 1841;
+export const CONSUMER_BUDGET = 1785;

--- a/ts-go-runtypes/internal/convert/convert.go
+++ b/ts-go-runtypes/internal/convert/convert.go
@@ -62,8 +62,8 @@ const (
 	CodeTemporalNotLoaded  = "CNV007"
 	CodeUnresolvedTypeName = "CNV008"
 	// A drizzle table declaration using constructs with no type spelling
-	// (runtime-function modifiers, sql values, extraConfig, references,
-	// non-literal args) — see drizzle.go.
+	// (interpolated sql, $type, non-literal args, out-of-file or backward
+	// references) — see drizzle.go.
 	CodeDrizzleUnsupported = "CNV009"
 )
 

--- a/ts-go-runtypes/internal/convert/drizzle.go
+++ b/ts-go-runtypes/internal/convert/drizzle.go
@@ -3,10 +3,17 @@
 // resolved types (never by function name) and rewrites them between the
 // canonical pair spellings:
 //
-//	builders form                                type form
-//	const usersRT = DB.pgTable('users', {…});    type UsersRT = DB.PgTable<'users', {…}>;
-//	type UsersRT = typeof usersRT;               const usersRT = DB.tableFromType<UsersRT>(getRunType<UsersRT>());
+//	builders form                              type form
+//	const users = DB.pgTable('users', {…});    type UsersTable = DB.PgTable<'users', {…}>;
+//	type UsersTable = typeof users;            const users = DB.tableFromType<UsersTable>(options?);
 //
+// The emitted const uses the MARKER form (no getRunType call — the devtools
+// transform resolves the type argument); the explicit
+// `tableFromType(getRunType<T>(), options?)` escape hatch is still recognized
+// (pairing ignores the value arguments) and stays as written while already in
+// the target form. References ride the options object
+// (`{tables: {parents: parents}}` — evaluated eagerly, so a backward
+// reference refuses with a reorder message).
 // Both directions preserve the VALUE (the const) and the TYPE name, so every
 // use keeps working; the two halves always print together (canonical pair).
 // The vocabulary is never a Go name table: builder fn names ride the type
@@ -272,6 +279,19 @@ type drizzleTableSpec struct {
 	tableName string
 	columns   []drizzleColumn
 	entries   []drizzleEntry
+	// DB table names this table references (columns + entries, first-seen
+	// order): what the type form's `{tables: {...}}` option must carry.
+	refTables []string
+}
+
+// addRefTable records a referenced DB table name once, in first-seen order.
+func (spec *drizzleTableSpec) addRefTable(tableName string) {
+	for _, existing := range spec.refTables {
+		if existing == tableName {
+			return
+		}
+	}
+	spec.refTables = append(spec.refTables, tableName)
 }
 
 func drizzleRefuse(decl *declaration, format string, args ...any) *Diagnostic {
@@ -437,7 +457,7 @@ func specFromBuildersAST(source string, decl *declaration, typeChecker *checker.
 	}
 	spec := &drizzleTableSpec{alias: nsIdent.Text(), tableFn: tableFn, tableName: nameArg.Text()}
 	if len(call.Arguments.Nodes) == 3 {
-		entries, entriesDiag := entriesFromExtraConfigAST(source, decl, call.Arguments.Nodes[2], nsIdent.Text(), typeChecker, tableNames)
+		entries, entriesDiag := entriesFromExtraConfigAST(source, decl, call.Arguments.Nodes[2], spec, typeChecker, tableNames)
 		if entriesDiag != nil {
 			return nil, nil, entriesDiag
 		}
@@ -457,6 +477,11 @@ func specFromBuildersAST(source string, decl *declaration, typeChecker *checker.
 			return nil, nil, diag
 		}
 		column.key = keyNode.Text()
+		for _, mod := range column.mods {
+			if mod.isReference {
+				spec.addRefTable(mod.refTable)
+			}
+		}
 		spec.columns = append(spec.columns, *column)
 	}
 	return spec, nsIdent, nil
@@ -559,8 +584,11 @@ func columnFromChain(source string, decl *declaration, expr *ast.Node, alias str
 
 // entryArgTexts renders one extraConfig argument in BOTH modes: the canonical
 // TYPE spelling ({col: 'a'}, {table: 'p', col: 'id'}, Sql<'...'>, literals)
-// and the canonical BUILDERS spelling (t.a, parentsRT.id, sql`...`).
-func entryArgTexts(source string, decl *declaration, node *ast.Node, alias string, paramName string, typeChecker *checker.Checker, fileInfo *drizzleFileInfo) (string, string, *Diagnostic) {
+// and the canonical BUILDERS spelling (t.a, parents.id, sql`...`). A
+// cross-table reference also lands in spec.refTables (the type form's tables
+// option needs it).
+func entryArgTexts(source string, decl *declaration, node *ast.Node, spec *drizzleTableSpec, paramName string, typeChecker *checker.Checker, fileInfo *drizzleFileInfo) (string, string, *Diagnostic) {
+	alias := spec.alias
 	if sqlText, ok := sqlTemplateText(node, typeChecker); ok {
 		valueText := ""
 		if fileInfo.sqlSpelling != "" {
@@ -577,6 +605,7 @@ func entryArgTexts(source string, decl *declaration, node *ast.Node, alias strin
 				return "{col: " + quoteSingle(key) + "}", "t." + key, nil
 			}
 			if tableName, ok := fileInfo.tableNameByConst[base]; ok {
+				spec.addRefTable(tableName)
 				return "{table: " + quoteSingle(tableName) + ", col: " + quoteSingle(key) + "}", base + "." + key, nil
 			}
 		}
@@ -585,7 +614,7 @@ func entryArgTexts(source string, decl *declaration, node *ast.Node, alias strin
 	if node.Kind == ast.KindArrayLiteralExpression {
 		var typeItems, valueItems []string
 		for _, element := range node.AsArrayLiteralExpression().Elements.Nodes {
-			typeText, valueText, diag := entryArgTexts(source, decl, element, alias, paramName, typeChecker, fileInfo)
+			typeText, valueText, diag := entryArgTexts(source, decl, element, spec, paramName, typeChecker, fileInfo)
 			if diag != nil {
 				return "", "", diag
 			}
@@ -605,7 +634,7 @@ func entryArgTexts(source string, decl *declaration, node *ast.Node, alias strin
 			if nameNode == nil {
 				return "", "", drizzleRefuse(decl, "extraConfig: unnamed config member")
 			}
-			typeText, valueText, diag := entryArgTexts(source, decl, assignment.Initializer, alias, paramName, typeChecker, fileInfo)
+			typeText, valueText, diag := entryArgTexts(source, decl, assignment.Initializer, spec, paramName, typeChecker, fileInfo)
 			if diag != nil {
 				return "", "", diag
 			}
@@ -623,7 +652,7 @@ func entryArgTexts(source string, decl *declaration, node *ast.Node, alias strin
 
 // entriesFromExtraConfigAST parses the table call's third argument — an arrow
 // callback returning an array literal of helper chains.
-func entriesFromExtraConfigAST(source string, decl *declaration, node *ast.Node, alias string, typeChecker *checker.Checker, tableNames map[string]string) ([]drizzleEntry, *Diagnostic) {
+func entriesFromExtraConfigAST(source string, decl *declaration, node *ast.Node, spec *drizzleTableSpec, typeChecker *checker.Checker, tableNames map[string]string) ([]drizzleEntry, *Diagnostic) {
 	fileInfo := &drizzleFileInfo{tableNameByConst: tableNames}
 	if node == nil || node.Kind != ast.KindArrowFunction {
 		return nil, drizzleRefuse(decl, "extraConfig must be an arrow callback returning an array of entries")
@@ -643,7 +672,7 @@ func entriesFromExtraConfigAST(source string, decl *declaration, node *ast.Node,
 	fileInfo.sqlSpelling = ""
 	var entries []drizzleEntry
 	for _, element := range body.AsArrayLiteralExpression().Elements.Nodes {
-		entry, diag := entryFromChainAST(source, decl, element, alias, paramName, typeChecker, fileInfo)
+		entry, diag := entryFromChainAST(source, decl, element, spec, paramName, typeChecker, fileInfo)
 		if diag != nil {
 			return nil, diag
 		}
@@ -653,7 +682,7 @@ func entriesFromExtraConfigAST(source string, decl *declaration, node *ast.Node,
 }
 
 // entryFromChainAST parses `NS.helper(args).m1(args)...` (outermost-last).
-func entryFromChainAST(source string, decl *declaration, expr *ast.Node, alias string, paramName string, typeChecker *checker.Checker, fileInfo *drizzleFileInfo) (*drizzleEntry, *Diagnostic) {
+func entryFromChainAST(source string, decl *declaration, expr *ast.Node, spec *drizzleTableSpec, paramName string, typeChecker *checker.Checker, fileInfo *drizzleFileInfo) (*drizzleEntry, *Diagnostic) {
 	var chain []drizzleEntryChain
 	current := expr
 	for {
@@ -669,7 +698,7 @@ func entryFromChainAST(source string, decl *declaration, expr *ast.Node, alias s
 		var argsType, argsValue []string
 		var argsDiag *Diagnostic
 		for _, argument := range call.Arguments.Nodes {
-			typeText, valueText, diag := entryArgTexts(source, decl, argument, alias, paramName, typeChecker, fileInfo)
+			typeText, valueText, diag := entryArgTexts(source, decl, argument, spec, paramName, typeChecker, fileInfo)
 			if diag != nil {
 				argsDiag = diag
 				break
@@ -680,7 +709,7 @@ func entryFromChainAST(source string, decl *declaration, expr *ast.Node, alias s
 		if argsDiag != nil {
 			return nil, argsDiag
 		}
-		if access.Expression != nil && ast.IsIdentifier(access.Expression) && access.Expression.Text() == alias {
+		if access.Expression != nil && ast.IsIdentifier(access.Expression) && access.Expression.Text() == spec.alias {
 			// The base helper call: reverse the collected chain into call order.
 			for left, right := 0, len(chain)-1; left < right; left, right = left+1, right-1 {
 				chain[left], chain[right] = chain[right], chain[left]
@@ -1129,7 +1158,7 @@ func collectModuleExports(prog *program.Program, modulePath string, names map[st
 // ── printers ─────────────────────────────────────────────────────────────────
 
 // printDrizzleType renders the canonical type-form pair from a spec.
-func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, constName string, exports map[string]bool, names *nameTable) (*printedDecl, *Diagnostic) {
+func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, constName string, exports map[string]bool, fileInfo *drizzleFileInfo) (*printedDecl, *Diagnostic) {
 	tableTypeName := upperFirst(spec.tableFn)
 	if !exports[tableTypeName] {
 		return nil, drizzleRefuse(decl, "the dialect module exports no table type %q", tableTypeName)
@@ -1174,6 +1203,30 @@ func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, const
 	if !exports["tableFromType"] {
 		return nil, drizzleRefuse(decl, "the dialect module exports no tableFromType")
 	}
+	// The tables option for References: `{tables: {<dbName>: <siblingConst>}}`.
+	// It is evaluated EAGERLY at the const, so the referenced table must be
+	// declared earlier in the file (the builders road's `() => parent.id`
+	// closure was lazy and allowed any order).
+	optionsText := ""
+	if len(spec.refTables) > 0 {
+		var tableEntries []string
+		for _, refTableName := range spec.refTables {
+			targetConst := fileInfo.constByTableName[refTableName]
+			if targetConst == "" {
+				return nil, drizzleRefuse(decl, "references table %q is not declared in this file", refTableName)
+			}
+			if fileInfo.posByTableName[refTableName] >= decl.Stmt.Pos() {
+				return nil, drizzleRefuse(decl,
+					"references table %q which is not declared earlier in the file — the type form's tables option is evaluated eagerly, reorder the declarations", refTableName)
+			}
+			key := refTableName
+			if !isPlainIdentifier(key) {
+				key = quoteSingle(key)
+			}
+			tableEntries = append(tableEntries, key+": "+targetConst)
+		}
+		optionsText = "{tables: {" + strings.Join(tableEntries, ", ") + "}}"
+	}
 	extrasText := ""
 	if len(spec.entries) > 0 {
 		if !exports["TableEntry"] {
@@ -1207,12 +1260,26 @@ func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, const
 		constPrefix = "export "
 	}
 	printed := &printedDecl{}
-	printed.needs.useGetRunType = true
 	printed.needs.keepLocal(spec.alias)
-	printed.text = fmt.Sprintf("%stype %s = %s.%s<%s, {\n%s\n}%s>;\n%sconst %s = %s.tableFromType<%s>(%s<%s>());",
+	printed.text = fmt.Sprintf("%stype %s = %s.%s<%s, {\n%s\n}%s>;\n%sconst %s = %s.tableFromType<%s>(%s);",
 		exportPrefix, typeName, spec.alias, tableTypeName, quoteSingle(spec.tableName), strings.Join(columns, "\n"), extrasText,
-		constPrefix, constName, spec.alias, typeName, names.GetRunType, typeName)
+		constPrefix, constName, spec.alias, typeName, optionsText)
 	return printed, nil
+}
+
+// isPlainIdentifier reports whether the text can stand as an unquoted object
+// key.
+func isPlainIdentifier(text string) bool {
+	if text == "" {
+		return false
+	}
+	for i, r := range text {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || r == '$'
+		if !isLetter && (i == 0 || r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
 }
 
 // printDrizzleBuilders renders the canonical builders-form pair from a spec.
@@ -1290,10 +1357,13 @@ type drizzlePlan struct {
 }
 
 // drizzleFileInfo carries the per-file lookups the drizzle arm shares across
-// declarations: const↔table-name maps (references) and the slim sql binding.
+// declarations: const↔table-name maps (references), the declaration position
+// per table name (the tables option's declared-earlier check) and the slim
+// sql binding.
 type drizzleFileInfo struct {
 	tableNameByConst map[string]string
 	constByTableName map[string]string
+	posByTableName   map[string]int
 	sqlSpelling      string
 }
 
@@ -1301,7 +1371,7 @@ const drizzleRootModule = "@mionjs/drizzle-orm"
 
 // buildDrizzleFileInfo scans the recognized declarations once per file.
 func buildDrizzleFileInfo(decls []*declaration, imports *importScan) *drizzleFileInfo {
-	info := &drizzleFileInfo{tableNameByConst: map[string]string{}, constByTableName: map[string]string{}}
+	info := &drizzleFileInfo{tableNameByConst: map[string]string{}, constByTableName: map[string]string{}, posByTableName: map[string]int{}}
 	for _, decl := range decls {
 		if !decl.Drizzle {
 			continue
@@ -1333,6 +1403,7 @@ func buildDrizzleFileInfo(decls []*declaration, imports *importScan) *drizzleFil
 		if tableName == "" {
 			continue
 		}
+		info.posByTableName[tableName] = decl.Stmt.Pos()
 		if decl.ConstName != "" {
 			info.tableNameByConst[decl.ConstName] = tableName
 			info.constByTableName[tableName] = decl.ConstName
@@ -1367,12 +1438,12 @@ func convertDrizzleDecl(prog *program.Program, typeChecker *checker.Checker, cac
 		}
 		typeName := decl.Name
 		if typeName == "" {
-			typeName = names.deriveTypeName(decl.ConstName)
+			typeName = names.deriveDrizzleTypeName(decl.ConstName)
 			if typeName == "" {
 				return nil, drizzleRefuse(decl, "no free type name for the pair")
 			}
 		}
-		return printDrizzleType(spec, decl, typeName, decl.ConstName, exports, names)
+		return printDrizzleType(spec, decl, typeName, decl.ConstName, exports, fileInfo)
 	}
 	// type → builders: the spec lives in the reflected graph; the alias and
 	// table type come from the alias declaration's type reference.
@@ -1408,7 +1479,7 @@ func convertDrizzleDecl(prog *program.Program, typeChecker *checker.Checker, cac
 	}
 	constName := decl.ConstName
 	if constName == "" {
-		constName = names.deriveConstName(decl.Name)
+		constName = names.deriveDrizzleConstName(decl.Name)
 		if constName == "" {
 			return nil, drizzleRefuse(decl, "no free const name for the pair")
 		}

--- a/ts-go-runtypes/internal/convert/drizzle.go
+++ b/ts-go-runtypes/internal/convert/drizzle.go
@@ -20,9 +20,9 @@
 // road's rtColSpec sentinel literals, type names are the first-letter
 // uppercase rule verified against the dialect module's REAL exports, and the
 // modifier vocabulary is whatever the builder's own return type / the mods
-// sentinel carries. Tables using constructs with no type spelling (runtime
-// function modifiers, sql values, extraConfig, references, non-literal args)
-// report CNV009 and stay untouched.
+// sentinel carries. Tables using constructs with no type spelling
+// (interpolated sql, $type, non-literal args, out-of-file or backward
+// references) report CNV009 and stay untouched.
 package convert
 
 import (

--- a/ts-go-runtypes/internal/convert/drizzle.go
+++ b/ts-go-runtypes/internal/convert/drizzle.go
@@ -237,7 +237,11 @@ func pairDrizzleDecls(decls []*declaration, typeofAliases map[string]*ast.Node, 
 
 // drizzleMod is one modifier call: the method name plus its rendered literal
 // arg texts (empty for a flag). A references mod carries its target
-// structurally instead (the two printers spell it differently).
+// structurally instead (the two printers spell it differently). A runtime
+// mod ($default/$defaultFn/$onUpdate/$onUpdateFn) carries its callback text
+// VERBATIM in args[0]: the type form spells the flag marker and moves the
+// callback into the const's options.runtime; the builders form puts it back
+// on the chain.
 type drizzleMod struct {
 	method      string
 	args        []string
@@ -245,6 +249,17 @@ type drizzleMod struct {
 	refColumn   string
 	refActions  string
 	isReference bool
+	isRuntime   bool
+}
+
+// drizzleMarkerName maps a modifier method onto its marker type name:
+// upperFirst, skipping the $ of the runtime methods ($defaultFn → $DefaultFn,
+// same rule $Type follows).
+func drizzleMarkerName(method string) string {
+	if strings.HasPrefix(method, "$") {
+		return "$" + upperFirst(method[1:])
+	}
+	return upperFirst(method)
 }
 
 // drizzleColumn is one column: record key, builder fn, the rendered db-name
@@ -535,8 +550,22 @@ func columnFromChain(source string, decl *declaration, expr *ast.Node, alias str
 		}
 		// A modifier call: record and step into the receiver.
 		method := access.Name().Text()
+		if method == "$type" {
+			return nil, drizzleRefuse(decl, "modifier $type has no chain spelling on the type road — author the table as a type and use the $Type marker")
+		}
 		if strings.HasPrefix(method, "$") {
-			return nil, drizzleRefuse(decl, "modifier %q is runtime-only and has no type spelling", method)
+			// Runtime-callback modifier: the callback moves VERBATIM into the
+			// emitted const's options.runtime; the type carries the flag marker
+			// (its existence is verified against the dialect exports at print).
+			callbackArgs := call.Arguments.Nodes
+			if len(callbackArgs) != 1 {
+				return nil, drizzleRefuse(decl, "modifier %q takes exactly one callback argument", method)
+			}
+			callbackNode := callbackArgs[0]
+			text := strings.TrimSpace(source[skipTrivia(source, callbackNode.Pos()):callbackNode.End()])
+			mods = append(mods, drizzleMod{method: method, isRuntime: true, args: []string{text}})
+			current = access.Expression
+			continue
 		}
 		if method == "references" {
 			refArgs := call.Arguments.Nodes
@@ -903,6 +932,18 @@ func specFromGraph(resolved *resolvedDecl, decl *declaration, alias string, tabl
 					column.mods = append(column.mods, mod)
 					continue
 				}
+				if modMember.Name == "$type" {
+					return nil, drizzleRefuse(decl, "column %q: the $Type override has no builders spelling — keep this table on the type road", columnMember.Name)
+				}
+				if strings.HasPrefix(modMember.Name, "$") {
+					// Runtime marker flag: the callback text is read off the
+					// paired const's options.runtime afterwards.
+					if valueNode.Kind != reflection.KindLiteral {
+						return nil, drizzleRefuse(decl, "column %q: malformed runtime marker %q", columnMember.Name, modMember.Name)
+					}
+					column.mods = append(column.mods, drizzleMod{method: modMember.Name, isRuntime: true})
+					continue
+				}
 				if valueNode.Kind == reflection.KindLiteral {
 					spec := drizzleMod{method: modMember.Name}
 					column.mods = append(column.mods, spec)
@@ -1181,7 +1222,7 @@ func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, const
 			text += "<" + strings.Join(typeArgs, ", ") + ">"
 		}
 		for _, mod := range column.mods {
-			markerName := upperFirst(mod.method)
+			markerName := drizzleMarkerName(mod.method)
 			if !exports[markerName] {
 				return nil, drizzleRefuse(decl, "modifier %q has no marker type %q in the dialect module", mod.method, markerName)
 			}
@@ -1193,8 +1234,10 @@ func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, const
 				text += ">"
 				continue
 			}
+			// A runtime mod spells the bare flag marker; its callback text goes
+			// into the options.runtime object below, never into the type.
 			text += " & " + spec.alias + "." + markerName
-			if len(mod.args) > 0 {
+			if !mod.isRuntime && len(mod.args) > 0 {
 				text += "<" + strings.Join(mod.args, ", ") + ">"
 			}
 		}
@@ -1203,11 +1246,12 @@ func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, const
 	if !exports["tableFromType"] {
 		return nil, drizzleRefuse(decl, "the dialect module exports no tableFromType")
 	}
-	// The tables option for References: `{tables: {<dbName>: <siblingConst>}}`.
-	// It is evaluated EAGERLY at the const, so the referenced table must be
-	// declared earlier in the file (the builders road's `() => parent.id`
-	// closure was lazy and allowed any order).
-	optionsText := ""
+	// The options object, canonical layout: `tables` first (References — it is
+	// evaluated EAGERLY at the const, so the referenced table must be declared
+	// earlier in the file; the builders road's `() => parent.id` closure was
+	// lazy and allowed any order), then `runtime` (the $ modifiers' callbacks,
+	// spec column order, chain method order).
+	var optionParts []string
 	if len(spec.refTables) > 0 {
 		var tableEntries []string
 		for _, refTableName := range spec.refTables {
@@ -1225,7 +1269,26 @@ func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, const
 			}
 			tableEntries = append(tableEntries, key+": "+targetConst)
 		}
-		optionsText = "{tables: {" + strings.Join(tableEntries, ", ") + "}}"
+		optionParts = append(optionParts, "tables: {"+strings.Join(tableEntries, ", ")+"}")
+	}
+	var runtimeEntries []string
+	for _, column := range spec.columns {
+		var callbackParts []string
+		for _, mod := range column.mods {
+			if mod.isRuntime && len(mod.args) == 1 {
+				callbackParts = append(callbackParts, mod.method+": "+mod.args[0])
+			}
+		}
+		if len(callbackParts) > 0 {
+			runtimeEntries = append(runtimeEntries, column.key+": {"+strings.Join(callbackParts, ", ")+"}")
+		}
+	}
+	if len(runtimeEntries) > 0 {
+		optionParts = append(optionParts, "runtime: {"+strings.Join(runtimeEntries, ", ")+"}")
+	}
+	optionsText := ""
+	if len(optionParts) > 0 {
+		optionsText = "{" + strings.Join(optionParts, ", ") + "}"
 	}
 	extrasText := ""
 	if len(spec.entries) > 0 {
@@ -1345,6 +1408,105 @@ func printDrizzleBuilders(spec *drizzleTableSpec, decl *declaration, typeName, c
 		exportPrefix, constName, spec.alias, spec.tableFn, quoteSingle(spec.tableName), strings.Join(columns, "\n"), extrasText,
 		aliasPrefix, typeName, constName)
 	return printed, nil
+}
+
+// readRuntimeCallbackTexts reads the paired const's options argument
+// (`tableFromType<T>({runtime: {...}})` — the explicit form's options ride
+// after the runType, so the first OBJECT-LITERAL argument is the bag) and
+// returns the verbatim callback texts per column key and method.
+func readRuntimeCallbackTexts(source string, decl *declaration) (map[string]map[string]string, *Diagnostic) {
+	texts := map[string]map[string]string{}
+	if decl.AliasStmt == nil {
+		return texts, nil
+	}
+	initializer := constInitializer(decl.AliasStmt)
+	if initializer == nil || initializer.Kind != ast.KindCallExpression {
+		return texts, nil
+	}
+	var optionsNode *ast.Node
+	for _, argument := range initializer.AsCallExpression().Arguments.Nodes {
+		if argument.Kind == ast.KindObjectLiteralExpression {
+			optionsNode = argument
+			break
+		}
+	}
+	if optionsNode == nil {
+		return texts, nil
+	}
+	for _, property := range optionsNode.AsObjectLiteralExpression().Properties.Nodes {
+		if property.Kind != ast.KindPropertyAssignment {
+			continue
+		}
+		assignment := property.AsPropertyAssignment()
+		nameNode := assignment.Name()
+		if nameNode == nil || nameNode.Text() != "runtime" || assignment.Initializer == nil {
+			continue
+		}
+		runtimeNode := assignment.Initializer
+		if runtimeNode.Kind != ast.KindObjectLiteralExpression {
+			return nil, drizzleRefuse(decl, "options.runtime must be a plain object literal")
+		}
+		for _, columnProperty := range runtimeNode.AsObjectLiteralExpression().Properties.Nodes {
+			if columnProperty.Kind != ast.KindPropertyAssignment {
+				return nil, drizzleRefuse(decl, "options.runtime entries must be plain `column: {method: callback}` members")
+			}
+			columnAssignment := columnProperty.AsPropertyAssignment()
+			columnName := columnAssignment.Name()
+			callbacksNode := columnAssignment.Initializer
+			if columnName == nil || callbacksNode == nil || callbacksNode.Kind != ast.KindObjectLiteralExpression {
+				return nil, drizzleRefuse(decl, "options.runtime entries must be plain `column: {method: callback}` members")
+			}
+			perColumn := map[string]string{}
+			for _, callbackProperty := range callbacksNode.AsObjectLiteralExpression().Properties.Nodes {
+				if callbackProperty.Kind != ast.KindPropertyAssignment {
+					return nil, drizzleRefuse(decl, "options.runtime callbacks must be plain `method: callback` members")
+				}
+				callbackAssignment := callbackProperty.AsPropertyAssignment()
+				methodName := callbackAssignment.Name()
+				callbackNode := callbackAssignment.Initializer
+				if methodName == nil || callbackNode == nil {
+					return nil, drizzleRefuse(decl, "options.runtime callbacks must be plain `method: callback` members")
+				}
+				perColumn[methodName.Text()] = strings.TrimSpace(source[skipTrivia(source, callbackNode.Pos()):callbackNode.End()])
+			}
+			texts[columnName.Text()] = perColumn
+		}
+	}
+	return texts, nil
+}
+
+// fillRuntimeCallbacks pairs the graph's runtime marker flags with the
+// options.runtime callback texts, both ways: a marker without a callback and
+// a callback without a marker each refuse naming the column and method.
+func fillRuntimeCallbacks(spec *drizzleTableSpec, decl *declaration, source string) *Diagnostic {
+	texts, diag := readRuntimeCallbackTexts(source, decl)
+	if diag != nil {
+		return diag
+	}
+	used := map[string]bool{}
+	for columnIndex := range spec.columns {
+		column := &spec.columns[columnIndex]
+		for modIndex := range column.mods {
+			mod := &column.mods[modIndex]
+			if !mod.isRuntime {
+				continue
+			}
+			text := texts[column.key][mod.method]
+			if text == "" {
+				return drizzleRefuse(decl, "column %q carries the %s marker but the const's options.runtime has no matching callback", column.key, mod.method)
+			}
+			mod.args = []string{text}
+			used[column.key+"."+mod.method] = true
+		}
+	}
+	for columnKey, methods := range texts {
+		for method := range methods {
+			if !used[columnKey+"."+method] {
+				return drizzleRefuse(decl, "options.runtime.%s.%s has no matching %s marker on the column type", columnKey, method, method)
+			}
+		}
+	}
+	return nil
 }
 
 // ── the conversion entry (called from ConvertFile) ───────────────────────────
@@ -1476,6 +1638,9 @@ func convertDrizzleDecl(prog *program.Program, typeChecker *checker.Checker, cac
 	spec, diag := specFromGraph(resolved, decl, nsIdent.Text(), tableFn, fileInfo)
 	if diag != nil {
 		return nil, diag
+	}
+	if runtimeDiag := fillRuntimeCallbacks(spec, decl, source); runtimeDiag != nil {
+		return nil, runtimeDiag
 	}
 	constName := decl.ConstName
 	if constName == "" {

--- a/ts-go-runtypes/internal/convert/drizzle_test.go
+++ b/ts-go-runtypes/internal/convert/drizzle_test.go
@@ -67,43 +67,43 @@ func convertDrizzleOne(t testing.TB, source string, opts convert.Options) (strin
 const drizzleHeader = "import * as DB from '@mionjs/drizzle-orm-pg-core';\n"
 
 const drizzleBuildersSource = drizzleHeader +
-	"export const usersRT = DB.pgTable('users', {\n" +
+	"export const users = DB.pgTable('users', {\n" +
 	"  id: DB.uuid('id').primaryKey().defaultRandom(),\n" +
 	"  name: DB.varchar('name', {length: 100}).notNull(),\n" +
 	"  age: DB.integer('age').notNull().default(21),\n" +
 	"  bio: DB.varchar('bio', {length: 500}),\n" +
 	"  note: DB.varchar(),\n" +
 	"});\n" +
-	"export type UsersRT = typeof usersRT;\n"
+	"export type UsersTable = typeof users;\n"
 
 const drizzleTypeSource = "import {getRunType} from '@ts-runtypes/core';\n" +
 	drizzleHeader +
-	"export type UsersRT = DB.PgTable<'users', {\n" +
+	"export type UsersTable = DB.PgTable<'users', {\n" +
 	"  id: DB.Uuid<'id'> & DB.PrimaryKey & DB.DefaultRandom;\n" +
 	"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;\n" +
 	"  age: DB.Integer<'age'> & DB.NotNull & DB.Default<21>;\n" +
 	"  bio: DB.Varchar<'bio', {length: 500}>;\n" +
 	"  note: DB.Varchar;\n" +
 	"}>;\n" +
-	"export const usersRT = DB.tableFromType<UsersRT>(getRunType<UsersRT>());\n"
+	"export const users = DB.tableFromType<UsersTable>(getRunType<UsersTable>());\n"
 
 func TestDrizzle_BuildersToType(t *testing.T) {
 	output, diags := convertDrizzleOne(t, drizzleBuildersSource, convert.Options{Target: convert.TargetType})
 	expectNoDiags(t, diags)
 	for _, want := range []string{
-		"export type UsersRT = DB.PgTable<'users', {",
+		"export type UsersTable = DB.PgTable<'users', {",
 		"  id: DB.Uuid<'id'> & DB.PrimaryKey & DB.DefaultRandom;",
 		"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;",
 		"  age: DB.Integer<'age'> & DB.NotNull & DB.Default<21>;",
 		"  bio: DB.Varchar<'bio', {length: 500}>;",
 		"  note: DB.Varchar;",
-		"export const usersRT = DB.tableFromType<UsersRT>();",
+		"export const users = DB.tableFromType<UsersTable>();",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("builders→type output missing %q:\n%s", want, output)
 		}
 	}
-	if strings.Contains(output, "typeof usersRT") {
+	if strings.Contains(output, "typeof users") {
 		t.Fatalf("builders→type left the typeof alias behind:\n%s", output)
 	}
 	// The marker form needs no getRunType: neither the call nor an import.
@@ -119,13 +119,13 @@ func TestDrizzle_TypeToBuilders(t *testing.T) {
 	output, diags := convertDrizzleOne(t, drizzleTypeSource, convert.Options{Target: convert.TargetBuilders})
 	expectNoDiags(t, diags)
 	for _, want := range []string{
-		"export const usersRT = DB.pgTable('users', {",
+		"export const users = DB.pgTable('users', {",
 		"  id: DB.uuid('id').primaryKey().defaultRandom(),",
 		"  name: DB.varchar('name', {length: 100}).notNull(),",
 		"  age: DB.integer('age').notNull().default(21),",
 		"  bio: DB.varchar('bio', {length: 500}),",
 		"  note: DB.varchar(),",
-		"export type UsersRT = typeof usersRT;",
+		"export type UsersTable = typeof users;",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("type→builders output missing %q:\n%s", want, output)
@@ -140,18 +140,18 @@ func TestDrizzle_TypeToBuilders(t *testing.T) {
 // type source (no getRunType anywhere) back to builders.
 func TestDrizzle_MarkerFormTypeToBuilders(t *testing.T) {
 	markerSource := drizzleHeader +
-		"export type UsersRT = DB.PgTable<'users', {\n" +
+		"export type UsersTable = DB.PgTable<'users', {\n" +
 		"  id: DB.Uuid<'id'> & DB.PrimaryKey;\n" +
 		"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;\n" +
 		"}>;\n" +
-		"export const usersRT = DB.tableFromType<UsersRT>();\n"
+		"export const users = DB.tableFromType<UsersTable>();\n"
 	output, diags := convertDrizzleOne(t, markerSource, convert.Options{Target: convert.TargetBuilders})
 	expectNoDiags(t, diags)
 	for _, want := range []string{
-		"export const usersRT = DB.pgTable('users', {",
+		"export const users = DB.pgTable('users', {",
 		"  id: DB.uuid('id').primaryKey(),",
 		"  name: DB.varchar('name', {length: 100}).notNull(),",
-		"export type UsersRT = typeof usersRT;",
+		"export type UsersTable = typeof users;",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("marker-form type→builders missing %q:\n%s", want, output)
@@ -250,13 +250,13 @@ func TestDrizzle_RoundTripFixpoint(t *testing.T) {
 const drizzleMysqlHeader = "import * as DB from '@mionjs/drizzle-orm-mysql-core';\n"
 
 const drizzleMysqlBuildersSource = drizzleMysqlHeader +
-	"export const devicesRT = DB.mysqlTable('devices', {\n" +
+	"export const devices = DB.mysqlTable('devices', {\n" +
 	"  id: DB.serial('id').primaryKey(),\n" +
 	"  name: DB.varchar('name', {length: 100}).notNull(),\n" +
 	"  views: DB.int('views', {unsigned: true}).notNull(),\n" +
 	"  plan: DB.text('plan', {enum: ['free', 'pro']}).notNull(),\n" +
 	"});\n" +
-	"export type DevicesRT = typeof devicesRT;\n"
+	"export type DevicesTable = typeof devices;\n"
 
 // TestDrizzle_MysqlRoundTripFixpoint drives a mysql builders table through
 // builders→type→builders→type, pinning the mysqlTable → MysqlTable pair and
@@ -265,12 +265,12 @@ func TestDrizzle_MysqlRoundTripFixpoint(t *testing.T) {
 	leg1, diags := convertDrizzleOne(t, drizzleMysqlBuildersSource, convert.Options{Target: convert.TargetType})
 	expectNoDiags(t, diags)
 	for _, want := range []string{
-		"export type DevicesRT = DB.MysqlTable<'devices', {",
+		"export type DevicesTable = DB.MysqlTable<'devices', {",
 		"  id: DB.Serial<'id'> & DB.PrimaryKey;",
 		"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;",
 		"  views: DB.Int<'views', {unsigned: true}> & DB.NotNull;",
 		"  plan: DB.Text<'plan', {enum: ['free', 'pro']}> & DB.NotNull;",
-		"export const devicesRT = DB.tableFromType<DevicesRT>();",
+		"export const devices = DB.tableFromType<DevicesTable>();",
 	} {
 		if !strings.Contains(leg1, want) {
 			t.Fatalf("mysql builders→type output missing %q:\n%s", want, leg1)
@@ -279,7 +279,7 @@ func TestDrizzle_MysqlRoundTripFixpoint(t *testing.T) {
 	leg2, diags := convertDrizzleOne(t, leg1, convert.Options{Target: convert.TargetBuilders})
 	expectNoDiags(t, diags)
 	for _, want := range []string{
-		"export const devicesRT = DB.mysqlTable('devices', {",
+		"export const devices = DB.mysqlTable('devices', {",
 		"  id: DB.serial('id').primaryKey(),",
 		"  views: DB.int('views', {unsigned: true}).notNull(),",
 		"  plan: DB.text('plan', {enum: ['free', 'pro']}).notNull(),",
@@ -374,6 +374,9 @@ func TestDrizzle_RefusalsNoTypeTwin(t *testing.T) {
 	}
 }
 
+// Deliberately legacy-named (parentsRT/childrenRT): existing names are always
+// preserved by conversion, whatever their suffix — this fixture doubles as
+// that coverage.
 const drizzleRefSqlSource = "import {sql} from '@mionjs/drizzle-orm';\n" + drizzleHeader +
 	"export const parentsRT = DB.pgTable('parents', {\n" +
 	"  id: DB.integer('id').primaryKey(),\n" +
@@ -420,7 +423,7 @@ func TestDrizzle_ReferencesAndSql(t *testing.T) {
 }
 
 const drizzleExtrasSource = "import {sql} from '@mionjs/drizzle-orm';\n" + drizzleHeader +
-	"export const extrasRT = DB.pgTable('extras_t', {\n" +
+	"export const extras = DB.pgTable('extras_t', {\n" +
 	"  a: DB.integer('a').notNull(),\n" +
 	"  b: DB.varchar('b', {length: 10}),\n" +
 	"}, (t) => [\n" +
@@ -429,7 +432,7 @@ const drizzleExtrasSource = "import {sql} from '@mionjs/drizzle-orm';\n" + drizz
 	"  DB.unique('uq_ab').on(t.a, t.b),\n" +
 	"  DB.check('chk_a', sql`a >= 0`),\n" +
 	"]);\n" +
-	"export type ExtrasRT = typeof extrasRT;\n"
+	"export type ExtrasTable = typeof extras;\n"
 
 // TestDrizzle_TableExtras pins the extraConfig road through both directions
 // and the fixpoint.

--- a/ts-go-runtypes/internal/convert/drizzle_test.go
+++ b/ts-go-runtypes/internal/convert/drizzle_test.go
@@ -76,8 +76,7 @@ const drizzleBuildersSource = drizzleHeader +
 	"});\n" +
 	"export type UsersTable = typeof users;\n"
 
-const drizzleTypeSource = "import {getRunType} from '@ts-runtypes/core';\n" +
-	drizzleHeader +
+const drizzleTypeSource = drizzleHeader +
 	"export type UsersTable = DB.PgTable<'users', {\n" +
 	"  id: DB.Uuid<'id'> & DB.PrimaryKey & DB.DefaultRandom;\n" +
 	"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;\n" +
@@ -85,7 +84,7 @@ const drizzleTypeSource = "import {getRunType} from '@ts-runtypes/core';\n" +
 	"  bio: DB.Varchar<'bio', {length: 500}>;\n" +
 	"  note: DB.Varchar;\n" +
 	"}>;\n" +
-	"export const users = DB.tableFromType<UsersTable>(getRunType<UsersTable>());\n"
+	"export const users = DB.tableFromType<UsersTable>();\n"
 
 func TestDrizzle_BuildersToType(t *testing.T) {
 	output, diags := convertDrizzleOne(t, drizzleBuildersSource, convert.Options{Target: convert.TargetType})
@@ -112,9 +111,6 @@ func TestDrizzle_BuildersToType(t *testing.T) {
 	}
 }
 
-// TestDrizzle_TypeToBuilders also covers the explicit escape hatch: the
-// fixture's const spells `tableFromType<T>(getRunType<T>())` and the
-// recognizer must accept it (pairing ignores the value arguments).
 func TestDrizzle_TypeToBuilders(t *testing.T) {
 	output, diags := convertDrizzleOne(t, drizzleTypeSource, convert.Options{Target: convert.TargetBuilders})
 	expectNoDiags(t, diags)
@@ -133,29 +129,6 @@ func TestDrizzle_TypeToBuilders(t *testing.T) {
 	}
 	if strings.Contains(output, "tableFromType") {
 		t.Fatalf("type→builders left the tableFromType handle behind:\n%s", output)
-	}
-}
-
-// TestDrizzle_MarkerFormTypeToBuilders converts the canonical MARKER-form
-// type source (no getRunType anywhere) back to builders.
-func TestDrizzle_MarkerFormTypeToBuilders(t *testing.T) {
-	markerSource := drizzleHeader +
-		"export type UsersTable = DB.PgTable<'users', {\n" +
-		"  id: DB.Uuid<'id'> & DB.PrimaryKey;\n" +
-		"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;\n" +
-		"}>;\n" +
-		"export const users = DB.tableFromType<UsersTable>();\n"
-	output, diags := convertDrizzleOne(t, markerSource, convert.Options{Target: convert.TargetBuilders})
-	expectNoDiags(t, diags)
-	for _, want := range []string{
-		"export const users = DB.pgTable('users', {",
-		"  id: DB.uuid('id').primaryKey(),",
-		"  name: DB.varchar('name', {length: 100}).notNull(),",
-		"export type UsersTable = typeof users;",
-	} {
-		if !strings.Contains(output, want) {
-			t.Fatalf("marker-form type→builders missing %q:\n%s", want, output)
-		}
 	}
 }
 

--- a/ts-go-runtypes/internal/convert/drizzle_test.go
+++ b/ts-go-runtypes/internal/convert/drizzle_test.go
@@ -97,8 +97,7 @@ func TestDrizzle_BuildersToType(t *testing.T) {
 		"  age: DB.Integer<'age'> & DB.NotNull & DB.Default<21>;",
 		"  bio: DB.Varchar<'bio', {length: 500}>;",
 		"  note: DB.Varchar;",
-		"export const usersRT = DB.tableFromType<UsersRT>(getRunType<UsersRT>());",
-		"import {getRunType} from '@ts-runtypes/core';",
+		"export const usersRT = DB.tableFromType<UsersRT>();",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("builders→type output missing %q:\n%s", want, output)
@@ -107,8 +106,15 @@ func TestDrizzle_BuildersToType(t *testing.T) {
 	if strings.Contains(output, "typeof usersRT") {
 		t.Fatalf("builders→type left the typeof alias behind:\n%s", output)
 	}
+	// The marker form needs no getRunType: neither the call nor an import.
+	if strings.Contains(output, "getRunType") {
+		t.Fatalf("builders→type emitted a getRunType reference:\n%s", output)
+	}
 }
 
+// TestDrizzle_TypeToBuilders also covers the explicit escape hatch: the
+// fixture's const spells `tableFromType<T>(getRunType<T>())` and the
+// recognizer must accept it (pairing ignores the value arguments).
 func TestDrizzle_TypeToBuilders(t *testing.T) {
 	output, diags := convertDrizzleOne(t, drizzleTypeSource, convert.Options{Target: convert.TargetBuilders})
 	expectNoDiags(t, diags)
@@ -127,6 +133,97 @@ func TestDrizzle_TypeToBuilders(t *testing.T) {
 	}
 	if strings.Contains(output, "tableFromType") {
 		t.Fatalf("type→builders left the tableFromType handle behind:\n%s", output)
+	}
+}
+
+// TestDrizzle_MarkerFormTypeToBuilders converts the canonical MARKER-form
+// type source (no getRunType anywhere) back to builders.
+func TestDrizzle_MarkerFormTypeToBuilders(t *testing.T) {
+	markerSource := drizzleHeader +
+		"export type UsersRT = DB.PgTable<'users', {\n" +
+		"  id: DB.Uuid<'id'> & DB.PrimaryKey;\n" +
+		"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;\n" +
+		"}>;\n" +
+		"export const usersRT = DB.tableFromType<UsersRT>();\n"
+	output, diags := convertDrizzleOne(t, markerSource, convert.Options{Target: convert.TargetBuilders})
+	expectNoDiags(t, diags)
+	for _, want := range []string{
+		"export const usersRT = DB.pgTable('users', {",
+		"  id: DB.uuid('id').primaryKey(),",
+		"  name: DB.varchar('name', {length: 100}).notNull(),",
+		"export type UsersRT = typeof usersRT;",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("marker-form type→builders missing %q:\n%s", want, output)
+		}
+	}
+}
+
+// TestDrizzle_DerivedPairNames pins the Table naming rule for invented names:
+// a table const derives a Table-suffixed type (users → UsersTable) and a
+// table type derives an RT-free const (UsersTable → users) — the RT-suffix
+// derivation stays reserved for actual runtype pairs.
+func TestDrizzle_DerivedPairNames(t *testing.T) {
+	buildersOnly := drizzleHeader +
+		"export const users = DB.pgTable('users', {id: DB.integer('id').primaryKey()});\n"
+	typeForm, diags := convertDrizzleOne(t, buildersOnly, convert.Options{Target: convert.TargetType})
+	expectNoDiags(t, diags)
+	for _, want := range []string{
+		"export type UsersTable = DB.PgTable<'users', {",
+		"export const users = DB.tableFromType<UsersTable>();",
+	} {
+		if !strings.Contains(typeForm, want) {
+			t.Fatalf("derived type name missing %q:\n%s", want, typeForm)
+		}
+	}
+
+	typeOnly := drizzleHeader +
+		"export type UsersTable = DB.PgTable<'users', {\n" +
+		"  id: DB.Integer<'id'> & DB.PrimaryKey;\n" +
+		"}>;\n"
+	buildersForm, diags := convertDrizzleOne(t, typeOnly, convert.Options{Target: convert.TargetBuilders})
+	expectNoDiags(t, diags)
+	for _, want := range []string{
+		"export const users = DB.pgTable('users', {",
+		"export type UsersTable = typeof users;",
+	} {
+		if !strings.Contains(buildersForm, want) {
+			t.Fatalf("derived const name missing %q:\n%s", want, buildersForm)
+		}
+	}
+	if strings.Contains(buildersForm, "usersRT") || strings.Contains(typeForm, "usersRT") {
+		t.Fatalf("drizzle derivation produced an RT-suffixed const:\n%s\n%s", typeForm, buildersForm)
+	}
+}
+
+// TestDrizzle_BackwardReferenceRefusal pins the eager-tables-option guard: a
+// child table declared BEFORE its referenced parent is legal on the builders
+// road (the closure is lazy) but has no valid type form, so it refuses with
+// CNV009 and stays byte-untouched.
+func TestDrizzle_BackwardReferenceRefusal(t *testing.T) {
+	source := drizzleHeader +
+		"export const children = DB.pgTable('children', {\n" +
+		"  pid: DB.integer('pid').references(() => parents.id),\n" +
+		"});\n" +
+		"export const parents = DB.pgTable('parents', {\n" +
+		"  id: DB.integer('id').primaryKey(),\n" +
+		"});\n"
+	output, diags := convertDrizzleOne(t, source, convert.Options{Target: convert.TargetType})
+	var found bool
+	for _, diagnostic := range diags {
+		if diagnostic.Code == convert.CodeDrizzleUnsupported && strings.Contains(diagnostic.Message, "reorder") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a CNV009 reorder refusal, got %v\noutput:\n%s", diags, output)
+	}
+	if !strings.Contains(output, "DB.pgTable('children', {") {
+		t.Fatalf("the refused child declaration was rewritten:\n%s", output)
+	}
+	// The parent has no ordering problem and converts on its own.
+	if !strings.Contains(output, "export const parents = DB.tableFromType<ParentsTable>();") {
+		t.Fatalf("the parent declaration did not convert:\n%s", output)
 	}
 }
 
@@ -173,7 +270,7 @@ func TestDrizzle_MysqlRoundTripFixpoint(t *testing.T) {
 		"  name: DB.Varchar<'name', {length: 100}> & DB.NotNull;",
 		"  views: DB.Int<'views', {unsigned: true}> & DB.NotNull;",
 		"  plan: DB.Text<'plan', {enum: ['free', 'pro']}> & DB.NotNull;",
-		"export const devicesRT = DB.tableFromType<DevicesRT>(getRunType<DevicesRT>());",
+		"export const devicesRT = DB.tableFromType<DevicesRT>();",
 	} {
 		if !strings.Contains(leg1, want) {
 			t.Fatalf("mysql builders→type output missing %q:\n%s", want, leg1)
@@ -296,6 +393,10 @@ func TestDrizzle_ReferencesAndSql(t *testing.T) {
 	for _, want := range []string{
 		"pid: DB.Integer<'pid'> & DB.References<'parents', 'id', {onDelete: 'cascade'}> & DB.NotNull;",
 		"createdAt: DB.Timestamp<'created_at'> & DB.Default<DB.Sql<'now()'>>;",
+		// The referenced table rides the emitted tables option (the runtime
+		// bridge resolves References through it).
+		"export const parentsRT = DB.tableFromType<ParentsRT>();",
+		"export const childrenRT = DB.tableFromType<ChildrenRT>({tables: {parents: parentsRT}});",
 	} {
 		if !strings.Contains(typeForm, want) {
 			t.Fatalf("builders→type missing %q:\n%s", want, typeForm)
@@ -466,6 +567,11 @@ func randomDrizzleBuildersFile(rng *rand.Rand) string {
 			}
 			columns = append(columns, "  "+key+": "+text+",")
 		}
+		// A forward reference onto the first table (col_0 always exists): the
+		// type form must carry it through the emitted tables option.
+		if tableIndex == 1 && rng.Intn(3) == 0 {
+			columns = append(columns, "  ref_pid: DB.integer('ref_pid').references(() => table0.col_0),")
+		}
 		extras := ""
 		if rng.Intn(2) == 0 {
 			var entries []string
@@ -479,7 +585,7 @@ func randomDrizzleBuildersFile(rng *rand.Rand) string {
 				extras = ", (t) => [\n" + strings.Join(entries, "\n") + "\n]"
 			}
 		}
-		fmt.Fprintf(&out, "export const table%dRT = DB.pgTable('t_%d', {\n%s\n}%s);\n", tableIndex, tableIndex, strings.Join(columns, "\n"), extras)
+		fmt.Fprintf(&out, "export const table%d = DB.pgTable('t_%d', {\n%s\n}%s);\n", tableIndex, tableIndex, strings.Join(columns, "\n"), extras)
 	}
 	return out.String()
 }

--- a/ts-go-runtypes/internal/convert/drizzle_test.go
+++ b/ts-go-runtypes/internal/convert/drizzle_test.go
@@ -297,8 +297,8 @@ func TestDrizzle_MysqlRoundTripFixpoint(t *testing.T) {
 
 func TestDrizzle_RefusalsCNV009(t *testing.T) {
 	cases := map[string]string{
-		"runtime fn modifier": drizzleHeader +
-			"export const t = DB.pgTable('t', {c: DB.integer('c').$defaultFn(() => 1)});\n",
+		"$type override": drizzleHeader +
+			"export const t = DB.pgTable('t', {c: DB.jsonb('c').$type<{a: number}>()});\n",
 		"references outside the file": drizzleHeader +
 			"declare const p: {id: number};\n" +
 			"export const t = DB.pgTable('t', {pid: DB.integer('pid').references(() => p.id)});\n",
@@ -466,6 +466,106 @@ func TestDrizzle_TableExtras(t *testing.T) {
 	}
 }
 
+const drizzleRuntimeSource = drizzleHeader +
+	"export const jobs = DB.pgTable('jobs', {\n" +
+	"  id: DB.uuid('id').primaryKey(),\n" +
+	"  slug: DB.varchar('slug', {length: 80}).notNull().$defaultFn(() => 'slug-' + Math.random()),\n" +
+	"  attempts: DB.integer('attempts').$default(() => 0),\n" +
+	"  touchedAt: DB.timestamp('touched_at', {mode: 'string'}).$onUpdate(() => new Date().toISOString()),\n" +
+	"  counter: DB.integer('counter').$onUpdateFn(() => {\n" +
+	"    const next = 1 + 1;\n" +
+	"    return next;\n" +
+	"  }),\n" +
+	"});\n" +
+	"export type JobsTable = typeof jobs;\n"
+
+// TestDrizzle_RuntimeModifiers pins the runtime-callback modifiers through
+// both directions: the type form carries the flag markers plus the callbacks
+// VERBATIM in options.runtime (alias preserved: $default vs $defaultFn,
+// multi-line bodies included), and the whole thing is a byte fixpoint.
+func TestDrizzle_RuntimeModifiers(t *testing.T) {
+	typeForm, diags := convertDrizzleOne(t, drizzleRuntimeSource, convert.Options{Target: convert.TargetType})
+	expectNoDiags(t, diags)
+	for _, want := range []string{
+		"  slug: DB.Varchar<'slug', {length: 80}> & DB.NotNull & DB.$DefaultFn;",
+		"  attempts: DB.Integer<'attempts'> & DB.$Default;",
+		"  touchedAt: DB.Timestamp<'touched_at', {mode: 'string'}> & DB.$OnUpdate;",
+		"  counter: DB.Integer<'counter'> & DB.$OnUpdateFn;",
+		"export const jobs = DB.tableFromType<JobsTable>({runtime: {" +
+			"slug: {$defaultFn: () => 'slug-' + Math.random()}, " +
+			"attempts: {$default: () => 0}, " +
+			"touchedAt: {$onUpdate: () => new Date().toISOString()}, " +
+			"counter: {$onUpdateFn: () => {\n" +
+			"    const next = 1 + 1;\n" +
+			"    return next;\n" +
+			"  }}}});",
+	} {
+		if !strings.Contains(typeForm, want) {
+			t.Fatalf("builders→type runtime missing %q:\n%s", want, typeForm)
+		}
+	}
+	buildersForm, diags := convertDrizzleOne(t, typeForm, convert.Options{Target: convert.TargetBuilders})
+	expectNoDiags(t, diags)
+	for _, want := range []string{
+		".notNull().$defaultFn(() => 'slug-' + Math.random()),",
+		".$default(() => 0),",
+		".$onUpdate(() => new Date().toISOString()),",
+		".$onUpdateFn(() => {\n    const next = 1 + 1;\n    return next;\n  }),",
+	} {
+		if !strings.Contains(buildersForm, want) {
+			t.Fatalf("type→builders runtime missing %q:\n%s", want, buildersForm)
+		}
+	}
+	typeAgain, diags := convertDrizzleOne(t, buildersForm, convert.Options{Target: convert.TargetType})
+	expectNoDiags(t, diags)
+	if typeAgain != typeForm {
+		t.Fatalf("runtime type form not a fixpoint:\n--- first ---\n%s\n--- second ---\n%s", typeForm, typeAgain)
+	}
+}
+
+// TestDrizzle_RuntimeMismatchRefusals pins the two-way marker↔callback
+// validation on the type→builders direction.
+func TestDrizzle_RuntimeMismatchRefusals(t *testing.T) {
+	cases := map[string]struct {
+		source        string
+		wantInMessage string
+	}{
+		"marker without callback": {
+			source: drizzleHeader +
+				"export type TTable = DB.PgTable<'t', {\n" +
+				"  c: DB.Integer<'c'> & DB.$DefaultFn;\n" +
+				"}>;\n" +
+				"export const t = DB.tableFromType<TTable>();\n",
+			wantInMessage: "no matching callback",
+		},
+		"callback without marker": {
+			source: drizzleHeader +
+				"export type TTable = DB.PgTable<'t', {\n" +
+				"  c: DB.Integer<'c'>;\n" +
+				"}>;\n" +
+				"export const t = DB.tableFromType<TTable>({runtime: {c: {$defaultFn: () => 1}}});\n",
+			wantInMessage: "no matching $defaultFn marker",
+		},
+	}
+	for label, testCase := range cases {
+		t.Run(label, func(t *testing.T) {
+			output, diags := convertDrizzleOne(t, testCase.source, convert.Options{Target: convert.TargetBuilders})
+			var found bool
+			for _, diagnostic := range diags {
+				if diagnostic.Code == convert.CodeDrizzleUnsupported && strings.Contains(diagnostic.Message, testCase.wantInMessage) {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("%s: expected a CNV009 refusal containing %q, got %v\noutput:\n%s", label, testCase.wantInMessage, diags, output)
+			}
+			if !strings.Contains(output, "DB.PgTable<'t', {") {
+				t.Fatalf("%s: the refused declaration was rewritten:\n%s", label, output)
+			}
+		})
+	}
+}
+
 // TestFuzz_DrizzleRoundTrip sweeps random slice-vocabulary tables through
 // builders→type→builders→type, pinning the same fixpoint oracle as the static
 // round-trip test. Iterations ride RT_FUZZ_ITER like the atom sweep.
@@ -517,50 +617,67 @@ func randomDrizzleBuildersFile(rng *rand.Rand) string {
 		for i := 0; i < columnCount; i++ {
 			key := fmt.Sprintf("col_%d", i)
 			var text string
+			// callbackValue keeps the runtime-modifier draws TYPE-CORRECT: the
+			// emitted options.runtime is typed () => ColDataOf<column>.
+			var callbackValue string
 			switch rng.Intn(9) {
 			case 0:
 				text = fmt.Sprintf("DB.varchar('c%d', {length: %d})", i, 1+rng.Intn(200))
 				if rng.Intn(2) == 0 {
 					text += ".default('dflt')"
 				}
+				callbackValue = "'rv'"
 			case 1:
 				text = fmt.Sprintf("DB.integer('c%d')", i)
 				if rng.Intn(2) == 0 {
 					text += fmt.Sprintf(".default(%d)", rng.Intn(100))
 				}
+				callbackValue = "7"
 			case 2:
 				text = fmt.Sprintf("DB.uuid('c%d')", i)
 				if rng.Intn(2) == 0 {
 					text += ".defaultRandom()"
 				}
+				callbackValue = "'00000000-0000-0000-0000-000000000000'"
 			case 3:
 				if rng.Intn(2) == 0 {
 					text = fmt.Sprintf("DB.text('c%d', {enum: ['a', 'b', 'c']})", i)
+					callbackValue = "'a'"
 				} else {
 					text = fmt.Sprintf("DB.text('c%d')", i)
+					callbackValue = "'rv'"
 				}
 			case 4:
 				text = fmt.Sprintf("DB.boolean('c%d')", i)
 				if rng.Intn(2) == 0 {
 					text += fmt.Sprintf(".default(%t)", rng.Intn(2) == 0)
 				}
+				callbackValue = "true"
 			case 5:
 				text = fmt.Sprintf("DB.timestamp('c%d', {mode: 'string'})", i)
 				if rng.Intn(2) == 0 {
 					text += ".defaultNow()"
 				}
+				callbackValue = "'2026-01-01T00:00:00Z'"
 			case 6:
 				text = fmt.Sprintf("DB.numeric('c%d', {precision: %d, scale: %d})", i, 1+rng.Intn(12), 1+rng.Intn(4))
+				callbackValue = "'1.5'"
 			case 7:
 				text = fmt.Sprintf("DB.bigint('c%d', {mode: 'number'})", i)
+				callbackValue = "9"
 			default:
 				text = fmt.Sprintf("DB.smallint('c%d')", i)
+				callbackValue = "1"
 			}
 			if rng.Intn(2) == 0 {
 				text += ".notNull()"
 			}
 			if rng.Intn(4) == 0 {
 				text += fmt.Sprintf(".unique('uq_c%d')", i)
+			}
+			if rng.Intn(4) == 0 {
+				method := []string{"$default", "$defaultFn", "$onUpdate", "$onUpdateFn"}[rng.Intn(4)]
+				text += "." + method + "(() => " + callbackValue + ")"
 			}
 			if i == 0 && rng.Intn(3) == 0 {
 				text += ".primaryKey()"

--- a/ts-go-runtypes/internal/convert/names.go
+++ b/ts-go-runtypes/internal/convert/names.go
@@ -93,20 +93,67 @@ func newNames(decls []*declaration, imports *importScan, inScope map[string]bool
 
 // deriveConstName maps a type name onto its runtype const (`MyType` →
 // `myTypeRT`), suffixing digits on collision. Returns "" when no free name
-// exists within the suffix budget.
+// exists within the suffix budget. Generic runtype pairs ONLY — a drizzle
+// table const is a table, not a runtype, and derives via the Table rule.
 func (names *nameTable) deriveConstName(typeName string) string {
 	base := lowerFirst(typeName) + "RT"
 	return names.claim(base)
 }
 
 // deriveTypeName maps a const name back onto a type name (`myTypeRT` →
-// `MyType`) for consts that never had an InferType alias.
+// `MyType`) for consts that never had an InferType alias. Generic runtype
+// pairs only (see deriveConstName).
 func (names *nameTable) deriveTypeName(constName string) string {
 	base := strings.TrimSuffix(constName, "RT")
 	if base == constName || base == "" {
 		base = constName + "Type"
 	}
 	return names.claim(upperFirst(base))
+}
+
+// jsReservedWords guards the drizzle const derivation: stripping Table off a
+// type name must never produce a keyword (`NewTable` → `new`).
+var jsReservedWords = map[string]bool{
+	"await": true, "break": true, "case": true, "catch": true, "class": true,
+	"const": true, "continue": true, "debugger": true, "default": true,
+	"delete": true, "do": true, "else": true, "enum": true, "export": true,
+	"extends": true, "false": true, "finally": true, "for": true,
+	"function": true, "if": true, "import": true, "in": true,
+	"instanceof": true, "let": true, "new": true, "null": true, "return": true,
+	"static": true, "super": true, "switch": true, "this": true, "throw": true,
+	"true": true, "try": true, "typeof": true, "var": true, "void": true,
+	"while": true, "with": true, "yield": true,
+}
+
+// deriveDrizzleConstName maps a drizzle table type name onto its table const
+// (`UsersTable` → `users`, falling back to `usersTable`, then digit
+// suffixes). Table consts drop the RT suffix everywhere: the const holds a
+// table, not a runtype.
+func (names *nameTable) deriveDrizzleConstName(typeName string) string {
+	base := strings.TrimSuffix(typeName, "Table")
+	if base == "" {
+		base = typeName
+	}
+	short := lowerFirst(base)
+	if !names.taken[short] && !jsReservedWords[short] {
+		names.taken[short] = true
+		return short
+	}
+	fallback := lowerFirst(typeName)
+	if fallback == short {
+		fallback = short + "Table"
+	}
+	return names.claim(fallback)
+}
+
+// deriveDrizzleTypeName maps a table const onto its table type name (`users`
+// → `UsersTable`); a const already carrying the Table suffix keeps one.
+func (names *nameTable) deriveDrizzleTypeName(constName string) string {
+	base := upperFirst(constName)
+	if !strings.HasSuffix(base, "Table") {
+		base += "Table"
+	}
+	return names.claim(base)
 }
 
 // claim returns base or a digit-suffixed variant, registering the result;


### PR DESCRIPTION
Implements runtime-callback modifiers and marker-form table materialization for the drizzle type-defined tables road, completing the ergonomic parity with the builders road.

> **Merge order:** the delegated finding PR for `docs/todos/drizzle-schema-helpers-test-coverage.md` (missing specs for pgSchema/pgSequence/pgTableCreator and the mysql/sqlite twins, found while auditing this surface) merges BEFORE this PR. This branch carries the todo doc; the parallel session implements it from `origin/main`.

## Summary

Runtime column callbacks (`$default`, `$defaultFn`, `$onUpdate`, `$onUpdateFn`) now work on the type road by carrying marker flags in the column type and moving the actual callback functions into `tableFromType`&#39;s options object. `tableFromType<T>(options?)` is now the ONLY signature (single marker form, no overloads): the old explicit `tableFromType(runType, options?)` form was dropped in review; dynamic callers holding a resolved graph use the exported `buildRtTableFromGraph` instead.

## Key changes

- **Runtime callback markers** (`$Default`, `$DefaultFn`, `$OnUpdate`, `$OnUpdateFn`): Added to `typeColumns.ts` following the existing `$Type` naming rule (upperFirst of the method name). The type carries only the flag; the callback rides `options.runtime`.

- **Marker form materialization**: `tableFromType<T>(options?)` resolves its type argument through the injected marker handle and memoizes per type id. `toDrizzle<T>(options?)` is the happy path for query/migration files and shares the same slim table.

- **Options object rename**: `TableFromTypeDeps` → `TableFromTypeOptions` with new `runtime?: RuntimeCallbacks` member carrying the per-column callbacks, and `tables?` for References.

- **Go convert tool updates**:
  - Recognizes runtime modifiers on the builders road and emits them as marker flags in the type form with callbacks in the const&#39;s options object
  - Derives table pair names without RT suffix: `users` const → `UsersTable` type (not `UsersRT`)
  - Tracks cross-table references in `spec.refTables` for the type form&#39;s `{tables: {...}}` option
  - Refuses backward references (child table declared before parent) with CNV009 since the type form&#39;s eager options object cannot express lazy closures
  - Emits the canonical marker form `DB.tableFromType<T>()` with no `getRunType` import (pairing tolerates value arguments)

- **Bridge validation**: `applyMods` in `fromType.ts` validates that runtime markers in the type match callbacks in `options.runtime` (both directions), then replays via the recorder&#39;s existing methods.

- **Builder return types**: `pgTable`/`mysqlTable`/`sqliteTable` declare `PgTable`/`MysqlTable`/`SqliteTable` as their returns (one public name for both roads), via a lazily-defaulted `NormalizedCols` fast-path parameter; `RefinedTable`&#39;s `R` is constrained to `TableRefinements<T>`.

- **Test coverage**: Marker form round-trips, derived pair names, backward reference refusal, and runtime callback behavior across all three dialects (pg, mysql, sqlite).

- **Type budget**: Lowered, not just held (step1 493→478, step2 1245→1198, consumer 1841→1785) from the flat table meta, single-conditional RefineCols, and the NormalizedCols fast path.

## Implementation notes

- The `drizzleMarkerName` helper maps builder method names to marker type names (e.g., `$defaultFn` → `$DefaultFn`).
- Runtime callbacks are moved VERBATIM between the builders chain and the options object by convert, and wrapped lazily during materialization.
- The marker form needs no `getRunType` import; the devtools transform resolves the type argument at build time.
- References in both columns and extraConfig entries now populate `spec.refTables`, which the type form&#39;s `{tables: {...}}` option must carry — fixing an import-time crash the old emitted references pair had (it never passed its deps).

https://claude.ai/code/session_01EeLAstbiF3U5Vm5ZULHyV7