### PR TITLE
perf(drizzle): stop the table types printing their columns twice in .d.ts

### DIFF
--- a/docs/todos/drizzle-type-road-modifier-props.md
+++ b/docs/todos/drizzle-type-road-modifier-props.md
@@ -1,0 +1,102 @@
+---
+type: chore
+spec: guidelines
+status: ready
+created: 2026-08-30
+---
+
+# Drizzle type road: modifiers as props, not intersected markers
+
+## Intent
+
+Authoring a slim table as a TYPE costs four times what the builders cost for the
+identical model, and three quarters of that is one thing: unpicking the modifier marker
+intersections. Measured on the real packages, same five columns, same
+`InferSelectModel`:
+
+| How the table is written                                | Net instantiations |
+| ------------------------------------------------------- | -----------------: |
+| builder road, `pgTable('users', {...})`                   |                501 |
+| type road, `Varchar<'name', {length: 100}> & NotNull`     |               1287 |
+| type road, columns already branded (no normalization)     |                321 |
+
+The third row names the branded column types directly, which skips `TypedCols` /
+`NormalizeCol` entirely. Nobody would author that by hand, but as a measurement it puts a
+number on the normalization: **966 of the type road's 1287**. The already-branded form is
+cheaper than the builder road, because no value-level inference happens, so the ceiling
+here is real.
+
+Consumers pay this in their editor on every keystroke, and the type road is the road we
+point people at for schema-first work.
+
+The full background, including the four column redesigns that were measured and rejected,
+is in [`packages/drizzle-orm/TYPE-COST.md`](../../packages/drizzle-orm/TYPE-COST.md).
+Read it before starting: it also records the trap that a small prototype of a new column
+design always looks good next to the real implementation.
+
+## Direction
+
+Verified starting points; the implementer plans the details.
+
+Today every modifier is its own interface holding one optional symbol-keyed member
+(`NotNull` at packages/drizzle-orm/src/typeColumns.ts:90), so an authored column is an
+intersection the checker must merge before anything can read it:
+
+```ts
+name: Varchar<'name', {length: 100}> & NotNull;
+createdAt: Timestamp<'created_at', {mode: 'date'}> & NotNull & DefaultNow;
+```
+
+The direction is to let the modifiers arrive as one literal object instead, so there is
+no intersection to unpick:
+
+```ts
+name: Varchar<'name', {length: 100; notNull: true}>;
+createdAt: Timestamp<'created_at', {mode: 'date'; notNull: true; defaultNow: true}>;
+```
+
+What that removes is `ColModsOf` (packages/drizzle-orm/src/typeColumns.ts:201), which
+re-materializes the merged intersection into a fresh object per column before any flag can
+be read. What it does NOT remove is the seven-odd `HasAnyKey` probes per column that derive
+`notNull` / `hasDefault` / `insertExcluded` from those mods, nor `NormalizeCol` itself
+(typeColumns.ts:282). **So the share of the 966 this collects is unknown, and measuring it
+is the first task, not the last.** If the isolated change does not move the number
+materially, say so and stop rather than shipping churn.
+
+Things to weigh, none of them settled:
+
+- **Config or third argument.** Folding the modifiers into the existing config object
+  (`Varchar<'name', {length: 100; notNull: true}>`) keeps the arity, but mixes drizzle's
+  own builder config with our flags in one bag, which the reflection walker and the convert
+  program both have to keep telling apart. A separate third argument keeps them apart at
+  the cost of one more type parameter. Measure both.
+- **The builder road must not regress.** It is the default road and it is the one that
+  scales with table width. Any change here is a loss if `pgTable(...)` gets more expensive.
+- **Two readers depend on the current sentinels.** The runtime bridge reads them in
+  `readColumnSpec` / `applyMods` (packages/drizzle-orm/src/fromType.ts:133 and :168), and
+  the Go convert program reads `@rtColModsKey` by name
+  (ts-go-runtypes/internal/convert/drizzle.go:45). Both move in the same change or the
+  type road and `drizzle-migrate` break.
+- **Whether this is breaking.** The dialect packages are at 0.45.0 and ride the drizzle
+  version line. Check whether they are actually published before deciding between a clean
+  swap and keeping the marker spelling working alongside the props one. The predecessor
+  spec ([docs/done/drizzle-type-road-ergonomics.md](../done/drizzle-type-road-ergonomics.md))
+  reworked this surface freely on the grounds that nothing was published yet; confirm that
+  still holds.
+- **Not in scope.** The `[rtTableKey]` meta shape, flattening columns into params bags, and
+  the ColumnFormat redesign. All measured, all rejected, all recorded in TYPE-COST.md.
+  Moving `toDrizzle` onto metadata-driven generation is a separate runtime question and
+  does not belong here.
+
+## Done when
+
+- A measured before/after on the real packages, in the same harness TYPE-COST.md uses, that
+  isolates this change alone. TYPE-COST.md updated with the number, whichever way it goes.
+- The type road's cost for a five-column table with a select model is materially closer to
+  321 than to 1287, or the todo is closed with the measurement showing why it cannot be.
+- The builder road's cost has not gone up, at 5, 20 and 40 columns.
+- `pnpm test` green, the type-budget budgets lowered rather than raised, the reflection
+  bridge and the Go convert program moved with the sentinels, and the drizzle-e2e lane
+  still passes on all three dialects.
+- Website docs and `packages/examples/` updated to the new spelling wherever the type road
+  is shown.

