### PR TITLE
Add test coverage for schema/creator/sequence helpers

### DIFF
--- a/docs/done/drizzle-schema-helpers-test-coverage.md
+++ b/docs/done/drizzle-schema-helpers-test-coverage.md
@@ -1,0 +1,102 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-08-29
+---
+
+# Test coverage for the schema / creator / sequence authoring helpers
+
+## Intent
+
+Six authoring helpers of the drizzle dialect packages are marked `migrated` in
+the manifests but have ZERO spec coverage: nothing pins that the recorded
+value materializes into the correct drizzle object through toDrizzle.
+
+- pg: `pgSchema` (and its `.table` / `.enum` / `.sequence` members),
+  `pgSequence`, `pgTableCreator`
+- mysql: `mysqlSchema`, `mysqlTableCreator`
+- sqlite: `sqliteTableCreator`
+
+The drizzle-proxy-migration rules say a `migrated` manifest entry lands with
+paired tests; these landed without them (predates the type-road ergonomics
+rework, found while auditing that surface on PR #166).
+
+## Evidence
+
+- `packages/drizzle-orm-*-core/manifests/*.manifest.json` list all six as
+  `status: "migrated"`.
+- `grep -rn "pgSchema\|pgTableCreator\|pgSequence\|mysqlSchema\|mysqlTableCreator\|sqliteTableCreator" packages/*/src/*.spec.ts`
+  returns nothing.
+- Implementations: `packages/drizzle-orm-pg-core/src/table.ts` (pgSchema,
+  pgTableCreator, PgSequence), `packages/drizzle-orm-pg-core/src/helpers.ts`
+  (pgSequence, pgEnum), and the mysql/sqlite twins.
+
+## Direction
+
+Add specs beside the existing per-dialect suites (e.g. in each package's
+`src/index.spec.ts` or a new `src/valueHelpers.spec.ts`) that compare the
+materialized result against building the same thing with raw drizzle:
+
+- pgSchema: a table declared via `schema.table(...)` materializes into a
+  drizzle table whose schema matches `dzPg.pgSchema('...').table(...)`
+  (compare getTableConfig, including the schema); the schema handle itself
+  materializes to drizzle's PgSchema; `schema.enum` and `schema.sequence`
+  round through toDrizzle.
+- pgTableCreator / mysqlTableCreator / sqliteTableCreator: the name-mapper is
+  applied (a table declared as 'users' materializes with the mapped name),
+  equal to raw drizzle's tableCreator result.
+- pgSequence / mysqlSchema: toDrizzle returns the drizzle object with the
+  recorded name and options.
+- Model derivation still works on creator/schema tables (InferSelectModel over
+  a creator table equals the plain-table model).
+- Any test exercising the marker API must follow the Marker test coverage
+  rule (both getRunTypeId call shapes) per ts-go-runtypes/CLAUDE.md; if these
+  specs stay purely value-level, say so in the spec header instead.
+
+## Out of scope
+
+New helper functionality, manifest regeneration, and the type road (these
+helpers are builders-only by design).
+
+## Done when
+
+Each of the six helpers has a spec pinning its materialized drizzle object
+against the raw drizzle equivalent, `pnpm test` is green, and the specs live
+in the dialect packages beside the existing suites.
+
+## Plan — value-level helper specs (approved 2026-08-29)
+
+One new spec file per dialect package, `src/valueHelpers.spec.ts`, purely
+value-level (no marker API, stated in each file header, so the Marker test
+coverage rule does not apply):
+
+- pg: the pgSchema handle materializes to a drizzle PgSchema (instanceof +
+  schemaName); schema.table (with an extraConfig index) compares equal to the
+  dzPg.pgSchema twin via a compact getTableConfig projection, schema
+  included; schema.enum materializes schema-qualified with the same
+  name/values; schema.sequence and standalone pgSequence (with and without
+  options) compare seqName/seqOptions/schema against the raw drizzle twins
+  and pass isPgSequence; pgTableCreator applies the name mapper equal to
+  dzPg.pgTableCreator and stays memoized.
+- mysql: the mysqlSchema handle (instanceof MySqlSchema + schemaName) and
+  schema.table vs the raw twin (schema included); mysqlTableCreator name
+  mapping vs the raw twin.
+- sqlite: sqliteTableCreator name mapping vs the raw twin, memoized.
+- Model derivation: InferSelectModel rows of creator/schema tables are
+  mutually assignable with the plain-table model (compile-time assignments
+  inside a test).
+
+No docs changes (test-only fix, no user-visible behavior). Not a fuzz
+candidate (the getTableConfig equality oracle is already pinned per call
+shape; no input space to explore). Finish: pnpm test green, lint/format,
+git mv the spec to docs/done/.
+
+## Shipped
+
+Landed as `src/valueHelpers.spec.ts` in each of the three dialect packages,
+exactly per the plan above: 17 tests covering all six helpers, purely
+value-level (no marker API, so the Marker test coverage rule does not
+apply; each spec file header says so). Model derivation is checked with
+compile-time assignments so the specs stay valid when the type-road
+ergonomics rework (PR #166) changes the helpers' return types.

--- a/packages/drizzle-orm-mysql-core/src/valueHelpers.spec.ts
+++ b/packages/drizzle-orm-mysql-core/src/valueHelpers.spec.ts
@@ -113,6 +113,7 @@ const plainUsers = mysqlTable('users', {
 
 describe('mysql value helpers — model derivation', () => {
   it('creator and schema tables derive the same select model as a plain table', () => {
+    expect(getTableConfig(toDrizzle(plainUsers)).name).toBe('users');
     const creatorRow: InferSelectModel<typeof creatorUsers> = {id: 1, name: 'ann'};
     const schemaRow: InferSelectModel<typeof schemaUsers> = creatorRow;
     const plainRow: InferSelectModel<typeof plainUsers> = schemaRow;

--- a/packages/drizzle-orm-mysql-core/src/valueHelpers.spec.ts
+++ b/packages/drizzle-orm-mysql-core/src/valueHelpers.spec.ts
@@ -1,0 +1,122 @@
+/* ########
+ * 2026 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+// Value pins for the mysql helpers that produce handles rather than plain
+// tables: mysqlSchema (and its .table member) and mysqlTableCreator. Raw
+// drizzle is the oracle: every recorded handle must materialize through
+// toDrizzle into the same object drizzle builds by hand. These specs are
+// purely value-level (no marker API), so the Marker test coverage rule does
+// not apply here.
+
+import {describe, it, expect} from 'vitest';
+import * as dzMy from 'drizzle-orm/mysql-core';
+import {getTableConfig} from 'drizzle-orm/mysql-core';
+import {index, int, mysqlSchema, mysqlTable, mysqlTableCreator, varchar} from './index.ts';
+import type {InferSelectModel} from '@mionjs/drizzle-orm';
+import {toDrizzle} from './drizzle.ts';
+
+/** Compact getTableConfig projection: just what the helper wiring decides
+ *  (the wide per-column matrix is already pinned by index.spec.ts). */
+function project(table: Parameters<typeof getTableConfig>[0]) {
+  const config = getTableConfig(table);
+  return {
+    name: config.name,
+    schema: config.schema,
+    columns: config.columns.map((column) => ({
+      name: column.name,
+      sqlType: column.getSQLType(),
+      notNull: column.notNull,
+      hasDefault: column.hasDefault,
+      primary: column.primary,
+    })),
+    indexes: config.indexes.map((idx) => {
+      const indexConfig = (idx as unknown as {config: {name?: string; unique: boolean; columns: unknown[]}}).config;
+      return {
+        name: indexConfig.name,
+        unique: indexConfig.unique,
+        columns: indexConfig.columns.map((column) => (column as {name: string}).name),
+      };
+    }),
+  };
+}
+
+// ── mysqlSchema ──────────────────────────────────────────────────────────────
+
+const appSchema = mysqlSchema('app');
+const dzAppSchema = dzMy.mysqlSchema('app');
+
+const schemaUsers = appSchema.table(
+  'users',
+  {
+    id: int('id').primaryKey(),
+    name: varchar('name', {length: 50}).notNull(),
+  },
+  (t) => [index('app_users_name_idx').on(t.name)]
+);
+const dzSchemaUsers = dzAppSchema.table(
+  'users',
+  {
+    id: dzMy.int('id').primaryKey(),
+    name: dzMy.varchar('name', {length: 50}).notNull(),
+  },
+  (t) => [dzMy.index('app_users_name_idx').on(t.name)]
+);
+
+describe('mysql value helpers — mysqlSchema', () => {
+  it('the schema handle materializes to a real drizzle MySqlSchema', () => {
+    const materialized = toDrizzle(appSchema);
+    expect(materialized).toBeInstanceOf(dzMy.MySqlSchema);
+    expect((materialized as dzMy.MySqlSchema).schemaName).toBe('app');
+  });
+
+  it('schema.table materializes schema-qualified, equal to the raw drizzle twin', () => {
+    expect(project(toDrizzle(schemaUsers))).toEqual(project(dzSchemaUsers));
+    expect(getTableConfig(toDrizzle(schemaUsers)).schema).toBe('app');
+  });
+});
+
+// ── mysqlTableCreator ────────────────────────────────────────────────────────
+
+const prefixed = mysqlTableCreator((name) => `pre_${name}`);
+const dzPrefixed = dzMy.mysqlTableCreator((name) => `pre_${name}`);
+
+const creatorUsers = prefixed('users', {
+  id: int('id').primaryKey(),
+  name: varchar('name', {length: 50}).notNull(),
+});
+const dzCreatorUsers = dzPrefixed('users', {
+  id: dzMy.int('id').primaryKey(),
+  name: dzMy.varchar('name', {length: 50}).notNull(),
+});
+
+describe('mysql value helpers — mysqlTableCreator', () => {
+  it('applies the name mapper exactly like raw drizzle', () => {
+    expect(getTableConfig(toDrizzle(creatorUsers)).name).toBe('pre_users');
+    expect(project(toDrizzle(creatorUsers))).toEqual(project(dzCreatorUsers));
+  });
+
+  it('memoizes: every call returns the same drizzle table', () => {
+    expect(toDrizzle(creatorUsers)).toBe(toDrizzle(creatorUsers));
+  });
+});
+
+// ── model derivation on creator/schema tables ────────────────────────────────
+
+const plainUsers = mysqlTable('users', {
+  id: int('id').primaryKey(),
+  name: varchar('name', {length: 50}).notNull(),
+});
+
+describe('mysql value helpers — model derivation', () => {
+  it('creator and schema tables derive the same select model as a plain table', () => {
+    const creatorRow: InferSelectModel<typeof creatorUsers> = {id: 1, name: 'ann'};
+    const schemaRow: InferSelectModel<typeof schemaUsers> = creatorRow;
+    const plainRow: InferSelectModel<typeof plainUsers> = schemaRow;
+    const backToCreator: InferSelectModel<typeof creatorUsers> = plainRow;
+    expect(backToCreator).toEqual({id: 1, name: 'ann'});
+  });
+});

--- a/packages/drizzle-orm-pg-core/src/valueHelpers.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/valueHelpers.spec.ts
@@ -1,0 +1,162 @@
+/* ########
+ * 2026 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+// Value pins for the pg helpers that produce handles rather than plain
+// tables: pgSchema (and its .table/.enum/.sequence members), pgSequence and
+// pgTableCreator. Raw drizzle is the oracle: every recorded handle must
+// materialize through toDrizzle into the same object drizzle builds by hand.
+// These specs are purely value-level (no marker API), so the Marker test
+// coverage rule does not apply here.
+
+import {describe, it, expect} from 'vitest';
+import * as dzPg from 'drizzle-orm/pg-core';
+import {getTableConfig} from 'drizzle-orm/pg-core';
+import {index, integer, pgSchema, pgSequence, pgTable, pgTableCreator, varchar} from './index.ts';
+import type {InferSelectModel} from '@mionjs/drizzle-orm';
+import {toDrizzle} from './drizzle.ts';
+
+/** Compact getTableConfig projection: just what the helper wiring decides
+ *  (the wide per-column matrix is already pinned by index.spec.ts). */
+function project(table: Parameters<typeof getTableConfig>[0]) {
+  const config = getTableConfig(table);
+  return {
+    name: config.name,
+    schema: config.schema,
+    columns: config.columns.map((column) => ({
+      name: column.name,
+      sqlType: column.getSQLType(),
+      notNull: column.notNull,
+      hasDefault: column.hasDefault,
+      primary: column.primary,
+    })),
+    indexes: config.indexes.map((idx) => {
+      const indexConfig = (idx as unknown as {config: {name?: string; unique: boolean; columns: unknown[]}}).config;
+      return {
+        name: indexConfig.name,
+        unique: indexConfig.unique,
+        columns: indexConfig.columns.map((column) => (column as {name: string}).name),
+      };
+    }),
+  };
+}
+
+const sequenceFields = (sequence: unknown) => {
+  const {seqName, seqOptions, schema} = sequence as {seqName?: string; seqOptions?: object; schema?: string};
+  return {seqName, seqOptions, schema};
+};
+
+// ── pgSchema and its members ─────────────────────────────────────────────────
+
+const appSchema = pgSchema('app');
+const dzAppSchema = dzPg.pgSchema('app');
+
+const schemaUsers = appSchema.table(
+  'users',
+  {
+    id: integer('id').primaryKey(),
+    name: varchar('name', {length: 50}).notNull(),
+  },
+  (t) => [index('app_users_name_idx').on(t.name)]
+);
+const dzSchemaUsers = dzAppSchema.table(
+  'users',
+  {
+    id: dzPg.integer('id').primaryKey(),
+    name: dzPg.varchar('name', {length: 50}).notNull(),
+  },
+  (t) => [dzPg.index('app_users_name_idx').on(t.name)]
+);
+
+describe('pg value helpers — pgSchema', () => {
+  it('the schema handle materializes to a real drizzle PgSchema', () => {
+    const materialized = toDrizzle(appSchema);
+    expect(materialized).toBeInstanceOf(dzPg.PgSchema);
+    expect(materialized.schemaName).toBe('app');
+  });
+
+  it('schema.table materializes schema-qualified, equal to the raw drizzle twin', () => {
+    expect(project(toDrizzle(schemaUsers))).toEqual(project(dzSchemaUsers));
+    expect(getTableConfig(toDrizzle(schemaUsers)).schema).toBe('app');
+  });
+
+  it('schema.enum materializes schema-qualified with the recorded name and values', () => {
+    const moodEnum = appSchema.enum('mood', ['happy', 'sad']);
+    const dzMoodEnum = dzAppSchema.enum('mood', ['happy', 'sad']);
+    const materialized = toDrizzle(moodEnum);
+    expect(materialized.enumName).toBe(dzMoodEnum.enumName);
+    expect(materialized.enumValues).toEqual(dzMoodEnum.enumValues);
+    expect((materialized as unknown as {schema?: string}).schema).toBe('app');
+  });
+
+  it('schema.sequence materializes to the drizzle sequence with name, options and schema', () => {
+    const appSeq = appSchema.sequence('app_seq', {startWith: 100, increment: 5});
+    const dzAppSeq = dzAppSchema.sequence('app_seq', {startWith: 100, increment: 5});
+    const materialized = toDrizzle(appSeq);
+    expect(dzPg.isPgSequence(materialized)).toBe(true);
+    expect(sequenceFields(materialized)).toEqual(sequenceFields(dzAppSeq));
+  });
+});
+
+// ── pgSequence ───────────────────────────────────────────────────────────────
+
+describe('pg value helpers — pgSequence', () => {
+  it('materializes with the recorded name and options, equal to raw drizzle', () => {
+    const orderSeq = pgSequence('order_seq', {startWith: 10, increment: 2, cycle: true});
+    const dzOrderSeq = dzPg.pgSequence('order_seq', {startWith: 10, increment: 2, cycle: true});
+    const materialized = toDrizzle(orderSeq);
+    expect(dzPg.isPgSequence(materialized)).toBe(true);
+    expect(sequenceFields(materialized)).toEqual(sequenceFields(dzOrderSeq));
+  });
+
+  it('the no-options form materializes too, memoized', () => {
+    const bareSeq = pgSequence('bare_seq');
+    expect(sequenceFields(toDrizzle(bareSeq))).toEqual(sequenceFields(dzPg.pgSequence('bare_seq')));
+    expect(toDrizzle(bareSeq)).toBe(toDrizzle(bareSeq));
+  });
+});
+
+// ── pgTableCreator ───────────────────────────────────────────────────────────
+
+const prefixed = pgTableCreator((name) => `pre_${name}`);
+const dzPrefixed = dzPg.pgTableCreator((name) => `pre_${name}`);
+
+const creatorUsers = prefixed('users', {
+  id: integer('id').primaryKey(),
+  name: varchar('name', {length: 50}).notNull(),
+});
+const dzCreatorUsers = dzPrefixed('users', {
+  id: dzPg.integer('id').primaryKey(),
+  name: dzPg.varchar('name', {length: 50}).notNull(),
+});
+
+describe('pg value helpers — pgTableCreator', () => {
+  it('applies the name mapper exactly like raw drizzle', () => {
+    expect(getTableConfig(toDrizzle(creatorUsers)).name).toBe('pre_users');
+    expect(project(toDrizzle(creatorUsers))).toEqual(project(dzCreatorUsers));
+  });
+
+  it('memoizes: every call returns the same drizzle table', () => {
+    expect(toDrizzle(creatorUsers)).toBe(toDrizzle(creatorUsers));
+  });
+});
+
+// ── model derivation on creator/schema tables ────────────────────────────────
+
+const plainUsers = pgTable('users', {
+  id: integer('id').primaryKey(),
+  name: varchar('name', {length: 50}).notNull(),
+});
+
+describe('pg value helpers — model derivation', () => {
+  it('creator and schema tables derive the same select model as a plain table', () => {
+    const creatorRow: InferSelectModel<typeof creatorUsers> = {id: 1, name: 'ann'};
+    const schemaRow: InferSelectModel<typeof schemaUsers> = creatorRow;
+    const plainRow: InferSelectModel<typeof plainUsers> = schemaRow;
+    const backToCreator: InferSelectModel<typeof creatorUsers> = plainRow;
+    expect(backToCreator).toEqual({id: 1, name: 'ann'});
+  });
+});

--- a/packages/drizzle-orm-pg-core/src/valueHelpers.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/valueHelpers.spec.ts
@@ -153,6 +153,7 @@ const plainUsers = pgTable('users', {
 
 describe('pg value helpers — model derivation', () => {
   it('creator and schema tables derive the same select model as a plain table', () => {
+    expect(getTableConfig(toDrizzle(plainUsers)).name).toBe('users');
     const creatorRow: InferSelectModel<typeof creatorUsers> = {id: 1, name: 'ann'};
     const schemaRow: InferSelectModel<typeof schemaUsers> = creatorRow;
     const plainRow: InferSelectModel<typeof plainUsers> = schemaRow;

--- a/packages/drizzle-orm-sqlite-core/src/valueHelpers.spec.ts
+++ b/packages/drizzle-orm-sqlite-core/src/valueHelpers.spec.ts
@@ -1,0 +1,92 @@
+/* ########
+ * 2026 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+// Value pins for sqliteTableCreator, the one sqlite helper that produces a
+// handle rather than a plain table. Raw drizzle is the oracle: the recorded
+// creator must materialize through toDrizzle into the same table drizzle
+// builds by hand. These specs are purely value-level (no marker API), so the
+// Marker test coverage rule does not apply here.
+
+import {describe, it, expect} from 'vitest';
+import * as dzSqlite from 'drizzle-orm/sqlite-core';
+import {getTableConfig} from 'drizzle-orm/sqlite-core';
+import {index, integer, sqliteTable, sqliteTableCreator, text} from './index.ts';
+import type {InferSelectModel} from '@mionjs/drizzle-orm';
+import {toDrizzle} from './drizzle.ts';
+
+/** Compact getTableConfig projection: just what the helper wiring decides
+ *  (the wide per-column matrix is already pinned by index.spec.ts). */
+function project(table: Parameters<typeof getTableConfig>[0]) {
+  const config = getTableConfig(table);
+  return {
+    name: config.name,
+    columns: config.columns.map((column) => ({
+      name: column.name,
+      sqlType: column.getSQLType(),
+      notNull: column.notNull,
+      hasDefault: column.hasDefault,
+      primary: column.primary,
+    })),
+    indexes: config.indexes.map((idx) => {
+      const indexConfig = (idx as unknown as {config: {name?: string; unique: boolean; columns: unknown[]}}).config;
+      return {
+        name: indexConfig.name,
+        unique: indexConfig.unique,
+        columns: indexConfig.columns.map((column) => (column as {name: string}).name),
+      };
+    }),
+  };
+}
+
+// ── sqliteTableCreator ───────────────────────────────────────────────────────
+
+const prefixed = sqliteTableCreator((name) => `pre_${name}`);
+const dzPrefixed = dzSqlite.sqliteTableCreator((name) => `pre_${name}`);
+
+const creatorUsers = prefixed(
+  'users',
+  {
+    id: integer('id').primaryKey(),
+    name: text('name').notNull(),
+  },
+  (t) => [index('users_name_idx').on(t.name)]
+);
+const dzCreatorUsers = dzPrefixed(
+  'users',
+  {
+    id: dzSqlite.integer('id').primaryKey(),
+    name: dzSqlite.text('name').notNull(),
+  },
+  (t) => [dzSqlite.index('users_name_idx').on(t.name)]
+);
+
+describe('sqlite value helpers — sqliteTableCreator', () => {
+  it('applies the name mapper exactly like raw drizzle (extraConfig included)', () => {
+    expect(getTableConfig(toDrizzle(creatorUsers)).name).toBe('pre_users');
+    expect(project(toDrizzle(creatorUsers))).toEqual(project(dzCreatorUsers));
+  });
+
+  it('memoizes: every call returns the same drizzle table', () => {
+    expect(toDrizzle(creatorUsers)).toBe(toDrizzle(creatorUsers));
+  });
+});
+
+// ── model derivation on creator tables ───────────────────────────────────────
+
+const plainUsers = sqliteTable('users', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+
+describe('sqlite value helpers — model derivation', () => {
+  it('a creator table derives the same select model as a plain table', () => {
+    const creatorRow: InferSelectModel<typeof creatorUsers> = {id: 1, name: 'ann'};
+    const plainRow: InferSelectModel<typeof plainUsers> = creatorRow;
+    const backToCreator: InferSelectModel<typeof creatorUsers> = plainRow;
+    expect(backToCreator).toEqual({id: 1, name: 'ann'});
+  });
+});

--- a/packages/drizzle-orm-sqlite-core/src/valueHelpers.spec.ts
+++ b/packages/drizzle-orm-sqlite-core/src/valueHelpers.spec.ts
@@ -84,6 +84,7 @@ const plainUsers = sqliteTable('users', {
 
 describe('sqlite value helpers — model derivation', () => {
   it('a creator table derives the same select model as a plain table', () => {
+    expect(getTableConfig(toDrizzle(plainUsers)).name).toBe('users');
     const creatorRow: InferSelectModel<typeof creatorUsers> = {id: 1, name: 'ann'};
     const plainRow: InferSelectModel<typeof plainUsers> = creatorRow;
     const backToCreator: InferSelectModel<typeof creatorUsers> = plainRow;


### PR DESCRIPTION
Adds comprehensive test coverage for six drizzle authoring helpers that were marked `migrated` in manifests but had zero spec coverage: `pgSchema`, `pgSequence`, `pgTableCreator` (pg), `mysqlSchema`, `mysqlTableCreator` (mysql), and `sqliteTableCreator` (sqlite).

## Changes

- **pg**: New `src/valueHelpers.spec.ts` with 10 tests covering:
  - `pgSchema` handle materializes to drizzle PgSchema (instanceof + schemaName check)
  - `schema.table()` with extraConfig produces schema-qualified tables equal to raw drizzle twins
  - `schema.enum()` and `schema.sequence()` materialize with correct name/values/schema
  - Standalone `pgSequence` (with and without options) compares against raw drizzle
  - `pgTableCreator` applies name mapper and memoizes correctly
  - Model derivation: `InferSelectModel` rows are mutually assignable across creator/schema/plain tables

- **mysql**: New `src/valueHelpers.spec.ts` with 5 tests covering:
  - `mysqlSchema` handle materializes to drizzle MySqlSchema
  - `schema.table()` produces schema-qualified tables equal to raw drizzle
  - `mysqlTableCreator` applies name mapper and memoizes

- **sqlite**: New `src/valueHelpers.spec.ts` with 2 tests covering:
  - `sqliteTableCreator` applies name mapper with extraConfig and memoizes
  - Model derivation works on creator tables

All specs are purely value-level (no marker API), so the Marker test coverage rule does not apply; each file header documents this. Tests use `toDrizzle()` to materialize recorded handles and compare against raw drizzle equivalents via `getTableConfig` projections and direct field inspection.

## Implementation details

- Each spec file uses a compact `project()` helper to extract the relevant table config fields (name, schema, columns, indexes) for comparison, avoiding the wide per-column matrix already pinned by existing index specs.
- Model derivation is checked with compile-time type assignments so specs remain valid when the type-road ergonomics rework changes helper return types.
- Memoization is verified by identity checks (`toBe()`) on repeated `toDrizzle()` calls.
- Sequence materialization compares `seqName`, `seqOptions`, and `schema` fields against raw drizzle twins.

https://claude.ai/code/session_01AS6KBUtR1BXKxQeckf3hc1