### PR TITLE
fix(bench): float format accepts whole numbers, stop labelling them invalid

### DIFF
--- a/container/benchmarks/competitors/ajv/cases.ts
+++ b/container/benchmarks/competitors/ajv/cases.ts
@@ -2923,17 +2923,19 @@ export const cases: CompetitorCases = {
       return (value: unknown) => validate(value) === true;
     },
   },
+  // FormatFloat carries no failable constraint, so the equivalent document is a
+  // plain `{type: 'number'}`: whole values are legal floats.
   'NUMBER_FORMAT.number_float': {
     build: () => {
       const ajv = new Ajv({strict: false, allowUnionTypes: true});
       addFormats(ajv, {mode: 'full'});
-      const validate = ajv.compile({type: 'number', not: {type: 'integer'}});
+      const validate = ajv.compile({type: 'number'});
       return (value: unknown) => validate(value) === true;
     },
     buildErrors: () => {
       const ajv = new Ajv({strict: false, allowUnionTypes: true, allErrors: true});
       addFormats(ajv, {mode: 'full'});
-      const validate = ajv.compile({type: 'number', not: {type: 'integer'}});
+      const validate = ajv.compile({type: 'number'});
       return (value: unknown) => validate(value) === true;
     },
   },

--- a/container/benchmarks/competitors/typebox/cases.ts
+++ b/container/benchmarks/competitors/typebox/cases.ts
@@ -3254,7 +3254,23 @@ export const cases: CompetitorCases = {
       };
     },
   },