--- a/packages/drizzle-orm-mysql-core/src/index.ts
+++ b/packages/drizzle-orm-mysql-core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   MyExtraConfigEntry,
   MyExtraConfigFn,
   MySqlSchema,
+  MysqlBuilderTable,
   MysqlTable,
   PrimaryKeyEntry,
   UniqueEntry,

--- a/packages/drizzle-orm-mysql-core/src/table.ts
+++ b/packages/drizzle-orm-mysql-core/src/table.ts
@@ -33,15 +33,21 @@ import type {} from './helpers.ts';
  *  a tuple of table entries (IndexEntry, CheckEntry, ... or the raw TableEntry
  *  carrier). Normalizes to the same RtTable shape the builders produce, so
  *  models and refinement work unchanged; materialize with tableFromType. */
-export type MysqlTable<
-  TName extends string,
-  Cols extends object,
-  Extras extends readonly object[] = [],
-  // Internal fast path: the factories pass their already-branded Cols here so
-  // a builder table never evaluates the TypedCols conditional (type-budget
-  // sensitive); authored type-road tables omit it and get normalized.
-  NormalizedCols extends object = TypedCols<Cols>,
-> = NormalizedCols & {readonly [rtTableKey]: RtTableMetaWithExtras<TName, NormalizedCols, Extras>};
+export type MysqlTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = MysqlBuilderTable<
+  TName,
+  TypedCols<Cols>,
+  Extras
+>;
+
+/** A mysql table whose columns are ALREADY normalized: what mysqlTable() returns,
+ *  and what MysqlTable resolves to once it has normalized an authored columns
+ *  record. Its own type alias rather than an extra type parameter on
+ *  MysqlTable, because a parameter the factories fill with the same Cols they
+ *  pass in slot two makes declaration emit print the whole columns record TWICE
+ *  in every consumer's .d.ts (measured: it nearly doubles the emitted table type). */
+export type MysqlBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
+  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
+};
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -148,12 +154,12 @@ export function mysqlTable<TName extends string, Cols extends Record<string, Any
   name: TName,
   columns: Cols,
   extraConfig?: MyExtraConfigFn<Cols>
-): MysqlTable<TName, Cols, [], Cols>;
+): MysqlBuilderTable<TName, Cols>;
 export function mysqlTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: MySqlColumnHelpers) => Cols,
   extraConfig?: MyExtraConfigFn<Cols>
-): MysqlTable<TName, Cols, [], Cols>;
+): MysqlBuilderTable<TName, Cols>;
 export function mysqlTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, mysqlBuildTable);
 }
@@ -165,12 +171,12 @@ export function mysqlTableCreator(customizeTableName: (name: string) => string) 
     name: TName,
     columns: Cols,
     extraConfig?: MyExtraConfigFn<Cols>
-  ): MysqlTable<TName, Cols, [], Cols>;
+  ): MysqlBuilderTable<TName, Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: MySqlColumnHelpers) => Cols,
     extraConfig?: MyExtraConfigFn<Cols>
-  ): MysqlTable<TName, Cols, [], Cols>;
+  ): MysqlBuilderTable<TName, Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-pg-core/src/index.ts
+++ b/packages/drizzle-orm-pg-core/src/index.ts
@@ -28,6 +28,7 @@ export type {
   CheckEntry,
   ForeignKeyEntry,
   IndexEntry,
+  PgBuilderTable,
   PgExtraConfigColumns,
   PgExtraConfigEntry,
   PgExtraConfigFn,

--- a/packages/drizzle-orm-pg-core/src/table.ts
+++ b/packages/drizzle-orm-pg-core/src/table.ts
@@ -43,19 +43,23 @@ import type {} from './helpers.ts';
  *  of table entries (IndexEntry, CheckEntry, ... or the raw TableEntry
  *  carrier). Normalizes to the same RtTable shape the builders produce, so
  *  models and refinement work unchanged; materialize with tableFromType. */
-export type PgTable<
-  TName extends string,
-  Cols extends object,
-  Extras extends readonly object[] = [],
-  // Internal fast path: the factories pass their already-branded Cols here so
-  // a builder table never evaluates the TypedCols conditional (type-budget
-  // sensitive); authored type-road tables omit it and get normalized.
-  NormalizedCols extends object = TypedCols<Cols>,
-> = NormalizedCols & {
-  readonly [rtTableKey]: RtTableMetaWithExtras<TName, NormalizedCols, Extras>;
+export type PgTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = PgBuilderTable<
+  TName,
+  TypedCols<Cols>,
+  Extras
+>;
+
+/** A pg table whose columns are ALREADY normalized: what pgTable() returns, and
+ *  what PgTable resolves to once it has normalized an authored columns record.
+ *  Its own type alias rather than an extra type parameter on PgTable, because a
+ *  parameter the factories fill with the same Cols they pass in slot two makes
+ *  declaration emit print the whole columns record TWICE in every consumer's
+ *  .d.ts (measured: it nearly doubles the emitted table type). */
+export type PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
+  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
   // Same object as the meta key, never a third intersection member: a declared
   // table pays one property, not another object (type-budget sensitive).
-  enableRLS(): PgTableWithRLS<TName, NormalizedCols, Extras>;
+  enableRLS(): PgTableWithRLS<TName, Cols, Extras>;
 };
 
 /** A pg table with row level security on: the same table minus enableRLS, so it
@@ -171,12 +175,12 @@ export function pgTable<TName extends string, Cols extends Record<string, AnyRtC
   name: TName,
   columns: Cols,
   extraConfig?: PgExtraConfigFn<Cols>
-): PgTable<TName, Cols, [], Cols>;
+): PgBuilderTable<TName, Cols>;
 export function pgTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: PgColumnHelpers) => Cols,
   extraConfig?: PgExtraConfigFn<Cols>
-): PgTable<TName, Cols, [], Cols>;
+): PgBuilderTable<TName, Cols>;
 export function pgTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, pgBuildTable);
 }
@@ -188,12 +192,12 @@ export function pgTableCreator(customizeTableName: (name: string) => string) {
     name: TName,
     columns: Cols,
     extraConfig?: PgExtraConfigFn<Cols>
-  ): PgTable<TName, Cols, [], Cols>;
+  ): PgBuilderTable<TName, Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: PgColumnHelpers) => Cols,
     extraConfig?: PgExtraConfigFn<Cols>
-  ): PgTable<TName, Cols, [], Cols>;
+  ): PgBuilderTable<TName, Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-sqlite-core/src/index.ts
+++ b/packages/drizzle-orm-sqlite-core/src/index.ts
@@ -23,6 +23,7 @@ export type {
   ForeignKeyEntry,
   IndexEntry,
   PrimaryKeyEntry,
+  SqliteBuilderTable,
   SqliteExtraConfigColumns,
   SqliteExtraConfigEntry,
   SqliteExtraConfigFn,

--- a/packages/drizzle-orm-sqlite-core/src/table.ts
+++ b/packages/drizzle-orm-sqlite-core/src/table.ts
@@ -32,15 +32,21 @@ import type {} from './helpers.ts';
  *  a tuple of table entries (IndexEntry, CheckEntry, ... or the raw TableEntry
  *  carrier). Normalizes to the same RtTable shape the builders produce, so
  *  models and refinement work unchanged; materialize with tableFromType. */
-export type SqliteTable<
-  TName extends string,
-  Cols extends object,
-  Extras extends readonly object[] = [],
-  // Internal fast path: the factories pass their already-branded Cols here so
-  // a builder table never evaluates the TypedCols conditional (type-budget
-  // sensitive); authored type-road tables omit it and get normalized.
-  NormalizedCols extends object = TypedCols<Cols>,
-> = NormalizedCols & {readonly [rtTableKey]: RtTableMetaWithExtras<TName, NormalizedCols, Extras>};
+export type SqliteTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = SqliteBuilderTable<
+  TName,
+  TypedCols<Cols>,
+  Extras
+>;
+
+/** A sqlite table whose columns are ALREADY normalized: what sqliteTable() returns,
+ *  and what SqliteTable resolves to once it has normalized an authored columns
+ *  record. Its own type alias rather than an extra type parameter on
+ *  SqliteTable, because a parameter the factories fill with the same Cols they
+ *  pass in slot two makes declaration emit print the whole columns record TWICE
+ *  in every consumer's .d.ts (measured: it nearly doubles the emitted table type). */
+export type SqliteBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
+  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
+};
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -147,12 +153,12 @@ export function sqliteTable<TName extends string, Cols extends Record<string, An
   name: TName,
   columns: Cols,
   extraConfig?: SqliteExtraConfigFn<Cols>