-  'NUMBER_FORMAT.number_float': NOT_SUPPORTED, // TypeBox has no non-integer constraint
+  // FormatFloat carries no failable constraint, so the equivalent schema is a plain
+  // Type.Number(): whole values are legal floats.
+  'NUMBER_FORMAT.number_float': {
+    build: () => {
+      const schema = Type.Number();
+      const check = TypeCompiler.Compile(schema);
+      return (value: unknown) => check.Check(value);
+    },
+    buildErrors: () => {
+      const schema = Type.Number();
+      const check = TypeCompiler.Compile(schema);
+      return (value: unknown) => {
+        for (const _ of check.Errors(value)) return false;
+        return true;
+      };
+    },
+  },
   'NUMBER_FORMAT.number_multipleOf': {
     build: () => {
       const schema = Type.Number({multipleOf: 5});

--- a/container/benchmarks/competitors/typia/cases.ts
+++ b/container/benchmarks/competitors/typia/cases.ts
@@ -2360,7 +2360,19 @@ export const cases: CompetitorCases = {
       return (v) => val(v).success;
     },
   },
-  'NUMBER_FORMAT.number_float': NOT_SUPPORTED, // our FormatFloat means non-integer; typia Type<'float'> means float32-representable (accepts integers)
+  // FormatFloat carries no failable constraint, so the equivalent typia type is a plain
+  // number. `tags.Type<'float'>` is NOT the match: it adds a float32 representability
+  // check RunTypes never imposes.
+  'NUMBER_FORMAT.number_float': {
+    build: () => {
+      const check = typia.createIs<number>();
+      return (v) => check(v);
+    },
+    buildErrors: () => {
+      const val = typia.createValidate<number>();
+      return (v) => val(v).success;
+    },
+  },
   'NUMBER_FORMAT.number_multipleOf': {
     build: () => {
       const check = typia.createIs<number & tags.MultipleOf<5>>();

--- a/container/benchmarks/competitors/zod/cases.ts
+++ b/container/benchmarks/competitors/zod/cases.ts
@@ -1636,12 +1636,11 @@ export const cases: CompetitorCases = {
       return (value: unknown) => schema.safeParse(value).success;
     },
   },
+  // FormatFloat carries no failable constraint, so the equivalent zod schema is a
+  // plain number: whole values are legal floats.
   'NUMBER_FORMAT.number_float': {
     buildErrors: () => {
-      const schema = z
-        .number()
-        
-        .refine((n) => !Number.isInteger(n));
+      const schema = z.number();
       return (value: unknown) => schema.safeParse(value).success;
     },
   },

--- a/container/benchmarks/shared/cases/format-validation/NumberFormat.ts
+++ b/container/benchmarks/shared/cases/format-validation/NumberFormat.ts
@@ -36,13 +36,13 @@ export const NUMBER_FORMAT = {
     ],
   },
   number_float: {
-    title: 'FormatFloat — non-integer only',
-    getSamples: () => ({valid: [1.5, -0.5, 3.14], invalid: [1, 0, -2]}),
-    expectedFormatErrors: () => [
-      {name: 'numberFormat', val: true, formatPathTail: 'float'},
-      {name: 'numberFormat', val: true, formatPathTail: 'float'},
-      {name: 'numberFormat', val: true, formatPathTail: 'float'},
-    ],
+    // `float` is a generation/presentation tag, NEVER a failable constraint: a float
+    // legally holds whole values like 2.0 (packages/ts-runtypes/src/formats/numberFormats.ts).
+    // So every finite number is valid here and only non-numbers are rejected — the tag
+    // steers mock generation and keeps binary packing on the float64 arm, nothing else.
+    title: 'FormatFloat — float-tagged number (whole values legal)',
+    getSamples: () => ({valid: [1.5, -0.5, 3.14, 1, 0, -2], invalid: ['1.5', null, true]}),
+    expectedFormatErrors: () => [null, null, null],
   },
   number_multipleOf: {
     title: 'FormatNumber<{multipleOf: 5}> — divisible by 5',

--- a/docs/done/bench-float-format-sample-mislabelled.md
+++ b/docs/done/bench-float-format-sample-mislabelled.md
@@ -1,0 +1,180 @@
+---
+type: fix
+spec: guidelines
+status: ready
+created: 2026-08-30
+---
+
+# The FormatFloat benchmark case labels legal values as invalid
+
+## Intent
+
+The benchmark lane reports a permanent correctness failure that is not a RunTypes bug. The
+BENCHMARK CASE is wrong, and while it stands it publishes a fake divergence against
+ts-runtypes on the Correctness page, and rewards any competitor that models `Float` as
+"rejects integers" for being wrong.
+
+Reproduced with `pnpm rtx bench bench-one ts-runtypes`:
+
+```
+✗ 2 fail/errored metric-case(s) across competitors:
+  ts-runtypes / NUMBER_FORMAT.number_float [validate]: fail — invalid[0] accepted
+  ts-runtypes / NUMBER_FORMAT.number_float [validationErrors]: fail — invalid[0] accepted
+```
+
+`invalid[0]` is `1`. RunTypes accepts it, and accepting it is CORRECT. `float` is
+documented as a generation and presentation tag, never a constraint that can fail
+(`packages/ts-runtypes/src/formats/numberFormats.ts:22`):
+
+```ts
+  /** Generation/presentation tag, NEVER a failable constraint (a float
+   *  legally holds whole values like 2.0): steers mock generation toward
+   *  fractional samples and keeps binary packing on the float64 arm.
+   *  Mutually exclusive with `integer`. */
+  float?: boolean;
+```
+
+and again on the builder (`numberFormats.ts:97`):
+
+```ts
+/** Float-natured number (`Float`): fractional mocks, float64 packing; whole values still validate. **/
+export const float = presetBuilder<Float>('number');
+```
+
+The case contradicts both (`container/benchmarks/shared/cases/format-validation/NumberFormat.ts:38`):
+
+```ts
+  number_float: {
+    title: 'FormatFloat — non-integer only',
+    getSamples: () => ({valid: [1.5, -0.5, 3.14], invalid: [1, 0, -2]}),
+    expectedFormatErrors: () => [
+      {name: 'numberFormat', val: true, formatPathTail: 'float'},
+      ...
+```
+
+Three declared `expectedFormatErrors` that no correct implementation can ever produce.
+
+## Direction
+
+Verify the contract first, then decide which side is wrong. The documented behaviour above
+is clear and this todo assumes the case is at fault, but the implementer should confirm
+that nothing else in the repo (Go emitter, the format docs on the website) treats `float`
+as failable before changing the samples.
+
+Assuming the case is at fault, roughly: retitle it to what `Float` actually is, move
+`[1, 0, -2]` into `valid`, and give the case a real invalid set (non-numbers, and whatever
+else `Number` genuinely rejects). `expectedFormatErrors` has to line up with the new
+invalid list. Then check whether the other four competitors' `number_float` entries encode
+the same wrong assumption and fix them alongside, or the divergence just moves.
+
+The implementer plans the details.
+
+**Test it the way a mislabelled sample actually gets caught.** No unit test fails today,
+which is why this shipped: a wrong label is invisible to the suite and only shows up as a
+cross-library divergence. So the fix needs something that pins the intent, not just a
+changed literal. Consider a check that a format tagged non-failable declares no
+`expectedFormatErrors`, which would catch this whole class rather than this one case.
+
+Worth a look while in here: are there other presentation-only format tags whose benchmark
+cases assert failures? `money` is flagged "PURE PRESENTATION METADATA" in the same file.
+
+## Done when
+
+- `pnpm rtx bench bench-one ts-runtypes` reports zero fail/errored metric-cases for
+  `NUMBER_FORMAT.number_float`, and the lane's exit status and coverage table are clean on
+  that case.
+- The case's title and samples match the documented `Float` contract.
+- Something in the test suite would now catch a presentation-only format being asserted as
+  failable, so the class does not come back.
+- `pnpm test`, `pnpm run lint`, `pnpm run format` clean.
+
+## Context
+
+Found while implementing `docs/done/bench-duplicate-columns-and-strict-section.md` on
+branch `claude/runtypes-benchmark-docs-si7uca`, running the benchmark lane to verify that
+work. Unrelated to it: that change touched the results reader and the strict suite, never
+format validation.
+
+Same class of problem as something that change had to guard against by hand: a wrongly
+labelled benchmark sample fails no test, it only surfaces later as a cross-library
+divergence. That is why the strict `realworld_order` case added there had its labelling
+checked against an independent implementation before landing.
+
+## Plan — what shipped (2026-08-30)
+
+**The case was the wrong side, confirmed on three independent sources** before any sample
+was touched:
+
+- The Go emitter agrees the tag never fails
+  (`ts-go-runtypes/internal/cachegen/typefunctions/formats/numeric/numberformat.go:52`,
+  `:90`): "The `float` tag deliberately emits nothing (annotation-only, whole values are
+  legal floats)" and "`float` never produces an error (annotation-only)". It only routes
+  binary packing to the float64 arm and rejects the contradictory `integer` + `float`
+  pair.
+- The repo's OWN format-validation suite already models it correctly
+  (`packages/ts-runtypes/test/suites/format-validation/NumberFormat.ts:235`):
+  `valid: [1.5, -0.5, 3.14, 1, 0, -2]`, `invalid: []`, `expectedFormatErrors: () => []`.
+- The website says the same and needed no edit
+  (`container/website/sites/mion/content/03.drizzle-orm/01.column-formats.md:77`): "Float
+  columns use the Float format: whole values like 2.0 still validate". Nothing on either
+  site claims `Float` rejects integers.
+
+### The shared case
+
+`container/benchmarks/shared/cases/format-validation/NumberFormat.ts` — retitled to
+"FormatFloat — float-tagged number (whole values legal)", the three whole numbers moved
+into `valid`, and a real invalid set of non-numbers (`'1.5'`, `null`, `true`) put in their
+place, so the reject path still measures something. `expectedFormatErrors` became three
+`null`s (the sibling `number_max` case already uses `null` for a root type mismatch).
+
+An empty invalid list was rejected as the alternative: the runner times the reject and
+mixed streams, and the website's Correctness page prints both sample arrays.
+
+### The competitor maps
+
+All four non-RunTypes columns encoded the same wrong assumption and were fixed alongside,
+or the divergence would just have moved:
+
+| Competitor | Before | After |
+| --- | --- | --- |
+| zod | `z.number().refine((n) => !Number.isInteger(n))` | `z.number()` |
+| ajv | `{type: 'number', not: {type: 'integer'}}` | `{type: 'number'}` |
+| typia | `NOT_SUPPORTED` ("our FormatFloat means non-integer") | `number` |
+| typebox | `NOT_SUPPORTED` ("no non-integer constraint") | `Type.Number()` |
+
+The two `NOT_SUPPORTED` entries were unsupported ONLY because of the wrong assumption, so
+both became real entries and the case gained two columns. `tags.Type<'float'>` was
+rejected for typia: it adds a float32 representability check RunTypes never imposes.
+`ts-runtypes/cases.ts` and `schemaCases.ts` were already correct (`TF.Float`) and are
+unchanged.
+
+### The test that pins the class
+
+`packages/ts-runtypes-devtools/test/bench-lane-contracts.test.ts` gained
+"the shared cases never assert a presentation-only format tag as failable". It DERIVES the
+non-failable tag set from the format sources (every param whose JSDoc says "NEVER a
+failable constraint" or "PURE PRESENTATION METADATA" — today `float` and `isCurrency`)
+rather than hardcoding it, so a presentation-only param added later is covered the day it
+lands. One test asserts the derivation still finds both tags, so it cannot go quietly
+empty; the other walks `shared/cases/**` and fails naming the file and tag.
+
+Verified it fails on the original bug before being accepted:
+
+```
+FAIL  test/bench-lane-contracts.test.ts > declares no expectedFormatErrors on any of them
++   "container/benchmarks/shared/cases/format-validation/NumberFormat.ts: float",
+```
+
+The `packages/` suites need no such guard: their cases are executed, so a wrong assertion
+there already fails a real test. Only the benchmark copy was data nothing checked.
+
+### The `money` question
+
+`isCurrency` is flagged "PURE PRESENTATION METADATA" in the same file and was checked: no
+shared case ever asserted it as failable, so nothing needed fixing. The new test now keeps
+it that way.
+
+### Docs
+
+No website change. Both sites already describe `Float` correctly (evidence above), and the
+benchmark case titles are lane data, not site content.

--- a/packages/ts-runtypes-devtools/test/bench-lane-contracts.test.ts
+++ b/packages/ts-runtypes-devtools/test/bench-lane-contracts.test.ts
@@ -15,7 +15,7 @@
 
 import {describe, it, expect} from 'vitest';
 import {spawnSync} from 'node:child_process';
-import {readFileSync, existsSync, mkdtempSync, writeFileSync} from 'node:fs';
+import {readFileSync, readdirSync, existsSync, mkdtempSync, writeFileSync} from 'node:fs';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {resolve, dirname, join} from 'node:path';
 import {tmpdir} from 'node:os';
@@ -71,6 +71,53 @@ describe('typia competitor map calls real typia exports', () => {
     const errorPathBuilders = [...source.matchAll(/const val = typia\.([A-Za-z]+)/g)].map((match) => match[1]);
     expect(errorPathBuilders.length).toBeGreaterThan(100);
     expect([...new Set(errorPathBuilders)].filter((name) => !name.startsWith('createValidate'))).toEqual([]);
+  });
+});
+
+describe('the shared cases never assert a presentation-only format tag as failable', () => {
+  // How a permanent fake correctness failure shipped: the shared `number_float` case
+  // titled FormatFloat "non-integer only" and listed [1, 0, -2] as invalid, but `float`
+  // is a generation/presentation tag that NEVER fails (a float legally holds 2.0), so
+  // RunTypes accepted all three and the lane reported a divergence against itself on
+  // every run. No unit test could catch it: the shared cases are data, the packages/
+  // suites keep their own copy, and a wrong label fails nothing until two libraries
+  // disagree. This pins the whole class instead of that one case.
+  //
+  // The non-failable tags are DERIVED from the format sources rather than listed here,
+  // so a newly added presentation-only param is covered the day it lands.
+  const FORMATS_DIR = join(REPO_ROOT, 'packages/ts-runtypes/src/formats');
+  const NON_FAILABLE_DOC = /NEVER a failable constraint|PURE PRESENTATION METADATA/;
+
+  function tsFiles(dir: string): string[] {
+    return readdirSync(dir, {withFileTypes: true}).flatMap((entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return tsFiles(full);
+      return entry.name.endsWith('.ts') ? [full] : [];
+    });
+  }
+
+  // Every param whose own JSDoc block declares it non-failable: take the identifier that
+  // opens the declaration right after the block's `*/`.
+  const nonFailableTags = new Set(
+    tsFiles(FORMATS_DIR).flatMap((file) =>
+      [...readFileSync(file, 'utf8').matchAll(/\/\*\*([\s\S]*?)\*\/\s*([A-Za-z_$][\w$]*)\??\s*:/g)]
+        .filter((match) => NON_FAILABLE_DOC.test(match[1]))
+        .map((match) => match[2])
+    )
+  );
+
+  it('finds the documented non-failable tags, so the derivation cannot go quietly empty', () => {
+    expect([...nonFailableTags].sort()).toEqual(['float', 'isCurrency']);
+  });
+
+  it('declares no expectedFormatErrors on any of them', () => {
+    const offenders: string[] = [];
+    for (const file of tsFiles(join(BENCH_DIR, 'shared/cases'))) {
+      for (const match of readFileSync(file, 'utf8').matchAll(/formatPathTail:\s*'([^']+)'/g)) {
+        if (nonFailableTags.has(match[1])) offenders.push(`${file.slice(REPO_ROOT.length + 1)}: ${match[1]}`);
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Implements `docs/todos/bench-float-format-sample-mislabelled.md` (moved to `docs/done/`).

## The problem

The shared benchmark case `NUMBER_FORMAT.number_float` titled `Float` "non-integer only" and listed `[1, 0, -2]` as **invalid**. That is not what `Float` means, so the lane reported a permanent fake correctness failure against ts-runtypes on every run:

```
✗ 2 fail/errored metric-case(s) across competitors:
  ts-runtypes / NUMBER_FORMAT.number_float [validate]: fail — invalid[0] accepted
  ts-runtypes / NUMBER_FORMAT.number_float [validationErrors]: fail — invalid[0] accepted
```

It also rewarded any competitor that models `Float` as "rejects integers" for being wrong.

## The case was the wrong side (verified before touching samples)

Three independent sources agree `float` is a generation/presentation tag that never fails:

- `packages/ts-runtypes/src/formats/numberFormats.ts:22` — "NEVER a failable constraint (a float legally holds whole values like 2.0)".
- The Go emitter, `ts-go-runtypes/internal/cachegen/typefunctions/formats/numeric/numberformat.go:52` and `:90` — "The `float` tag deliberately emits nothing (annotation-only, whole values are legal floats)" / "`float` never produces an error". It only routes binary packing to the float64 arm.
- The repo's own vitest suite already models it correctly: `packages/ts-runtypes/test/suites/format-validation/NumberFormat.ts:235` has `valid: [1.5, -0.5, 3.14, 1, 0, -2]`, `invalid: []`.

## What changed

**The shared case** (`container/benchmarks/shared/cases/format-validation/NumberFormat.ts`): retitled, the three whole numbers moved into `valid`, and a real invalid set of non-numbers put in their place so the reject path still measures something.

```ts
getSamples: () => ({valid: [1.5, -0.5, 3.14, 1, 0, -2], invalid: ['1.5', null, true]}),
expectedFormatErrors: () => [null, null, null],
```

An empty invalid list was rejected as the alternative: the runner times the reject and mixed streams, and the website's Correctness page prints both sample arrays.

**All four competitor maps**, which encoded the same wrong assumption (otherwise the divergence just moves):

| Competitor | Before | After |
| --- | --- | --- |
| zod | `z.number().refine((n) => !Number.isInteger(n))` | `z.number()` |
| ajv | `{type: 'number', not: {type: 'integer'}}` | `{type: 'number'}` |
| typia | `NOT_SUPPORTED` ("our FormatFloat means non-integer") | `number` |
| typebox | `NOT_SUPPORTED` ("no non-integer constraint") | `Type.Number()` |

Both `NOT_SUPPORTED` entries were unsupported **only** because of the wrong assumption, so the case gained two real columns. `tags.Type<'float'>` was rejected for typia: it adds a float32 representability check RunTypes never imposes. The two ts-runtypes maps were already correct (`TF.Float`) and are unchanged.

## The test that pins the class

No unit test could catch this: the shared cases are data, the `packages/` suites keep their own copy, and a wrong label fails nothing until two libraries disagree. `packages/ts-runtypes-devtools/test/bench-lane-contracts.test.ts` gained a check that **derives** the non-failable tag set from the format sources (every param whose JSDoc says "NEVER a failable constraint" or "PURE PRESENTATION METADATA" — today `float` and `isCurrency`) rather than hardcoding it, then fails if any shared case asserts one as failable. A companion test asserts the derivation still finds both tags, so it cannot go quietly empty.

Confirmed it fails on the original bug:

```
FAIL  test/bench-lane-contracts.test.ts > declares no expectedFormatErrors on any of them
+   "container/benchmarks/shared/cases/format-validation/NumberFormat.ts: float",
```

`isCurrency` was checked too (the todo flagged it): no shared case ever asserted it as failable, and the new test keeps it that way.

## Docs

No website change needed. Both sites already describe `Float` correctly, e.g. `container/website/sites/mion/content/03.drizzle-orm/01.column-formats.md:77` — "whole values like 2.0 still validate". Nothing on either site claims `Float` rejects integers.

## Verification

- `RT_BENCH_TIME_MS=200 RT_BENCH_NO_TYPIA=1 pnpm rtx bench bench-one ts-runtypes` → `validate ok=275 fail=0`, `validationErrors ok=275 fail=0`, "every supported function passed correctness on BOTH paths for all cases". Was 2 failing metric-cases before.
- All five columns run the case clean on both metrics and both paths (each checked with `RT_BENCH_CASE=number_float`), typia and typebox included.
- `pnpm rtx bench typecheck` → every competitor map still total over `CaseKey`.
- `pnpm test` → 388 files, 10605 tests passed.
- `pnpm run lint` and `pnpm run format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016okLQrywqp1bkojJMdpDsN

---
_Generated by [Claude Code](https://claude.ai/code/session_016okLQrywqp1bkojJMdpDsN)_