-): SqliteTable<TName, Cols, [], Cols>;
+): SqliteBuilderTable<TName, Cols>;
 export function sqliteTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: SQLiteColumnHelpers) => Cols,
   extraConfig?: SqliteExtraConfigFn<Cols>
-): SqliteTable<TName, Cols, [], Cols>;
+): SqliteBuilderTable<TName, Cols>;
 export function sqliteTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, sqliteBuildTable);
 }
@@ -164,12 +170,12 @@ export function sqliteTableCreator(customizeTableName: (name: string) => string)
     name: TName,
     columns: Cols,
     extraConfig?: SqliteExtraConfigFn<Cols>
-  ): SqliteTable<TName, Cols, [], Cols>;
+  ): SqliteBuilderTable<TName, Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: SQLiteColumnHelpers) => Cols,
     extraConfig?: SqliteExtraConfigFn<Cols>
-  ): SqliteTable<TName, Cols, [], Cols>;
+  ): SqliteBuilderTable<TName, Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm/TYPE-COST.md
+++ b/packages/drizzle-orm/TYPE-COST.md
@@ -1,0 +1,141 @@
+# Type-instantiation cost of the slim column and table types
+
+Every consumer's editor pays these numbers on every keystroke, so this file records what
+has been measured, to keep the next person from re-deriving it. The measurements come
+from the harness in [`packages/type-budget`](../type-budget/), the same one behind
+[`reports/model-pipeline.md`](../type-budget/reports/model-pipeline.md); each figure
+below is **net instantiations**, the snippet's own cost with the import baseline
+subtracted.
+
+## The headline: the type road pays 4x the builder road for the same model
+
+The same five-column table, the same `InferSelectModel`, three ways of writing it:
+
+| How the table is written                                | Net instantiations |
+| ------------------------------------------------------- | -----------------: |
+| builder road, `pgTable('users', {...})`                 |                501 |
+| type road, `PgTable<'users', {Varchar<...> & NotNull}>` |               1287 |
+| type road, columns already branded (`PgBuilderTable`)   |                321 |
+
+The third row skips `TypedCols` / `NormalizeCol` entirely by naming the branded column
+types directly. It is not a design anyone would author by hand, but as a measurement it
+isolates the normalization exactly:
+
+**966 of the type road's 1287, three quarters of it, is turning
+`Varchar<'name', {length: 100}> & NotNull` into a branded column.** Everything else about
+the type road is already cheaper than the builder road, because no value-level inference
+happens.
+
+That is where the money is. Anything that lets the type road spell its modifiers without
+an intersection the checker has to unpick would collect most of that 966.
+
+## Rejected: moving the column metadata into a flat "params bag"
+
+The idea: a column type stops carrying its metadata in generic positions
+(`RtPgColumn<Data, NotNull, HasDefault, InsertExcluded>`) and carries it as props on one
+object instead, the way a runtypes `TypeFormat` does. Four shapes were measured. All four
+lost.
+
+### It is not the `[rtTableKey]` duplication
+
+Hovering a slim table shows its columns once in the intersection and again inside the
+meta, which reads like wasted work. It is not: TypeScript instantiates the columns once
+and both positions reference the same type.
+
+| Meta shape                                         | Net |
+| -------------------------------------------------- | --: |
+| `Cols & {[key]: Meta<Name, Cols, Extras>}` (today) | 219 |
+| `Cols & {[key]: Meta<Name, Extras>}` (no columns)  | 219 |
+
+Writing the mapped type out twice by hand, with no shared alias, costs **+1**. And
+dropping `columns` from the meta makes things worse, because `ColsOf` stops being an
+indexed access:
+
+```ts
+type ColsOf<T> = T[typeof rtTableKey]['columns']; // 224
+type ColsOf<T> = Omit<T, typeof rtTableKey>; // 264
+```
+
+### Flattening the columns to bags, measured against the real packages
+
+Keep today's column brand, but flatten each column to `{data, notNull, hasDefault,
+insertExcluded}` once per table and let the models read those props by indexed access
+instead of four `infer` conditionals per column. This is the only variant that could be
+measured with no prototype stand-ins on either side, so it is the one to trust.
+
+| Columns | today's `Infer*` | bag models |      |
+| ------: | ---------------: | ---------: | ---- |
+|       5 |              888 |        897 | +1%  |
+|      10 |             1078 |       1175 | +9%  |
+|      20 |             1448 |       1727 | +19% |
+|      40 |             2198 |       2835 | +29% |
+
+Worse, and worse as the table widens. The mapped pass that builds the bags costs the same
+conditionals the models were doing, and then the models pay an extra indexed access on
+top. The sharing never pays for the object.
+
+### Full ColumnFormat, modifiers merged by a mapped type
+
+`Merge<P, {notNull: true}>` per builder call and per modifier. Measured against the real
+`pgTable`:
+
+| Case                       | today | ColumnFormat |
+| -------------------------- | ----: | -----------: |
+| declare a 5-column table   |   314 | 1013 (+223%) |
+| + select model             |   501 | 1233 (+146%) |
+| + select and insert models |  1067 |  1606 (+51%) |
+| 40 columns, both models    |  2213 | 4804 (+117%) |
+
+A mapped type per modifier call is far too expensive for the builder road.
+
+### ColumnFormat, modifiers accumulated by intersection
+
+Drop `Merge`: every prop optional, absent meaning false, `.notNull()` returns
+`ColFormat<P & {notNull: true}>`, and the models probe with a single `extends` and no
+`infer`. This is the best version of the idea.
+
+| Columns | today | merge-free bag |      |
+| ------: | ----: | -------------: | ---- |
+|       5 |   903 |            552 | -39% |
+|      10 |  1093 |            818 | -25% |
+|      20 |  1463 |           1372 | -6%  |
+|      40 |  2213 |           2458 | +11% |
+
+It wins on narrow tables and loses on wide ones, crossing over around twenty columns. And
+this is a **stripped prototype measured against the real implementation**: it has no
+runtype formats, no key flags, no `$type`, no arrays, no reflection sentinels. Every
+feature added moves the crossover down. The apparent win is the prototype's simplicity,
+not the design's.
+
+That is the trap in this whole area, and it is worth stating plainly: a small prototype of
+a new column design will always look good next to the real one. The bag-flattening figures
+above are the honest measurement, because both sides are real code.
+
+## What this does not measure
+
+- `refineTableType`, the single most expensive step in the pipeline at 1198.
+- The runtime half. Moving `toDrizzle` onto metadata-driven generation, the way MockData
+  reads a `TypeFormat`, is a runtime architecture question and independent of everything
+  above. Half of it already exists: `buildRtTableFromGraph` reconstructs a slim table from
+  the reflected `@rtTableKey` meta. Two things to settle before the builder road joins it:
+  a bag has no call ORDER, where the recorder replays modifiers in the order they were
+  written, and runtime-only values (interpolated `sql`, `$defaultFn`, cross-table
+  references) can live in a runtime bag but never in a type, which is why the type road
+  already routes them through `options.runtime`.
+
+## Reproducing
+
+Build measurers with `makeMeasurer` from
+[`packages/ts-runtypes/test/types/compileHarness.ts`](../ts-runtypes/test/types/compileHarness.ts),
+passing `RESOLVING_OPTIONS` and a snippet path inside `packages/type-budget` so the
+workspace packages resolve. Put each design's machinery in its own PREAMBLE, so the
+baseline subtraction removes the machinery and what is left is what a user's table costs.
+
+Two traps:
+
+- **Consume the model.** Read fields into annotated consts. A bare
+  `type Row = InferSelectModel<...>` measures almost nothing, because the checker stays
+  lazy and the case looks free.
+- **Check the errors.** A snippet with type errors reports a number, and it is meaningless:
+  the checker stops early. The first run of this spike had a broken prototype and reported
+  a 57% win that vanished once it compiled.

--- a/packages/type-budget/reports/lane-comparison.json
+++ b/packages/type-budget/reports/lane-comparison.json
@@ -8,8 +8,8 @@
         {
           "step": 1,
           "label": "slim table + row",
-          "delta": 490,
-          "budget": 490
+          "delta": 489,
+          "budget": 489
         },
         {
           "step": 2,
@@ -36,7 +36,7 @@
           "budget": 2541
         }
       ],
-      "total": 5482
+      "total": 5481
     },
     {
       "name": "type-only",

--- a/packages/type-budget/reports/lane-comparison.md
+++ b/packages/type-budget/reports/lane-comparison.md
@@ -20,12 +20,12 @@ report, paid only in the files that run queries.
 
 | Step | Layer | slim | type-only | builder |
 | ---: | ----- | ---: | ---: | ---: |
-| 1 | declare the formatted row | 490 | 47 | 576 |
+| 1 | declare the formatted row | 489 | 47 | 576 |
 | 2 | refine two columns | 1198 | 393 | 384 |
 | 3 | select / insert / update models | 673 | 254 | 262 |
 | 4 | mion route api | 581 | 510 | 506 |
 | 5 | initClient | 2540 | 2601 | 2817 |
-| | **Total** | **5482** | **3805** | **4545** |
+| | **Total** | **5481** | **3805** | **4545** |
 
 ## Reading this
 

--- a/packages/type-budget/reports/model-pipeline.json
+++ b/packages/type-budget/reports/model-pipeline.json
@@ -5,50 +5,50 @@
     {
       "step": 1,
       "label": "slim table + row",
-      "delta": 490,
-      "budget": 490,
-      "cumulative": 490
+      "delta": 489,
+      "budget": 489,
+      "cumulative": 489
     },
     {
       "step": 2,
       "label": "refineTableType",
       "delta": 1198,
       "budget": 1198,
-      "cumulative": 1688
+      "cumulative": 1687
     },
     {
       "step": 3,
       "label": "Infer* models",
       "delta": 673,
       "budget": 673,
-      "cumulative": 2361
+      "cumulative": 2360
     },
     {
       "step": 4,
       "label": "mion route api",
       "delta": 581,
       "budget": 581,
-      "cumulative": 2942
+      "cumulative": 2941
     },
     {
       "step": 5,
       "label": "initClient",
       "delta": 2540,
       "budget": 2541,
-      "cumulative": 5482
+      "cumulative": 5481
     },
     {
       "step": 6,
       "label": "db query (toDrizzle)",
       "delta": 7847,
       "budget": 7850,
-      "cumulative": 13329
+      "cumulative": 13328
     }
   ],
   "consumer": {
-    "budget": 1787,
-    "netInstantiations": 1787,
+    "budget": 1784,
+    "netInstantiations": 1784,
     "keepsGenericAlias": true,
-    "dtsBytes": 1422
+    "dtsBytes": 970
   }
 }

--- a/packages/type-budget/reports/model-pipeline.md
+++ b/packages/type-budget/reports/model-pipeline.md
@@ -11,14 +11,14 @@ carries no signal on its own. Budgets may only ever be lowered.
 
 | Step | Layer | Net instantiations added | Budget | Cumulative |
 | ---: | ----- | -----------------------: | -----: | ---------: |
-| 1 | slim table + row | 490 | 490 | 490 |
-| 2 | refineTableType | 1198 | 1198 | 1688 |
-| 3 | Infer* models | 673 | 673 | 2361 |
-| 4 | mion route api | 581 | 581 | 2942 |
-| 5 | initClient | 2540 | 2541 | 5482 |
-| 6 | db query (toDrizzle) | 7847 | 7850 | 13329 |
+| 1 | slim table + row | 489 | 489 | 489 |
+| 2 | refineTableType | 1198 | 1198 | 1687 |
+| 3 | Infer* models | 673 | 673 | 2360 |
+| 4 | mion route api | 581 | 581 | 2941 |
+| 5 | initClient | 2540 | 2541 | 5481 |
+| 6 | db query (toDrizzle) | 7847 | 7850 | 13328 |
 
-Total for the whole chain: **13329**.
+Total for the whole chain: **13328**.
 
 Every one of these is paid again on every keystroke. TypeScript memoises type
 instantiations within a single check, but each edit builds a new checker, so the
@@ -28,9 +28,9 @@ work is redone. Parsing is reused across edits; type instantiation is not.
 
 | What | Value |
 | ---- | ----: |
-| Consumer net instantiations | 1787 |
-| Budget | 1787 |
-| Emitted declaration size (bytes) | 1422 |
+| Consumer net instantiations | 1784 |
+| Budget | 1784 |
+| Emitted declaration size (bytes) | 970 |
 | Declaration keeps the generic alias unresolved | yes |
 
 Declaration emit prints the type alias as it was written, never the type it

--- a/packages/type-budget/test/declarationEmit.test.ts
+++ b/packages/type-budget/test/declarationEmit.test.ts
@@ -121,6 +121,19 @@ describe('declaration emit over slim drizzle tables', () => {
     });
   }
 
+  // A library that exports its slim table ships that table's whole columns
+  // record in its .d.ts, and every consumer parses and checks what is there. The
+  // factories used to return `PgTable<Name, Cols, [], Cols>` — the columns in
+  // slot two AND again in the normalized fast-path slot — so the record was
+  // printed TWICE. Counting one column's own emitted type is what pins the fix:
+  // a return to the 4-parameter form doubles it and fails here.
+  it('the exported table prints its columns once, not twice', {timeout: 60_000}, () => {
+    const outcome = emitDeclarations(`${HEADER}${slimTable}\nexport const usersTable = users;\n`);
+    expect(outcome.emitSkipped).toBe(false);
+    const ageOccurrences = outcome.dts.split('RtPgIntColumn').length - 1;
+    expect(ageOccurrences, `emitted declaration:\n${outcome.dts}`).toBe(1);
+  });
+
   // Emit succeeding is not enough: the format metadata has to survive into the
   // declaration, or consumers lose the refined bounds.
   it('the emitted declaration still carries the format brand', {timeout: 60_000}, () => {

--- a/packages/type-budget/test/modelPipelineHarness.ts
+++ b/packages/type-budget/test/modelPipelineHarness.ts
@@ -103,7 +103,12 @@ export const PIPELINE_STEPS: PipelineStep[] = [
     // the callback's return type is now `readonly Entry[] | Record<string, Entry>`
     // — and a two-member union costs the checker 7 more instantiations than a
     // single array type. Measured by reverting exactly that one line.
-    budget: 490,
+    //
+    // 490 -> 489. The factories now return a 3-parameter PgBuilderTable instead
+    // of PgTable with its columns passed twice (slot two AND the normalized fast
+    // path), which also stops declaration emit printing the whole column record
+    // twice in every consumer's .d.ts.
+    budget: 489,
     body: `
 const users = pgTable('users', {
   name: varchar('name', {length: 100}).notNull(),
@@ -400,5 +405,8 @@ export function measureConsumerLane(): ConsumerLaneResult {
  *
  *  1785 -> 1787: the column brand gained the key flags drizzle's own typing
  *  reads (isPrimaryKey / isAutoincrement / hasRuntimeDefault / identity), which
- *  a consumer pays two instantiations to read past. **/
-export const CONSUMER_BUDGET = 1787;
+ *  a consumer pays two instantiations to read past.
+ *
+ *  1787 -> 1784: the table type stopped carrying its columns twice, so the
+ *  emitted declaration a consumer reads is a third smaller. **/
+export const CONSUMER_BUDGET = 1784;


### PR DESCRIPTION
Two commits: a measured perf fix, and the spike record that came out of investigating it.

## 1. Stop the table types printing their columns twice in `.d.ts`

Each dialect factory returned its table type with the columns in **two** slots:

```ts
): PgTable<TName, Cols, [], Cols>;   // slot two, and again in the fast-path slot
```

That 4th parameter (`NormalizedCols`) was an internal fast path so a builder table never evaluates the `TypedCols` conditional. It works, but TypeScript's declaration emit prints every type argument, defaulted ones included, so **every consumer's `.d.ts` carried the whole column record twice**.

Each dialect now has a 3-parameter builder-table alias the factories return, and the public table type is a thin wrapper that normalizes into it:

```ts
export type PgTable<TName, Cols, Extras = []> = PgBuilderTable<TName, TypedCols<Cols>, Extras>;

export type PgBuilderTable<TName, Cols, Extras = []> = Cols & {
  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
  enableRLS(): PgTableWithRLS<TName, Cols, Extras>;
};
```

Same for `MysqlBuilderTable` and `SqliteBuilderTable`.

Every committed budget moved **down**, none up:

| What | Before | After |
| --- | ---: | ---: |
| Step 1, slim table + row | 490 | 489 |
| Downstream consumer instantiations | 1787 | 1784 |
| Emitted declaration (model pipeline) | 1422 B | 970 B |
| Emitted declaration, exported 10-column table | 3302 B | 1702 B |

**Backward compatible.** `PgBuilderTable<'x', C>` and `PgTable<'x', C, []>` are the same type: `TypedCols<C>` passes an already-branded columns record through wholesale. Anyone writing `PgTable<...>` by hand on the type road is unaffected. The only break would be code passing a 4th type argument, which was documented as an internal fast path and has no uses in the repo.

**Tests.** New case in `declarationEmit.test.ts` counts one column's emitted type in an exported table and asserts it appears once; returning to the 4-parameter form doubles it and fails. Both type-budget report artifacts regenerated on their own, and both budgets were lowered in `modelPipelineHarness.ts`. Green: `@mionjs/drizzle-orm` (22), `-pg-core` (105), `-mysql-core` (58), `-sqlite-core` (39), `type-budget` (31), plus `pnpm run lint`.

## 2. `packages/drizzle-orm/TYPE-COST.md`, the spike record

The fix above came out of asking whether the columns appearing twice under `[rtTableKey]` on hover was costing anything. It is not: 219 net instantiations with and without `columns` in the meta, and removing them makes the models worse (`ColsOf` becomes `Omit` at 264 instead of an indexed access at 224).

That led to a spike on moving column metadata into a flat params bag, the way a runtypes `TypeFormat` carries its props. Four shapes measured, all four lost. The one measured with no prototype stand-ins on either side, flattening today's real columns to bags and reading them by indexed access, goes from +1% at five columns to **+29% at forty**.

What the spike did find is where the money actually is. Same table, same model, three ways of writing it:

| How the table is written | net |
| --- | ---: |
| builder road, `pgTable('users', {...})` | 501 |
| type road, `Varchar<'name', {length: 100}> & NotNull` | 1287 |
| type road, columns already branded (no normalization) | 321 |

**966 of the type road's 1287, three quarters of it, is unpicking the marker intersections.** No code change for that here; the doc records the measurement and the reproduction recipe so the next attempt starts from evidence.