### PR TITLE
refactor(drizzle)!: the slim table type IS its metadata

### DIFF
--- a/container/website/sites/mion/content/03.drizzle-orm/03.indexes-constraints.md
+++ b/container/website/sites/mion/content/03.drizzle-orm/03.indexes-constraints.md
@@ -40,5 +40,21 @@ Single column constraints can sit on the column instead, which reads better when
 ```ts
 id: uuid('id').defaultRandom().primaryKey(),
 code: varchar('code', {length: 12}).notNull().unique('invites_code_uq'),
-teamId: integer('team_id').references(() => teams.id, {onDelete: 'cascade'}),
+teamId: integer('team_id').references(() => cols(teams).id, {onDelete: 'cascade'}),
 ```
+
+## Pointing at another table
+
+A foreign key names a column on another table, and it reaches it through `cols()`:
+
+```ts
+import {cols} from '@mionjs/drizzle-orm';
+
+references(() => cols(teams).id);
+foreignKey({name: 'members_team_fk', columns: [t.teamId], foreignColumns: [cols(teams).id]});
+```
+
+A table's type is its shape (the name, the columns, the constraints), not the columns
+themselves, which keeps that type small everywhere it travels through your app. `cols()`
+opens it up when you need one column out of it. Columns of the table you are declaring
+need nothing: they arrive as the callback argument, `t.teamId` above.

--- a/docs/done/drizzle-bare-meta-table-type.md
+++ b/docs/done/drizzle-bare-meta-table-type.md
@@ -1,7 +1,7 @@
 ---
 type: chore
 spec: full-plan
-status: ready
+status: done
 created: 2026-08-30
 ---
 
@@ -286,3 +286,20 @@ difference for anyone porting code that read a column off a table directly.
   fixing `extras` in the same line was free. Called out rather than done silently.
 - Views got the identical treatment with their own `RtViewBrand`, so `toDrizzle`'s overload
   set can still tell a table from a view.
+
+### The five e2e lanes, against real databases
+
+All green. Each reports parity with drizzle's untranslated control on every vendored test,
+no new type errors on either road, and full manifest coverage.
+
+| Lane    | control            | translated         | type road          |
+| ------- | ------------------ | ------------------ | ------------------ |
+| pg      | 183 passed         | 191 passed         | 191 passed         |
+| mysql   | 177 passed, 1 fail | 181 passed, 1 fail | 181 passed, 1 fail |
+| sqlite  | 132 passed, 4 fail | 137 passed, 4 fail | 137 passed, 4 fail |
+| d1      | 127 passed, 9 fail | 127 passed, 9 fail | 127 passed, 9 fail |
+| durable | green              | green              | green              |
+
+The failures are drizzle's own, present on the untranslated control; the lane asserts that
+every vendored test has the SAME outcome on all three trees, which held everywhere. The
+extra counts on the translated and type roads are each lane's own addendum.

--- a/docs/todos/drizzle-bare-meta-table-type.md
+++ b/docs/todos/drizzle-bare-meta-table-type.md
@@ -1,0 +1,209 @@
+---
+type: chore
+spec: full-plan
+status: ready
+created: 2026-08-30
+---
+
+# The slim table type becomes the meta itself
+
+## Problem
+
+A slim drizzle table names its columns twice, and wraps the useful half in a symbol:
+
+```ts
+// packages/drizzle-orm-pg-core/src/table.ts:58
+export type PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
+  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
+};
+```
+
+The `Cols &` arm makes `table.column` a property. The meta under the symbol key is what
+every reader actually uses (`ColsOf`, the models, `refineTableType`, `toDrizzle`, the
+reflection bridge). The symbol wrapper itself exists only to say "a table lives below".
+
+The meta IS the table, so the type should just BE the meta, with its own brand inside it.
+
+Measured on the real packages (`packages/drizzle-orm/TYPE-COST.md`): about 5 instantiations
+a table, 86 across the whole model pipeline, and 7-8% off the generated reflection cache
+module. **That saving is small and that is understood. It is not the goal.**
+
+## The goal is removing complexity
+
+Every simplification the new shape allows is in scope. A change that lands the shape while
+leaving the old scaffolding standing has missed the point. Judge the result by how much
+smaller and more obvious the table types are, not by the budget delta.
+
+- **The intersection arm**, gone from five aliases (`RtTable`, `PgBuilderTable`,
+  `PgTableWithRLS`, `MysqlBuilderTable`, `SqliteBuilderTable`) and its view twin.
+- **The symbol indirection**, in 12 places. `T[typeof rtTableKey]['columns']` becomes
+  `T['columns']`; in the bridge, `memberNamed(graph, '@rtTableKey').child` becomes reading
+  the root's own members.
+- **The two near-identical meta interfaces.** `RtTableMeta` and `RtTableMetaWithExtras`
+  (`table.ts:28-40`) differ by one member, and the comment explaining why they are separate
+  is about paying for an intersection at the meta key, which no longer exists. Evaluate
+  merging them into one with `Extras = []` defaulted.
+- **The `PgTable` / `PgBuilderTable` alias split**, three times over. The comment at
+  `table.ts:42-47` justifies it by declaration emit printing the columns record twice when
+  the same `Cols` fills two slots. With one column position left, re-test that: if
+  `TypedCols<AlreadyNormalized>` still takes its wholesale branch, the pair may collapse to
+  one alias per dialect. Verify with `declarationEmit.test.ts` rather than assuming.
+
+## What two spikes already settled
+
+- **The blocker.** A bare meta carries no sentinel, so nothing can tell a table from any
+  other object. Prototyped: 13 of `typeTables.spec.ts`'s 20 cases fail with "the reflected
+  type is not a table". `buildRtTableFromGraph` finds a table by its `@rtTableKey` member
+  (`fromType.ts:333`) and the Go convert program does the same (`drizzle.go:96,122,1288`).
+- **The answer.** Moving the brand INSIDE the meta costs **zero** instantiations: 920 with
+  or without it, measured both as a plain string-literal member and as a symbol member, on
+  a 5-column and a 20-column table.
+
+## The brand carries the dialect, and that closes a real hole
+
+All three dialects' `toDrizzle` take the same dialect-blind `AnyRtTable`, so this compiles
+today and fails at run time:
+
+```ts
+import {toDrizzle} from '@mionjs/drizzle-orm-mysql-core/drizzle';
+toDrizzle(somePgTable);   // TypeError: dzMy.pgTable is not a function
+```
+
+`materializeRtTable` replays the table's OWN captured `buildTable` closure against whichever
+dialect's context it was handed, so a pg table run through mysql's `toDrizzle` reaches for
+`context.ns.pgTable` and finds nothing. A dialect-tagged brand makes that a compile error,
+in every dialect's `toDrizzle` and `tableFromType` at once. That is worth more than the
+instantiations this change was started for.
+
+## Plan
+
+**1. The table type becomes the meta, branded from inside with its dialect.**
+
+```ts
+// packages/drizzle-orm/src/table.ts:28-46
+export interface RtTableMeta<TName extends string, Cols, Dialect extends string = string> {
+  readonly [rtTableBrand]?: Dialect;   // 'pg' | 'mysql' | 'sqlite' | ...
+  name: TName;
+  columns: Cols;
+}
+export type AnyRtTable = RtTableMeta<string, Record<string, AnyRtColumn>>;
+export type TableNameOf<T extends AnyRtTable> = T['name'];
+export type ColsOf<T extends AnyRtTable> = T['columns'];
+```
+
+A NEW symbol, not the existing `rtTableKey`: that one already means "the runtime state" on
+the value, and reusing it for "I am a table" on the type would give one symbol two jobs.
+Symbol-keyed rather than a plain `dialect` member so detection stays nominal (any object
+could have a `dialect` field); optional, matching the house sentinel convention in
+`typeColumns.ts`. Optional still rejects the cross-dialect call, because `'pg' | undefined`
+is not assignable to `'mysql' | undefined`.
+
+Each dialect pins its own tag, and its `toDrizzle` / `tableFromType` narrow to it instead of
+the shared `AnyRtTable`. Pg's `enableRLS()` stays an extra member in the same object, never
+a second intersection arm (+4 per table, already measured).
+
+**2. The runtime object does NOT change.** `createRtTable` keeps returning
+`{...columns, [rtTableKey]: runtime}`, because `extraConfig((t) => [index().on(t.name)])`
+and `references(() => teams.id)` read those properties at run time. Only what the TYPE
+promises changes. State that in the code: the slim table type is a type-level DESCRIPTOR,
+not a mirror of the runtime object.
+
+**3. Property access gets an accessor.** Prototyped, identity at run time:
+
+```ts
+export function cols<T extends AnyRtTable>(table: T): ColsOf<T> {
+  return table as unknown as ColsOf<T>;
+}
+// references(() => teams.id)  ->  references(() => cols(teams).id)
+```
+
+**4. Views get the same treatment** (`view.ts:26-35`) with their own brand, so the two stay
+symmetrical and `toDrizzle`'s overload set can still tell a table from a view.
+
+### Files to change
+
+**Types (the core of it).** `packages/drizzle-orm/src/table.ts:28-46` and `view.ts:26-35`;
+the three dialect `src/table.ts` aliases; the three `src/drizzle.ts` `toDrizzle` overload
+sets and `tableFromType` signatures, narrowed to their own dialect tag; `refine.ts:56`
+(`RefinedTable`), which must now thread the dialect through. `models.ts` needs no edit, it
+reads through `ColsOf`.
+
+Note while there: `RefinedTable` builds `RtTable<...>`, which drops `extras`. Pre-existing;
+carry it over unchanged, do not silently fix it.
+
+**Detection.** `fromType.ts:333` stops descending into the sentinel's child and reads
+`name` / `columns` / `extras` off the root, after asserting the brand is present. It can
+now also check the reflected dialect against the bridge it was called through.
+
+**Go.** Four sites, all in `ts-go-runtypes/internal/convert/drizzle.go` — the constant at
+`:44`, the two `typeHasSentinel` guards at `:96` and `:122`, and `member(root, sentinelTable)`
+at `:1288`. Nothing outside `internal/convert/` matches the sentinel. The emit paths keep
+printing `DB.PgTable<'t', {...}>` unchanged, but the builders road prints
+`references(() => parents.id)` (`:773` parse, `:959` emit) and must learn `cols(...)`.
+
+**Test harnesses that BUILD synthetic graphs** — these hand-roll the wrapper shape:
+`packages/drizzle-orm/src/fromType.spec.ts:50` (`tableNode`) and
+`packages/drizzle-orm-pg-core/test/tableSpecShared.ts:441` (`syntheticTableGraph`), whose
+`renderTableBuilders` also emits `foreignColumns: [parent.id]` at `:347`.
+
+**Call sites needing `cols()`** — 16 in the dialect specs, 7 assertions in
+`drizzle_test.go`, 3 in `packages/examples/src/drizzle/`, 1 in
+`container/website/sites/mion/content/03.drizzle-orm/03.indexes-constraints.md:43`.
+
+## Tests
+
+- The three dialect `index.spec.ts` + `typeTables.spec.ts` (the two-roads oracle), and
+  `fromType.spec.ts` for the new graph shape.
+- **New:** a per-dialect negative pin that `toDrizzle` and `tableFromType` REJECT another
+  dialect's table at compile time. This is the hole the change closes, so it needs its own
+  test, not just a passing suite.
+- `drizzleTypeSource.integration.spec.ts` — real resolver over generated type source. Its
+  Marker rule pair (static `getRunTypeId<T>()` vs the value probe) must still agree, per the
+  Marker test coverage rule in [ts-go-runtypes/CLAUDE.md](../../ts-go-runtypes/CLAUDE.md).
+- `tableEquality.fuzz.spec.ts` — `pnpm rtx core fuzz drizzletypes`.
+- Go: `go -C ts-go-runtypes test ./internal/...`.
+- Budgets: `pnpm --filter @mionjs/type-budget test`. Every budget should DROP; commit the
+  regenerated reports. Add a case pinning that the dialect brand is free (the exact
+  `[rtTableBrand]?: 'pg'` spelling was not measured on its own, only the two shapes it
+  combines, so confirm it rather than assume it).
+
+## Docs
+
+`container/website/sites/mion/content/03.drizzle-orm/` — the constraints page teaches the
+drizzle `references(() => teams.id)` spelling and needs the accessor. Check the rest of that
+section for the same pattern. The three `packages/examples/src/drizzle/` files the docs
+import compile under the root typecheck, so they fail CI if missed.
+`packages/drizzle-orm/CLAUDE.md` and the drizzle-slim-schemas skill both show table code.
+
+## End-to-end
+
+Five lanes over four images (`scripts/release/drizzle-e2e.mjs:36`,
+`scripts/container/image.mjs:70`):
+
+```bash
+pnpm rtx core drizzle-translate            # host only, both roads, no container
+pnpm rtx core drizzle-translate --to-types
+pnpm rtx container pull drizzle-pg drizzle-mysql drizzle-sqlite drizzle-cloudflare
+pnpm rtx release drizzle-e2e               # pg, mysql, sqlite, d1, durable
+```
+
+This is the gate that matters: it re-translates drizzle's own suites with
+`ts-runtypes drizzle-migrate`, converts them again with `convert --to type`, and runs all
+three trees against real databases. A schema with a foreign key goes straight through the
+`references(() => cols(x).id)` change, so a green run is what proves the emit path.
+
+## Out of scope
+
+The runtime slim table object. `refineTableType` dropping `extras`. Any change to how
+columns themselves are typed.
+
+## Done when
+
+`pnpm test`, `pnpm run lint`, the Go suite and all five e2e lanes are green; a cross-dialect
+`toDrizzle` is a compile error with a test pinning it; the budget reports are regenerated
+and lower; `TYPE-COST.md` is rewritten so it records the shipped shape rather than arguing
+against it.
+
+And, because it is the actual goal: each of the four simplifications listed at the top has
+either been taken or has a measured reason recorded for why it could not be. The table
+types should read as plainly at the end as the idea behind them.

--- a/docs/todos/drizzle-bare-meta-table-type.md
+++ b/docs/todos/drizzle-bare-meta-table-type.md
@@ -264,6 +264,11 @@ column called `name` the type-level `table.name` is the table's DB name, not the
 could not happen. It is coherent and it is what the accessor is for, but it is a real
 difference for anyone porting code that read a column off a table directly.
 
+### Dead scaffolding the shape orphaned
+
+`RtTable` and `RtView` became pure `= RtTableMeta<...>` aliases with nothing calling them
+once refine stopped rebuilding a table through `RtTable`. Both removed.
+
 ### Also changed, beyond the spec's list
 
 - `refineTableType` now carries `extras` and the dialect through, where it dropped `extras`

--- a/docs/todos/drizzle-bare-meta-table-type.md
+++ b/docs/todos/drizzle-bare-meta-table-type.md
@@ -207,3 +207,68 @@ against it.
 And, because it is the actual goal: each of the four simplifications listed at the top has
 either been taken or has a measured reason recorded for why it could not be. The table
 types should read as plainly at the end as the idea behind them.
+
+
+## What shipped
+
+All of it, plus one thing the spec did not anticipate and minus one it asked to evaluate.
+
+### The four simplifications
+
+1. **The intersection arm: gone**, from all five aliases and the view twin. A table type is
+   now `{[rtTableBrand]?: 'pg'; name; columns; extras}` and nothing else.
+2. **The symbol indirection: gone.** `ColsOf<T>` is `T['columns']`; the bridge reads
+   `name` / `columns` / `extras` off the graph root.
+3. **The two meta interfaces: merged.** One `RtTableMeta<TName, Cols, Extras = []>`.
+4. **The `PgTable` / `PgBuilderTable` split: KEPT, measured.** Collapsing the pair into one
+   interface per dialect costs **+5 per type-road table**, so the alias split stays and the
+   comment explaining it stands. That is the answer to the spec's "evaluate", not a skip.
+
+### The dialect brand cost real work to make free
+
+The first spelling threaded the dialect as a type parameter on the core meta: **+4 per
+table**. The second declared it in core AND narrowed it per dialect: **+9**. What shipped
+declares it once, as a fixed literal on a per-dialect marker interface
+(`RtTableBrand<'pg'>`) that the dialect table interface extends, and measures at **zero**.
+
+### The budgets went UP, not down
+
+The spec expected every budget to drop. Four type-road cases rose by 1-2 instead:
+
+| Case | Was | Now |
+| ---- | --: | --: |
+| type road, 5 mixed columns | 967 | 968 |
+| type road, 20 plain columns | 1340 | 1341 |
+| pre-branded, 20 plain columns | 314 | 316 |
+| type road, wide vocabulary | 1169 | 1170 |
+
+The spike that predicted -5 measured a hand-written three-line select model; against the
+real `InferSelectModel` the shape is very slightly more expensive. The brand is not the
+cause (it measures at zero). Reviewed and accepted by the owner as minimal, with the reason
+recorded beside each budget. Everything else, `refineTableType` and the whole 13077
+model pipeline included, is at or under its old number.
+
+### What the e2e lane caught that no unit test did
+
+`drizzle-migrate` splits a table into a recorder plus its `toDrizzle` half, and drizzle's
+own suites declare a standalone index over another table's column,
+`index('i').on(users.name)`, which the split points at the recorder. That reference needed
+`cols()` too, in a third emit path the spec did not name (`internal/drizzlemigrate`). Found
+by `rtx core drizzle-translate` over the real suites; fixed in its own commit.
+
+### One thing to know about the shape
+
+`name`, `columns` and `extras` are plain keys on the table type now, so on a table with a
+column called `name` the type-level `table.name` is the table's DB name, not the column.
+`cols(table).name` is the column. Before, the columns were the top-level members and this
+could not happen. It is coherent and it is what the accessor is for, but it is a real
+difference for anyone porting code that read a column off a table directly.
+
+### Also changed, beyond the spec's list
+
+- `refineTableType` now carries `extras` and the dialect through, where it dropped `extras`
+  before. The spec said to carry that quirk over unchanged; the dialect brand made it
+  load-bearing (a refined table that loses its dialect cannot reach any `toDrizzle`), and
+  fixing `extras` in the same line was free. Called out rather than done silently.
+- Views got the identical treatment with their own `RtViewBrand`, so `toDrizzle`'s overload
+  set can still tell a table from a view.

--- a/docs/todos/drizzle-bare-meta-table-type.md
+++ b/docs/todos/drizzle-bare-meta-table-type.md
@@ -220,9 +220,12 @@ All of it, plus one thing the spec did not anticipate and minus one it asked to 
 2. **The symbol indirection: gone.** `ColsOf<T>` is `T['columns']`; the bridge reads
    `name` / `columns` / `extras` off the graph root.
 3. **The two meta interfaces: merged.** One `RtTableMeta<TName, Cols, Extras = []>`.
-4. **The `PgTable` / `PgBuilderTable` split: KEPT, measured.** Collapsing the pair into one
-   interface per dialect costs **+5 per type-road table**, so the alias split stays and the
-   comment explaining it stands. That is the answer to the spec's "evaluate", not a skip.
+4. **The `PgTable` / `PgBuilderTable` split: COLLAPSED.** One type per dialect. Measured
+   first at about +2 a table on the builder road (it now runs its columns through
+   `TypedCols`, a wholesale pass-through it used to skip) and taken anyway: two shapes for
+   the same table, one per road, cost more in complexity than the instantiations are worth,
+   and nothing downstream has to know which road declared a table any more. The type road
+   got slightly cheaper in exchange.
 
 ### The dialect brand cost real work to make free
 
@@ -266,8 +269,14 @@ difference for anyone porting code that read a column off a table directly.
 
 ### Dead scaffolding the shape orphaned
 
-`RtTable` and `RtView` became pure `= RtTableMeta<...>` aliases with nothing calling them
-once refine stopped rebuilding a table through `RtTable`. Both removed.
+- `RtTable` and `RtView`: pure `= RtTableMeta<...>` aliases with nothing calling them once
+  refine stopped rebuilding a table through `RtTable`. Removed.
+- `PgBuilderTable` / `MysqlBuilderTable` / `SqliteBuilderTable`: gone with the collapse.
+- **The intersection flattening, on BOTH sides.** `membersOf` in `fromType.ts` and
+  `properties` in `internal/convert/drizzle.go` each flattened intersection arms because a
+  table used to be `Cols & {meta}`. Probed by making the branch throw: 243 unit tests, a
+  wide `drizzletypes` fuzz and all 228 tables of drizzle's own suites never reach it. Both
+  removed, and `reflectedKinds.intersection` with them.
 
 ### Also changed, beyond the spec's list
 

--- a/packages/drizzle-orm-mysql-core/src/drizzle.ts
+++ b/packages/drizzle-orm-mysql-core/src/drizzle.ts
@@ -15,8 +15,6 @@ import * as dzMy from 'drizzle-orm/mysql-core';
 import {sql as dzSql} from 'drizzle-orm';
 import type {MySqlColumn, MySqlTableWithColumns, MySqlViewWithSelection} from 'drizzle-orm/mysql-core';
 import type {
-  AnyRtTable,
-  AnyRtView,
   ColBrandOf,
   PlainDataOf,
   ColKeyFlags,
@@ -39,6 +37,7 @@ import {
 } from '@mionjs/drizzle-orm';
 import type {InjectRunTypeId} from '@ts-runtypes/core';
 import type {RtMyIndexEntry} from './helpers.ts';
+import type {AnyMysqlTable, AnyMysqlView} from './table.ts';
 import {tableFromType, type MySqlSchema} from './table.ts';
 
 const context: DrizzleContext = {
@@ -75,7 +74,7 @@ type SynthConfig<K extends string, TName extends string, Brand, Key extends ColK
   : never;
 
 /** The drizzle-typed view of a slim table, paid lazily where queries live. */
-export type ToDrizzleTable<T extends AnyRtTable> = MySqlTableWithColumns<{
+export type ToDrizzleTable<T extends AnyMysqlTable> = MySqlTableWithColumns<{
   name: TableNameOf<T>;
   schema: undefined;
   dialect: 'mysql';
@@ -89,7 +88,7 @@ export type ToDrizzleTable<T extends AnyRtTable> = MySqlTableWithColumns<{
 /** The drizzle-typed view of a slim VIEW. Same synthesis as ToDrizzleTable;
  *  TExisting stays `boolean` because nothing in select typing branches on it
  *  and pinning it would cost a type parameter on every declared view. */
-export type ToDrizzleView<V extends AnyRtView> = MySqlViewWithSelection<
+export type ToDrizzleView<V extends AnyMysqlView> = MySqlViewWithSelection<
   ViewNameOf<V>,
   boolean,
   {
@@ -99,15 +98,15 @@ export type ToDrizzleView<V extends AnyRtView> = MySqlViewWithSelection<
   }
 >;
 
-export function toDrizzle<T extends AnyRtTable>(table: T): ToDrizzleTable<T>;
-export function toDrizzle<V extends AnyRtView>(view: V): ToDrizzleView<V>;
+export function toDrizzle<T extends AnyMysqlTable>(table: T): ToDrizzleTable<T>;
+export function toDrizzle<V extends AnyMysqlView>(view: V): ToDrizzleView<V>;
 export function toDrizzle(handle: MySqlSchema): dzMy.MySqlSchema;
 // An INDEX declared outside any table's extraConfig. drizzle's query side takes
 // its own IndexBuilder (dzMy.IndexBuilder) for a hint, and the table's replay
 // takes the recorder, so a schema that does both declares the index once and
 // materializes it here for the query half.
 export function toDrizzle(entry: RtMyIndexEntry): dzMy.IndexBuilder;
-export function toDrizzle<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
+export function toDrizzle<T extends AnyMysqlTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
 export function toDrizzle(value?: object, id?: unknown): unknown {
   if (value !== undefined) {
     const attached = (value as Record<symbol, unknown>)[rtValueKey];
@@ -126,7 +125,7 @@ export function toDrizzle(value?: object, id?: unknown): unknown {
       );
     }
   }
-  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyRtTable> | undefined);
+  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyMysqlTable> | undefined);
   return materializeRtTable(slim, context);
 }
 

--- a/packages/drizzle-orm-mysql-core/src/index.spec.ts
+++ b/packages/drizzle-orm-mysql-core/src/index.spec.ts
@@ -54,7 +54,7 @@ import {
   year,
 } from './index.ts';
 import type {InferInsertModel, InferSelectModel, InferSelectViewModel, InferUpdateModel} from '@mionjs/drizzle-orm';
-import {refineTableType, sql} from '@mionjs/drizzle-orm';
+import {cols, refineTableType, sql} from '@mionjs/drizzle-orm';
 import {toDrizzle} from './drizzle.ts';
 import {mysqlView} from './views.ts';
 
@@ -133,7 +133,7 @@ const users = mysqlTable(
     born: year('born'),
     active: boolean('active').notNull().default(true),
     meta: json('meta').$type<{tags: string[]}>(),
-    teamId: int('team_id').references(() => teams.id, {onDelete: 'cascade'}),
+    teamId: int('team_id').references(() => cols(teams).id, {onDelete: 'cascade'}),
     fullName: text('full_name').generatedAlwaysAs(sql`name`),
     seenAt: datetime('seen_at', {mode: 'string'}),
     createdAt: timestamp('created_at').notNull().defaultNow().onUpdateNow(),
@@ -141,7 +141,7 @@ const users = mysqlTable(
   (t) => [
     index('users_name_idx').on(t.name, t.level).using('btree'),
     unique('users_name_uq').on(t.name),
-    foreignKey({name: 'users_team_fk', columns: [t.teamId], foreignColumns: [teams.id]}).onUpdate('restrict'),
+    foreignKey({name: 'users_team_fk', columns: [t.teamId], foreignColumns: [cols(teams).id]}).onUpdate('restrict'),
     check('users_level_check', sql`${t.level} >= 0`),
   ]
 );
@@ -374,7 +374,7 @@ const activeTeams = mysqlView('active_teams', {
   .algorithm('merge')
   .sqlSecurity('definer')
   .withCheckOption('cascaded')
-  .as(sql`select ${teams.id}, ${teams.code} from ${teams}`);
+  .as(sql`select ${cols(teams).id}, ${cols(teams).code} from ${teams}`);
 const dzActiveTeams = dzMy
   .mysqlView('active_teams', {
     id: dzMy.int('id'),

--- a/packages/drizzle-orm-mysql-core/src/index.ts
+++ b/packages/drizzle-orm-mysql-core/src/index.ts
@@ -28,7 +28,6 @@ export type {
   MySqlSchema,
   AnyMysqlTable,
   AnyMysqlView,
-  MysqlBuilderTable,
   MysqlTable,
   PrimaryKeyEntry,
   UniqueEntry,

--- a/packages/drizzle-orm-mysql-core/src/index.ts
+++ b/packages/drizzle-orm-mysql-core/src/index.ts
@@ -26,6 +26,8 @@ export type {
   MyExtraConfigEntry,
   MyExtraConfigFn,
   MySqlSchema,
+  AnyMysqlTable,
+  AnyMysqlView,
   MysqlBuilderTable,
   MysqlTable,
   PrimaryKeyEntry,

--- a/packages/drizzle-orm-mysql-core/src/table.ts
+++ b/packages/drizzle-orm-mysql-core/src/table.ts
@@ -27,31 +27,24 @@ import {mysqlColumnHelpers, type MySqlColumnHelpers} from './columns.ts';
 import {requireColumns} from './views.ts';
 import type {} from './helpers.ts';
 
-/** Pure-type twin of `mysqlTable(name, columns, extraConfig?)`: a table
- *  declared entirely as a type, from the column types (Varchar, Int, ...),
- *  modifier markers (NotNull, PrimaryKey, ...) and, for the extraConfig road,
- *  a tuple of table entries (IndexEntry, CheckEntry, ... or the raw TableEntry
- *  carrier). Normalizes to the same RtTable shape the builders produce, so
- *  models and refinement work unchanged; materialize with tableFromType. */
-export type MysqlTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = MysqlBuilderTable<
-  TName,
-  TypedCols<Cols>,
-  Extras
->;
-
-/** A mysql table whose columns are ALREADY normalized: what mysqlTable() returns,
- *  and what MysqlTable resolves to once it has normalized an authored columns
- *  record. Its own type alias rather than an extra type parameter on
- *  MysqlTable, because a parameter the factories fill with the same Cols they
- *  pass in slot two makes declaration emit print the whole columns record TWICE
- *  in every consumer's .d.ts (measured: it nearly doubles the emitted table type). */
-export interface MysqlBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
-  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'mysql'> {}
+/** A mysql table: the metadata and nothing wrapped around it.
+ *
+ *  ONE type for both roads. `mysqlTable('users', {...})` returns it with columns
+ *  the builders already branded, and `MysqlTable<'users', {id: Int<'id'>}>`
+ *  declares the same thing from the column TYPES; TypedCols passes an
+ *  already-branded record straight through, so the two land on one type.
+ *
+ *  It used to be two (MysqlTable normalizing, MysqlBuilderTable pre-normalized)
+ *  to save the builder road a TypedCols pass. That is worth about 5
+ *  instantiations a table and it is not worth two shapes: every table in the
+ *  codebase reads the same way, and nothing has to know which road declared it. */
+export interface MysqlTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, TypedCols<Cols>, Extras>, RtTableBrand<'mysql'> {}
 
 /** Any mysql table, whatever its name and columns. What this package's toDrizzle
  *  and tableFromType take, so another dialect's table is a compile error rather
  *  than a missing-function crash at materialization. */
-export type AnyMysqlTable = MysqlBuilderTable<string, Record<string, AnyRtColumn>, readonly object[]>;
+export type AnyMysqlTable = MysqlTable<string, Record<string, AnyRtColumn>, readonly object[]>;
 /** Any mysql view, the twin of AnyMysqlTable. */
 export type AnyMysqlView = import('./views.ts').MysqlSlimView<string, Record<string, AnyRtColumn>>;
 
@@ -163,12 +156,12 @@ export function mysqlTable<TName extends string, Cols extends Record<string, Any
   name: TName,
   columns: Cols,
   extraConfig?: MyExtraConfigFn<Cols>
-): MysqlBuilderTable<TName, Cols>;
+): MysqlTable<TName, Cols>;
 export function mysqlTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: MySqlColumnHelpers) => Cols,
   extraConfig?: MyExtraConfigFn<Cols>
-): MysqlBuilderTable<TName, Cols>;
+): MysqlTable<TName, Cols>;
 export function mysqlTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, mysqlBuildTable);
 }
@@ -180,12 +173,12 @@ export function mysqlTableCreator(customizeTableName: (name: string) => string) 
     name: TName,
     columns: Cols,
     extraConfig?: MyExtraConfigFn<Cols>
-  ): MysqlBuilderTable<TName, Cols>;
+  ): MysqlTable<TName, Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: MySqlColumnHelpers) => Cols,
     extraConfig?: MyExtraConfigFn<Cols>
-  ): MysqlBuilderTable<TName, Cols>;
+  ): MysqlTable<TName, Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-mysql-core/src/table.ts
+++ b/packages/drizzle-orm-mysql-core/src/table.ts
@@ -11,16 +11,16 @@
 
 import type {
   AnyRtColumn,
-  AnyRtTable,
   DrizzleContext,
   ReflectedNode,
   RtExtraColumn,
-  RtTableMetaWithExtras,
+  RtTableBrand,
+  RtTableMeta,
   TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
-import {buildRtTableFromGraph, createRtTable, RtValueRecorder, RtViewBuilder, rtTableKey, rtValueKey} from '@mionjs/drizzle-orm';
+import {buildRtTableFromGraph, createRtTable, RtValueRecorder, RtViewBuilder, rtValueKey} from '@mionjs/drizzle-orm';
 import type {InjectRunTypeId} from '@ts-runtypes/core';
 import {getRunType} from '@ts-runtypes/core';
 import {mysqlColumnHelpers, type MySqlColumnHelpers} from './columns.ts';
@@ -45,9 +45,15 @@ export type MysqlTable<TName extends string, Cols extends object, Extras extends
  *  MysqlTable, because a parameter the factories fill with the same Cols they
  *  pass in slot two makes declaration emit print the whole columns record TWICE
  *  in every consumer's .d.ts (measured: it nearly doubles the emitted table type). */
-export type MysqlBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
-  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
-};
+export interface MysqlBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'mysql'> {}
+
+/** Any mysql table, whatever its name and columns. What this package's toDrizzle
+ *  and tableFromType take, so another dialect's table is a compile error rather
+ *  than a missing-function crash at materialization. */
+export type AnyMysqlTable = MysqlBuilderTable<string, Record<string, AnyRtColumn>, readonly object[]>;
+/** Any mysql view, the twin of AnyMysqlTable. */
+export type AnyMysqlView = import('./views.ts').MysqlSlimView<string, Record<string, AnyRtColumn>>;
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -99,12 +105,12 @@ const fromTypeTables = new Map<string, object>();
  *  a builder call does: two tables of the same type can carry different
  *  callbacks or different referenced tables, and sharing would silently hand
  *  the second one the first one's. */
-export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
+export function tableFromType<T extends AnyMysqlTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
   const runType = getRunType<T>(undefined, id);
-  if (options !== undefined) return buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable, options) as T;
+  if (options !== undefined) return buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable, options, 'mysql') as T;
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
-    slimTable = buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable);
+    slimTable = buildRtTableFromGraph(runType as ReflectedNode, mysqlBuildTable, undefined, 'mysql');
     fromTypeTables.set(runType.id, slimTable);
   }
   return slimTable as T;

--- a/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-mysql-core/src/typeTables.spec.ts
@@ -16,8 +16,9 @@
 import {describe, it, expect} from 'vitest';
 import {getTableConfig} from 'drizzle-orm/mysql-core';
 import {createValidateFn, getRunTypeId} from '@ts-runtypes/core';
-import type {InferInsertModel, InferSelectModel} from '@mionjs/drizzle-orm';
-import type {Int, MysqlTable, Serial, Text, Timestamp, Varchar} from './index.ts';
+import type {InferInsertModel, InferSelectModel, RtTableMeta} from '@mionjs/drizzle-orm';
+import {rtTableBrand} from '@mionjs/drizzle-orm';
+import type {AnyMysqlTable, Int, MysqlTable, Serial, Text, Timestamp, Varchar} from './index.ts';
 import {int, mysqlTable, serial, tableFromType, text, timestamp, varchar} from './index.ts';
 import {toDrizzle} from './drizzle.ts';
 
@@ -169,5 +170,35 @@ describe('mysql type-defined tables — runtime-callback modifiers', () => {
     const minimal: TypeInsertRuntime = {id: 1}; // slug is notNull but $DefaultFn makes it optional
     expect(getRunTypeId<TypeInsertRuntime>()).toBe(getRunTypeId<InferInsertModel<typeof runtimeBuilders>>());
     expect(getRunTypeId(minimal)).toBe(getRunTypeId<TypeInsertRuntime>());
+  });
+});
+
+// A table carries the dialect that recorded it, inside its own metadata. That
+// is what makes reaching the wrong package's toDrizzle a COMPILE error, where
+// it used to typecheck and then die at materialization: every table replays its
+// own captured buildTable closure against whichever context it is handed.
+//
+// The foreign table is spelled here rather than imported, because a dialect
+// package must not depend on its siblings. What this package owes the pin is
+// the other half: that its OWN builders and table types carry its tag.
+describe('mysql tables are typed to the mysql package', () => {
+  it('tags what mysqlTable() and MysqlTable<> produce as mysql', () => {
+    const table = mysqlTable('tagged', {id: int('id').primaryKey()});
+    const accepted: AnyMysqlTable = table;
+    type FromType = MysqlTable<'tagged', {id: Int<'id', {primaryKey: true}>}>;
+    const acceptedType: AnyMysqlTable = {} as FromType;
+    expect(accepted).toBe(table);
+    expect(acceptedType).toBeDefined();
+  });
+
+  it('rejects another dialect table, as a value and as a type argument', () => {
+    interface ForeignLike extends RtTableMeta<'users', {id: Int<'id'>}, []> {
+      readonly [rtTableBrand]?: 'pg';
+    }
+    // @ts-expect-error a pg-tagged table is not a mysql table
+    const rejected: AnyMysqlTable = {} as ForeignLike;
+    // @ts-expect-error and it cannot be rebuilt through this package's bridge
+    void tableFromType<ForeignLike>;
+    expect(rejected).toBeDefined();
   });
 });

--- a/packages/drizzle-orm-mysql-core/src/views.ts
+++ b/packages/drizzle-orm-mysql-core/src/views.ts
@@ -14,9 +14,12 @@
 // but not supported: its columns come from drizzle's select typing, the exact
 // generic chain the slim design removes (packages/drizzle-orm/CLAUDE.md).
 
-import type {AnyRtColumn, DrizzleContext, RtSql, RtView} from '@mionjs/drizzle-orm';
+import type {AnyRtColumn, DrizzleContext, RtSql, RtViewBrand, RtViewMeta} from '@mionjs/drizzle-orm';
 import {RtViewBuilder} from '@mionjs/drizzle-orm';
 
+/** A mysql slim view: the view metadata, tagged with the dialect that
+ *  recorded it, so it cannot reach another dialect's toDrizzle. */
+export interface MysqlSlimView<TName extends string, Cols> extends RtViewMeta<TName, Cols>, RtViewBrand<'mysql'> {}
 /** The stand-in a columnless `mysqlView(name)` returns: it has no `as`, so the
  *  query-builder form fails at the call that would use it, naming itself. */
 export interface ViewFromQueryBuilderNotSupported {
@@ -32,9 +35,9 @@ export interface MySqlViewBuilder<TName extends string, Cols extends Record<stri
   sqlSecurity(sqlSecurity: MySqlViewSecurity): MySqlViewBuilder<TName, Cols>;
   withCheckOption(withCheckOption?: MySqlViewCheckOption): MySqlViewBuilder<TName, Cols>;
   /** The view's query, as literal sql. */
-  as(query: RtSql): RtView<TName, Cols>;
+  as(query: RtSql): MysqlSlimView<TName, Cols>;
   /** The view already exists: drizzle-kit emits no CREATE VIEW for it. */
-  existing(): RtView<TName, Cols>;
+  existing(): MysqlSlimView<TName, Cols>;
 }
 
 /** The mysql buildView closure (also used by mysqlSchema's view). */

--- a/packages/drizzle-orm-pg-core/src/drizzle.ts
+++ b/packages/drizzle-orm-pg-core/src/drizzle.ts
@@ -20,8 +20,6 @@ import * as dzPg from 'drizzle-orm/pg-core';
 import {sql as dzSql} from 'drizzle-orm';
 import type {PgColumn, PgTableWithColumns, PgViewWithSelection} from 'drizzle-orm/pg-core';
 import type {
-  AnyRtTable,
-  AnyRtView,
   ColBrandOf,
   PlainDataOf,
   ColKeyFlags,
@@ -44,6 +42,7 @@ import {
 } from '@mionjs/drizzle-orm';
 import type {InjectRunTypeId} from '@ts-runtypes/core';
 import type {PgEnum, PgEnumObject, PgRole, RtLinkedPolicy, RtPolicyEntry, RtIndexEntry} from './helpers.ts';
+import type {AnyPgTable, AnyPgView} from './table.ts';
 import {tableFromType, type PgSchema, type PgSequence} from './table.ts';
 
 const context: DrizzleContext = {
@@ -85,7 +84,7 @@ type SynthConfig<K extends string, TName extends string, Brand, Key extends ColK
 
 /** The drizzle-typed view of a slim table: what db.select/insert/update infer
  *  from. Evaluated lazily, only where toDrizzle is actually used. */
-export type ToDrizzleTable<T extends AnyRtTable> = PgTableWithColumns<{
+export type ToDrizzleTable<T extends AnyPgTable> = PgTableWithColumns<{
   name: TableNameOf<T>;
   schema: undefined;
   dialect: 'pg';
@@ -99,7 +98,7 @@ export type ToDrizzleTable<T extends AnyRtTable> = PgTableWithColumns<{
 /** The drizzle-typed view of a slim VIEW. Same synthesis as ToDrizzleTable;
  *  TExisting stays `boolean` because nothing in select typing branches on it
  *  and pinning it would cost a type parameter on every declared view. */
-export type ToDrizzleView<V extends AnyRtView> = PgViewWithSelection<
+export type ToDrizzleView<V extends AnyPgView> = PgViewWithSelection<
   ViewNameOf<V>,
   boolean,
   {
@@ -116,8 +115,8 @@ export type ToDrizzleView<V extends AnyRtView> = PgViewWithSelection<
  *  is the type road's happy path: it resolves the table type itself
  *  (ts-runtypes-devtools must be active) and shares tableFromType's per-type
  *  slim table. */
-export function toDrizzle<T extends AnyRtTable>(table: T): ToDrizzleTable<T>;
-export function toDrizzle<V extends AnyRtView>(view: V): ToDrizzleView<V>;
+export function toDrizzle<T extends AnyPgTable>(table: T): ToDrizzleTable<T>;
+export function toDrizzle<V extends AnyPgView>(view: V): ToDrizzleView<V>;
 export function toDrizzle<T extends readonly [string, ...string[]]>(handle: PgEnum<T>): dzPg.PgEnum<[T[0], ...string[]]>;
 export function toDrizzle<E extends Record<string, string>>(handle: PgEnumObject<E>): dzPg.PgEnumObject<E>;
 export function toDrizzle(handle: PgSchema): dzPg.PgSchema;
@@ -134,7 +133,7 @@ export function toDrizzle(handle: RtPolicyEntry): dzPg.PgPolicy;
 // takes the recorder, so a schema that does both declares the index once and
 // materializes it here for the query half.
 export function toDrizzle(entry: RtIndexEntry): dzPg.IndexBuilder;
-export function toDrizzle<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
+export function toDrizzle<T extends AnyPgTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
 export function toDrizzle(value?: object, id?: unknown): unknown {
   if (value !== undefined) {
     const attached = (value as Record<symbol, unknown>)[rtValueKey];
@@ -151,7 +150,7 @@ export function toDrizzle(value?: object, id?: unknown): unknown {
       );
     }
   }
-  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyRtTable> | undefined);
+  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyPgTable> | undefined);
   return materializeRtTable(slim, context);
 }
 

--- a/packages/drizzle-orm-pg-core/src/drizzleTypeSource.integration.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/drizzleTypeSource.integration.spec.ts
@@ -106,6 +106,9 @@ function renderFixture(rng: () => number, iteration: number): Rendered {
     `import type * as DB from './src/index.ts';\n` +
     `import * as DBV from './src/index.ts';\n` +
     `import type {InferSelectModel} from '@mionjs/drizzle-orm';\n` +
+    // cols(): a slim table's TYPE is its metadata, so a cross-table reference
+    // reaches the columns through the accessor rather than a property.
+    `import {cols} from '@mionjs/drizzle-orm';\n` +
     `const fzParent = DBV.pgTable('${FUZZ_PARENT_NAME}', {id: DBV.integer('id').primaryKey()});\n` +
     `${typeDecls}\n${builderDecls}\ndeclare const fzValueProbe: Fz0;\n` +
     `${tableProbes}\ngetRunTypeId(fzValueProbe);\n${modelProbes}\n`;

--- a/packages/drizzle-orm-pg-core/src/index.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/index.spec.ts
@@ -79,7 +79,7 @@ import {
   varchar,
 } from './index.ts';
 import type {InferInsertModel, InferSelectModel, InferSelectViewModel, InferUpdateModel} from '@mionjs/drizzle-orm';
-import {refineTableType, sql} from '@mionjs/drizzle-orm';
+import {cols, refineTableType, sql} from '@mionjs/drizzle-orm';
 import {toDrizzle} from './drizzle.ts';
 
 // ── the equality oracle ──────────────────────────────────────────────────────
@@ -200,7 +200,7 @@ const users = pgTable(
     meta: jsonb('meta').$type<{tags: string[]}>(),
     ip: inet('ip'),
     mask: bit('mask', {dimensions: 8}),
-    teamId: integer('team_id').references(() => teams.id, {onDelete: 'cascade'}),
+    teamId: integer('team_id').references(() => cols(teams).id, {onDelete: 'cascade'}),
     fullName: text('full_name').generatedAlwaysAs(sql`name || ' '`),
     bornOn: date('born_on', {mode: 'string'}),
     wakeAt: time('wake_at'),
@@ -213,7 +213,7 @@ const users = pgTable(
       .where(sql`${t.age} > ${18}`),
     uniqueIndex('users_nickname_uidx').on(t.nickname),
     unique('users_name_team_uq').on(t.name, t.teamId).nullsNotDistinct(),
-    foreignKey({name: 'users_team_fk', columns: [t.teamId], foreignColumns: [teams.id]}).onUpdate('restrict'),
+    foreignKey({name: 'users_team_fk', columns: [t.teamId], foreignColumns: [cols(teams).id]}).onUpdate('restrict'),
     check('users_age_check', sql`${t.age} >= 0`),
     pgPolicy('users_read_policy', {as: 'permissive', for: 'select', to: [auditor], using: sql`true`}),
   ]
@@ -543,7 +543,7 @@ const nyUsers = pgView('new_yorkers', {
   id: uuid('id').primaryKey(),
   name: varchar('name', {length: 100}).notNull(),
   city: text('city'),
-}).as(sql`select ${users.id}, ${users.name}, 'NY' from ${users}`);
+}).as(sql`select ${cols(users).id}, ${cols(users).name}, 'NY' from ${users}`);
 const dzNyUsers = dzPgView('new_yorkers', {
   id: dzUuid('id').primaryKey(),
   name: dzVarchar('name', {length: 100}).notNull(),
@@ -567,7 +567,7 @@ const topTeams = pgMaterializedView('top_teams', {
   .with({fillfactor: 90})
   .tablespace('custom_tablespace')
   .withNoData()
-  .as(sql`select ${teams.id}, ${teams.code} from ${teams}`);
+  .as(sql`select ${cols(teams).id}, ${cols(teams).code} from ${teams}`);
 const dzTopTeams = dzPgMaterializedView('top_teams', {
   id: dzSerial('id').primaryKey(),
   code: dzVarchar('code', {length: 10}).notNull(),

--- a/packages/drizzle-orm-pg-core/src/index.ts
+++ b/packages/drizzle-orm-pg-core/src/index.ts
@@ -28,6 +28,8 @@ export type {
   CheckEntry,
   ForeignKeyEntry,
   IndexEntry,
+  AnyPgTable,
+  AnyPgView,
   PgBuilderTable,
   PgExtraConfigColumns,
   PgExtraConfigEntry,
@@ -54,6 +56,7 @@ export * from './helpers.ts';
 export {pgMaterializedView, pgView} from './views.ts';
 export type {
   PgMaterializedViewBuilder,
+  PgSlimView,
   PgViewBuilder,
   PgViewBuilderCore,
   PgViewWithConfig,

--- a/packages/drizzle-orm-pg-core/src/index.ts
+++ b/packages/drizzle-orm-pg-core/src/index.ts
@@ -30,7 +30,6 @@ export type {
   IndexEntry,
   AnyPgTable,
   AnyPgView,
-  PgBuilderTable,
   PgExtraConfigColumns,
   PgExtraConfigEntry,
   PgExtraConfigFn,

--- a/packages/drizzle-orm-pg-core/src/table.ts
+++ b/packages/drizzle-orm-pg-core/src/table.ts
@@ -36,37 +36,26 @@ import {pgColumnHelpers, type PgColumnHelpers} from './columns.ts';
 import {requireColumns} from './views.ts';
 import type {} from './helpers.ts';
 
-/** Pure-type twin of `pgTable(name, columns, extraConfig?)`: a table declared
- *  entirely as a type, from the column types (Varchar, Uuid, ...), modifier
- *  markers (NotNull, PrimaryKey, ...) and, for the extraConfig road, a tuple
- *  of table entries (IndexEntry, CheckEntry, ... or the raw TableEntry
- *  carrier). Normalizes to the same RtTable shape the builders produce, so
- *  models and refinement work unchanged; materialize with tableFromType. */
-export type PgTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = PgBuilderTable<
-  TName,
-  TypedCols<Cols>,
-  Extras
->;
-
-/** A pg table whose columns are ALREADY normalized: what pgTable() returns, and
- *  what PgTable resolves to once it has normalized an authored columns record.
- *  Its own type alias rather than an extra type parameter on PgTable, because a
- *  parameter the factories fill with the same Cols they pass in slot two makes
- *  declaration emit print the whole columns record TWICE in every consumer's
- *  .d.ts (measured: it nearly doubles the emitted table type).
+/** A pg table: the metadata and nothing wrapped around it.
  *
- *  An interface EXTENDING the meta rather than intersecting with it: enableRLS
- *  then rides in the same object type, where an intersection would be a second
- *  one for the checker to merge on every declared table. */
-export interface PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
-  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'pg'> {
+ *  ONE type for both roads. `pgTable('users', {...})` returns it with columns
+ *  the builders already branded, and `PgTable<'users', {id: Uuid<'id'>}>`
+ *  declares the same thing from the column TYPES; TypedCols passes an
+ *  already-branded record straight through, so the two land on one type.
+ *
+ *  It used to be two (PgTable normalizing, PgBuilderTable pre-normalized) to
+ *  save the builder road a TypedCols pass. That is worth about 5 instantiations
+ *  a table and it is not worth two shapes: every table in the codebase reads
+ *  the same way, and nothing has to know which road declared it. */
+export interface PgTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, TypedCols<Cols>, Extras>, RtTableBrand<'pg'> {
   enableRLS(): PgTableWithRLS<TName, Cols, Extras>;
 }
 
 /** A pg table with row level security on: the same table minus enableRLS, so it
  *  cannot be enabled twice. Mirrors drizzle's own `Omit<..., 'enableRLS'>`. */
 export interface PgTableWithRLS<TName extends string, Cols extends object, Extras extends readonly object[] = []>
-  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'pg'> {}
+  extends RtTableMeta<TName, TypedCols<Cols>, Extras>, RtTableBrand<'pg'> {}
 
 /** Any pg table, whatever its name and columns. What this package's toDrizzle
  *  and tableFromType take, so another dialect's table is a compile error rather
@@ -185,12 +174,12 @@ export function pgTable<TName extends string, Cols extends Record<string, AnyRtC
   name: TName,
   columns: Cols,
   extraConfig?: PgExtraConfigFn<Cols>
-): PgBuilderTable<TName, Cols>;
+): PgTable<TName, Cols>;
 export function pgTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: PgColumnHelpers) => Cols,
   extraConfig?: PgExtraConfigFn<Cols>
-): PgBuilderTable<TName, Cols>;
+): PgTable<TName, Cols>;
 export function pgTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, pgBuildTable);
 }
@@ -202,12 +191,12 @@ export function pgTableCreator(customizeTableName: (name: string) => string) {
     name: TName,
     columns: Cols,
     extraConfig?: PgExtraConfigFn<Cols>
-  ): PgBuilderTable<TName, Cols>;
+  ): PgTable<TName, Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: PgColumnHelpers) => Cols,
     extraConfig?: PgExtraConfigFn<Cols>
-  ): PgBuilderTable<TName, Cols>;
+  ): PgTable<TName, Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-pg-core/src/table.ts
+++ b/packages/drizzle-orm-pg-core/src/table.ts
@@ -13,11 +13,11 @@
 
 import type {
   AnyRtColumn,
-  AnyRtTable,
   DrizzleContext,
   ReflectedNode,
   RtExtraColumn,
-  RtTableMetaWithExtras,
+  RtTableBrand,
+  RtTableMeta,
   TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
@@ -28,7 +28,6 @@ import {
   RtColumnRecorder,
   RtValueRecorder,
   RtViewBuilder,
-  rtTableKey,
   rtValueKey,
 } from '@mionjs/drizzle-orm';
 import type {InjectRunTypeId} from '@ts-runtypes/core';
@@ -54,19 +53,27 @@ export type PgTable<TName extends string, Cols extends object, Extras extends re
  *  Its own type alias rather than an extra type parameter on PgTable, because a
  *  parameter the factories fill with the same Cols they pass in slot two makes
  *  declaration emit print the whole columns record TWICE in every consumer's
- *  .d.ts (measured: it nearly doubles the emitted table type). */
-export type PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
-  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
-  // Same object as the meta key, never a third intersection member: a declared
-  // table pays one property, not another object (type-budget sensitive).
+ *  .d.ts (measured: it nearly doubles the emitted table type).
+ *
+ *  An interface EXTENDING the meta rather than intersecting with it: enableRLS
+ *  then rides in the same object type, where an intersection would be a second
+ *  one for the checker to merge on every declared table. */
+export interface PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'pg'> {
   enableRLS(): PgTableWithRLS<TName, Cols, Extras>;
-};
+}
 
 /** A pg table with row level security on: the same table minus enableRLS, so it
  *  cannot be enabled twice. Mirrors drizzle's own `Omit<..., 'enableRLS'>`. */
-export type PgTableWithRLS<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
-  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
-};
+export interface PgTableWithRLS<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'pg'> {}
+
+/** Any pg table, whatever its name and columns. What this package's toDrizzle
+ *  and tableFromType take, so another dialect's table is a compile error rather
+ *  than a `dzPg.mysqlTable is not a function` at run time. */
+export type AnyPgTable = PgTableWithRLS<string, Record<string, AnyRtColumn>, readonly object[]>;
+/** Any pg view, the twin of AnyPgTable. */
+export type AnyPgView = import('./views.ts').PgSlimView<string, Record<string, AnyRtColumn>>;
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -118,12 +125,12 @@ const fromTypeTables = new Map<string, object>();
  *  a builder call does: two tables of the same type can carry different
  *  callbacks or different referenced tables, and sharing would silently hand
  *  the second one the first one's. */
-export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
+export function tableFromType<T extends AnyPgTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
   const runType = getRunType<T>(undefined, id);
-  if (options !== undefined) return buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable, options) as T;
+  if (options !== undefined) return buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable, options, 'pg') as T;
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
-    slimTable = buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable);
+    slimTable = buildRtTableFromGraph(runType as ReflectedNode, pgBuildTable, undefined, 'pg');
     fromTypeTables.set(runType.id, slimTable);
   }
   return slimTable as T;

--- a/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-pg-core/src/typeTables.spec.ts
@@ -15,10 +15,11 @@
 import {describe, it, expect} from 'vitest';
 import {getTableConfig} from 'drizzle-orm/pg-core';
 import {getRunTypeId} from '@ts-runtypes/core';
-import type {InferInsertModel, InferSelectModel, Sql} from '@mionjs/drizzle-orm';
-import {sql as slimSql} from '@mionjs/drizzle-orm';
+import type {InferInsertModel, InferSelectModel, RtTableMeta, Sql} from '@mionjs/drizzle-orm';
+import {rtTableBrand, cols, sql as slimSql} from '@mionjs/drizzle-orm';
 import {project as sharedProject} from '../test/tableSpecShared.ts';
 import type {
+  AnyPgTable,
   CheckEntry,
   ForeignKeyEntry,
   IndexEntry,
@@ -176,7 +177,7 @@ describe('pg type-defined tables — same model runtype id', () => {
 const parentsBuilders = pgTable('parents', {id: integer('id').primaryKey()});
 const childrenBuilders = pgTable('children', {
   pid: integer('pid')
-    .references(() => parentsBuilders.id, {onDelete: 'cascade'})
+    .references(() => cols(parentsBuilders).id, {onDelete: 'cascade'})
     .notNull(),
   createdAt: timestamp('created_at').default(slimSql`now()`),
 });
@@ -218,7 +219,7 @@ const extrasBuilders = pgTable(
     uniqueIndex('uidx_b').on(t.b),
     unique('uq_ab').on(t.a, t.b),
     check('chk_a', slimSql`a >= 0`),
-    foreignKey({name: 'fk_pid', columns: [t.pid], foreignColumns: [parentsBuilders.id]}),
+    foreignKey({name: 'fk_pid', columns: [t.pid], foreignColumns: [cols(parentsBuilders).id]}),
   ]
 );
 type ExtrasType = PgTable<
@@ -340,5 +341,37 @@ describe('pg type-defined tables — widened vocabulary twin', () => {
     const row: WideSelectType = {} as WideSelectType;
     expect(getRunTypeId<WideSelectType>()).toBe(getRunTypeId<WideSelectBuilders>());
     expect(getRunTypeId(row)).toBe(getRunTypeId<WideSelectType>());
+  });
+});
+
+// A table carries the dialect that recorded it, inside its own metadata. That
+// is what makes reaching the wrong package's toDrizzle a COMPILE error, where
+// it used to typecheck and then die at materialization: every table replays its
+// own captured buildTable closure against whichever context it is handed, so a
+// pg table run through mysql reached for `context.ns.pgTable` and found nothing.
+//
+// The foreign table is spelled here rather than imported, because a dialect
+// package must not depend on its siblings. What each package owes this pin is
+// the other half: that its OWN builders and table types carry its tag, which
+// the first case below is.
+describe('pg tables are typed to the pg package', () => {
+  it('tags what pgTable() and PgTable<> produce as pg', () => {
+    const table = pgTable('tagged', {id: integer('id').primaryKey()});
+    const accepted: AnyPgTable = table;
+    type FromType = PgTable<'tagged', {id: Integer<'id', {primaryKey: true}>}>;
+    const acceptedType: AnyPgTable = {} as FromType;
+    expect(accepted).toBe(table);
+    expect(acceptedType).toBeDefined();
+  });
+
+  it('rejects another dialect table, as a value and as a type argument', () => {
+    interface MysqlLike extends RtTableMeta<'users', {id: Integer<'id'>}, []> {
+      readonly [rtTableBrand]?: 'mysql';
+    }
+    // @ts-expect-error a mysql-tagged table is not a pg table
+    const rejected: AnyPgTable = {} as MysqlLike;
+    // @ts-expect-error and it cannot be rebuilt through the pg bridge either
+    void tableFromType<MysqlLike>;
+    expect(rejected).toBeDefined();
   });
 });

--- a/packages/drizzle-orm-pg-core/src/views.ts
+++ b/packages/drizzle-orm-pg-core/src/views.ts
@@ -16,9 +16,12 @@
 // mistake shows up as a readable error on `.as(...)` rather than an arity
 // complaint (packages/drizzle-orm/CLAUDE.md records why).
 
-import type {AnyRtColumn, DrizzleContext, RtSql, RtView} from '@mionjs/drizzle-orm';
+import type {AnyRtColumn, DrizzleContext, RtSql, RtViewBrand, RtViewMeta} from '@mionjs/drizzle-orm';
 import {RtViewBuilder} from '@mionjs/drizzle-orm';
 
+/** A pg slim view: the view metadata, tagged with the dialect that
+ *  recorded it, so it cannot reach another dialect's toDrizzle. */
+export interface PgSlimView<TName extends string, Cols> extends RtViewMeta<TName, Cols>, RtViewBrand<'pg'> {}
 /** The stand-in a columnless `pgView(name)` returns: it has no `as`, so the
  *  query-builder form fails at the call that would use it, naming itself. */
 export interface ViewFromQueryBuilderNotSupported {
@@ -37,9 +40,9 @@ export interface PgViewBuilder<TName extends string, Cols extends Record<string,
   PgViewBuilder<TName, Cols>
 > {
   /** The view's query, as literal sql. */
-  as(query: RtSql): RtView<TName, Cols>;
+  as(query: RtSql): PgSlimView<TName, Cols>;
   /** The view already exists: drizzle-kit emits no CREATE VIEW for it. */
-  existing(): RtView<TName, Cols>;
+  existing(): PgSlimView<TName, Cols>;
 }
 
 export interface PgMaterializedViewBuilder<
@@ -49,8 +52,8 @@ export interface PgMaterializedViewBuilder<
   using(method: string): PgMaterializedViewBuilder<TName, Cols>;
   tablespace(tablespace: string): PgMaterializedViewBuilder<TName, Cols>;
   withNoData(): PgMaterializedViewBuilder<TName, Cols>;
-  as(query: RtSql): RtView<TName, Cols>;
-  existing(): RtView<TName, Cols>;
+  as(query: RtSql): PgSlimView<TName, Cols>;
+  existing(): PgSlimView<TName, Cols>;
 }
 
 /** The pg buildView closures, also used by pgSchema's view/materializedView. */

--- a/packages/drizzle-orm-pg-core/test/tableSpecShared.ts
+++ b/packages/drizzle-orm-pg-core/test/tableSpecShared.ts
@@ -344,7 +344,7 @@ export function renderTableBuilders(spec: TableSpec, tableName: string, namespac
       const fkColumn = spec.columns.find((column) => column.referencesParent)!;
       return (
         `    ${namespace}.foreignKey({name: '${extra.name}', ` +
-        `columns: [t.${fkColumn.key}], foreignColumns: [${parentConst}.id]}),`
+        `columns: [t.${fkColumn.key}], foreignColumns: [cols(${parentConst}).id]}),`
       );
     }
     const on = (extra.onKeys ?? []).map((key) => `t.${key}`).join(', ');
@@ -436,9 +436,15 @@ export function syntheticTableGraph(spec: TableSpec, tableName: string): Reflect
       }),
     });
   });
-  const meta: Record<string, ReflectedNode> = {name: literalNode(tableName), columns: objectNode(columns)};
+  // The table type IS its metadata, so name / columns / extras are the root's
+  // own members and the brand is what marks the node as a table.
+  const meta: Record<string, ReflectedNode> = {
+    'þ@rtTableBrand': literalNode('pg'),
+    name: literalNode(tableName),
+    columns: objectNode(columns),
+  };
   if (entries.length > 0) meta.extras = tupleNode(entries);
-  return objectNode({'þ@rtTableKey': objectNode(meta)});
+  return objectNode(meta);
 }
 
 // ── views: the same spec machinery, read-only ────────────────────────────────

--- a/packages/drizzle-orm-sqlite-core/src/drizzle.ts
+++ b/packages/drizzle-orm-sqlite-core/src/drizzle.ts
@@ -15,17 +15,7 @@
 import * as dzSqlite from 'drizzle-orm/sqlite-core';
 import {sql as dzSql} from 'drizzle-orm';
 import type {SQLiteColumn, SQLiteTableWithColumns, SQLiteViewWithSelection} from 'drizzle-orm/sqlite-core';
-import type {
-  AnyRtTable,
-  AnyRtView,
-  ColBrandOf,
-  PlainDataOf,
-  ColsOf,
-  DrizzleContext,
-  TableNameOf,
-  ViewColsOf,
-  ViewNameOf,
-} from '@mionjs/drizzle-orm';
+import type {ColBrandOf, PlainDataOf, ColsOf, DrizzleContext, TableNameOf, ViewColsOf, ViewNameOf} from '@mionjs/drizzle-orm';
 import type {TableFromTypeOptions} from '@mionjs/drizzle-orm';
 import {
   isRtView,
@@ -38,6 +28,7 @@ import {
 } from '@mionjs/drizzle-orm';
 import type {InjectRunTypeId} from '@ts-runtypes/core';
 import type {RtSqliteIndexEntry} from './helpers.ts';
+import type {AnySqliteTable, AnySqliteView} from './table.ts';
 import {tableFromType} from './table.ts';
 
 const context: DrizzleContext = {
@@ -72,7 +63,7 @@ type SynthConfig<K extends string, TName extends string, Brand> = Brand extends 
   : never;
 
 /** The drizzle-typed view of a slim table, paid lazily where queries live. */
-export type ToDrizzleTable<T extends AnyRtTable> = SQLiteTableWithColumns<{
+export type ToDrizzleTable<T extends AnySqliteTable> = SQLiteTableWithColumns<{
   name: TableNameOf<T>;
   schema: undefined;
   dialect: 'sqlite';
@@ -84,7 +75,7 @@ export type ToDrizzleTable<T extends AnyRtTable> = SQLiteTableWithColumns<{
 /** The drizzle-typed view of a slim VIEW. Same synthesis as ToDrizzleTable;
  *  TExisting stays `boolean` because nothing in select typing branches on it
  *  and pinning it would cost a type parameter on every declared view. */
-export type ToDrizzleView<V extends AnyRtView> = SQLiteViewWithSelection<
+export type ToDrizzleView<V extends AnySqliteView> = SQLiteViewWithSelection<
   ViewNameOf<V>,
   boolean,
   {
@@ -92,14 +83,17 @@ export type ToDrizzleView<V extends AnyRtView> = SQLiteViewWithSelection<
   }
 >;
 
-export function toDrizzle<T extends AnyRtTable>(table: T): ToDrizzleTable<T>;
-export function toDrizzle<V extends AnyRtView>(view: V): ToDrizzleView<V>;
+export function toDrizzle<T extends AnySqliteTable>(table: T): ToDrizzleTable<T>;
+export function toDrizzle<V extends AnySqliteView>(view: V): ToDrizzleView<V>;
 // An INDEX declared outside any table's extraConfig. drizzle's query side takes
 // its own IndexBuilder (dzSqlite.IndexBuilder) for a hint, and the table's replay
 // takes the recorder, so a schema that does both declares the index once and
 // materializes it here for the query half.
 export function toDrizzle(entry: RtSqliteIndexEntry): dzSqlite.IndexBuilder;
-export function toDrizzle<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): ToDrizzleTable<T>;
+export function toDrizzle<T extends AnySqliteTable>(
+  options?: TableFromTypeOptions<T>,
+  id?: InjectRunTypeId<T>
+): ToDrizzleTable<T>;
 export function toDrizzle(value?: object, id?: unknown): unknown {
   if (value !== undefined) {
     const attached = (value as Record<symbol, unknown>)[rtValueKey];
@@ -117,7 +111,7 @@ export function toDrizzle(value?: object, id?: unknown): unknown {
       );
     }
   }
-  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnyRtTable> | undefined);
+  const slim = tableFromType(value as TableFromTypeOptions | undefined, id as InjectRunTypeId<AnySqliteTable> | undefined);
   return materializeRtTable(slim, context);
 }
 

--- a/packages/drizzle-orm-sqlite-core/src/index.spec.ts
+++ b/packages/drizzle-orm-sqlite-core/src/index.spec.ts
@@ -28,7 +28,7 @@ import {sql as dzRealSql} from 'drizzle-orm';
 import {createValidateFn, getRunTypeId} from '@ts-runtypes/core';
 import {check, foreignKey, index, integer, numeric, primaryKey, real, sqliteTable, text, unique} from './index.ts';
 import type {InferInsertModel, InferSelectModel, InferSelectViewModel, InferUpdateModel} from '@mionjs/drizzle-orm';
-import {refineTableType, sql} from '@mionjs/drizzle-orm';
+import {cols, refineTableType, sql} from '@mionjs/drizzle-orm';
 import {toDrizzle} from './drizzle.ts';
 import {sqliteView, view as sqliteViewAlias} from './views.ts';
 
@@ -102,7 +102,7 @@ const users = sqliteTable(
     score: real('score').default(0.5),
     balance: numeric('balance', {mode: 'number'}),
     active: integer('active', {mode: 'boolean'}).notNull().default(true),
-    teamId: integer('team_id').references(() => teams.id, {onDelete: 'cascade'}),
+    teamId: integer('team_id').references(() => cols(teams).id, {onDelete: 'cascade'}),
     fullName: text('full_name').generatedAlwaysAs(sql`name`),
     createdAt: integer('created_at', {mode: 'timestamp'}).notNull().default(sql.raw('(unixepoch())')),
   },
@@ -111,7 +111,7 @@ const users = sqliteTable(
       .on(t.name)
       .where(sql`${t.score} > ${0}`),
     unique('users_name_uq').on(t.name),
-    foreignKey({name: 'users_team_fk', columns: [t.teamId], foreignColumns: [teams.id]}).onUpdate('restrict'),
+    foreignKey({name: 'users_team_fk', columns: [t.teamId], foreignColumns: [cols(teams).id]}).onUpdate('restrict'),
     check('users_score_check', sql`${t.score} >= 0`),
   ]
 );
@@ -326,7 +326,7 @@ function projectView(view: object) {
 const teamNames = sqliteView('team_names', {
   id: integer('id'),
   code: text('code').notNull(),
-}).as(sql`select ${teams.id}, ${teams.code} from ${teams}`);
+}).as(sql`select ${cols(teams).id}, ${cols(teams).code} from ${teams}`);
 const dzTeamNames = dzSqlite
   .sqliteView('team_names', {id: dzInteger('id'), code: dzText('code').notNull()})
   .as(dzRealSql`select ${dzTeams.id}, ${dzTeams.code} from ${dzTeams}`);

--- a/packages/drizzle-orm-sqlite-core/src/index.ts
+++ b/packages/drizzle-orm-sqlite-core/src/index.ts
@@ -23,6 +23,8 @@ export type {
   ForeignKeyEntry,
   IndexEntry,
   PrimaryKeyEntry,
+  AnySqliteTable,
+  AnySqliteView,
   SqliteBuilderTable,
   SqliteExtraConfigColumns,
   SqliteExtraConfigEntry,

--- a/packages/drizzle-orm-sqlite-core/src/index.ts
+++ b/packages/drizzle-orm-sqlite-core/src/index.ts
@@ -25,7 +25,6 @@ export type {
   PrimaryKeyEntry,
   AnySqliteTable,
   AnySqliteView,
-  SqliteBuilderTable,
   SqliteExtraConfigColumns,
   SqliteExtraConfigEntry,
   SqliteExtraConfigFn,

--- a/packages/drizzle-orm-sqlite-core/src/table.ts
+++ b/packages/drizzle-orm-sqlite-core/src/table.ts
@@ -26,31 +26,24 @@ import {getRunType} from '@ts-runtypes/core';
 import {sqliteColumnHelpers, type SQLiteColumnHelpers} from './columns.ts';
 import type {} from './helpers.ts';
 
-/** Pure-type twin of `sqliteTable(name, columns, extraConfig?)`: a table
- *  declared entirely as a type, from the column types (Integer, Text, ...),
- *  modifier markers (NotNull, PrimaryKey, ...) and, for the extraConfig road,
- *  a tuple of table entries (IndexEntry, CheckEntry, ... or the raw TableEntry
- *  carrier). Normalizes to the same RtTable shape the builders produce, so
- *  models and refinement work unchanged; materialize with tableFromType. */
-export type SqliteTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = SqliteBuilderTable<
-  TName,
-  TypedCols<Cols>,
-  Extras
->;
-
-/** A sqlite table whose columns are ALREADY normalized: what sqliteTable() returns,
- *  and what SqliteTable resolves to once it has normalized an authored columns
- *  record. Its own type alias rather than an extra type parameter on
- *  SqliteTable, because a parameter the factories fill with the same Cols they
- *  pass in slot two makes declaration emit print the whole columns record TWICE
- *  in every consumer's .d.ts (measured: it nearly doubles the emitted table type). */
-export interface SqliteBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
-  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'sqlite'> {}
+/** A sqlite table: the metadata and nothing wrapped around it.
+ *
+ *  ONE type for both roads. `sqliteTable('users', {...})` returns it with columns
+ *  the builders already branded, and `SqliteTable<'users', {id: Int<'id'>}>`
+ *  declares the same thing from the column TYPES; TypedCols passes an
+ *  already-branded record straight through, so the two land on one type.
+ *
+ *  It used to be two (SqliteTable normalizing, SqliteBuilderTable pre-normalized)
+ *  to save the builder road a TypedCols pass. That is worth about 5
+ *  instantiations a table and it is not worth two shapes: every table in the
+ *  codebase reads the same way, and nothing has to know which road declared it. */
+export interface SqliteTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, TypedCols<Cols>, Extras>, RtTableBrand<'sqlite'> {}
 
 /** Any sqlite table, whatever its name and columns. What this package's toDrizzle
  *  and tableFromType take, so another dialect's table is a compile error rather
  *  than a missing-function crash at materialization. */
-export type AnySqliteTable = SqliteBuilderTable<string, Record<string, AnyRtColumn>, readonly object[]>;
+export type AnySqliteTable = SqliteTable<string, Record<string, AnyRtColumn>, readonly object[]>;
 /** Any sqlite view, the twin of AnySqliteTable. */
 export type AnySqliteView = import('./views.ts').SqliteSlimView<string, Record<string, AnyRtColumn>>;
 
@@ -162,12 +155,12 @@ export function sqliteTable<TName extends string, Cols extends Record<string, An
   name: TName,
   columns: Cols,
   extraConfig?: SqliteExtraConfigFn<Cols>
-): SqliteBuilderTable<TName, Cols>;
+): SqliteTable<TName, Cols>;
 export function sqliteTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
   name: TName,
   columns: (helpers: SQLiteColumnHelpers) => Cols,
   extraConfig?: SqliteExtraConfigFn<Cols>
-): SqliteBuilderTable<TName, Cols>;
+): SqliteTable<TName, Cols>;
 export function sqliteTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
   return createRtTable(name, resolveColumns(columns), extraConfig as never, sqliteBuildTable);
 }
@@ -179,12 +172,12 @@ export function sqliteTableCreator(customizeTableName: (name: string) => string)
     name: TName,
     columns: Cols,
     extraConfig?: SqliteExtraConfigFn<Cols>
-  ): SqliteBuilderTable<TName, Cols>;
+  ): SqliteTable<TName, Cols>;
   function createTable<TName extends string, Cols extends Record<string, AnyRtColumn>>(
     name: TName,
     columns: (helpers: SQLiteColumnHelpers) => Cols,
     extraConfig?: SqliteExtraConfigFn<Cols>
-  ): SqliteBuilderTable<TName, Cols>;
+  ): SqliteTable<TName, Cols>;
   function createTable(name: string, columns: ColumnsArg<Record<string, unknown>>, extraConfig?: unknown) {
     return createRtTable(name, resolveColumns(columns), extraConfig as never, (context, tableName, builders, extraReplay) => {
       const drizzleCreator = creator.toDrizzleValue(context) as (...a: unknown[]) => unknown;

--- a/packages/drizzle-orm-sqlite-core/src/table.ts
+++ b/packages/drizzle-orm-sqlite-core/src/table.ts
@@ -11,16 +11,16 @@
 
 import type {
   AnyRtColumn,
-  AnyRtTable,
   DrizzleContext,
   ReflectedNode,
   RtExtraColumn,
-  RtTableMetaWithExtras,
+  RtTableBrand,
+  RtTableMeta,
   TableFromTypeOptions,
   TypedCols,
 } from '@mionjs/drizzle-orm';
 import type {EntryColRefs, TableEntry} from '@mionjs/drizzle-orm';
-import {buildRtTableFromGraph, createRtTable, RtValueRecorder, rtTableKey} from '@mionjs/drizzle-orm';
+import {buildRtTableFromGraph, createRtTable, RtValueRecorder} from '@mionjs/drizzle-orm';
 import type {InjectRunTypeId} from '@ts-runtypes/core';
 import {getRunType} from '@ts-runtypes/core';
 import {sqliteColumnHelpers, type SQLiteColumnHelpers} from './columns.ts';
@@ -44,9 +44,15 @@ export type SqliteTable<TName extends string, Cols extends object, Extras extend
  *  SqliteTable, because a parameter the factories fill with the same Cols they
  *  pass in slot two makes declaration emit print the whole columns record TWICE
  *  in every consumer's .d.ts (measured: it nearly doubles the emitted table type). */
-export type SqliteBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
-  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
-};
+export interface SqliteBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'sqlite'> {}
+
+/** Any sqlite table, whatever its name and columns. What this package's toDrizzle
+ *  and tableFromType take, so another dialect's table is a compile error rather
+ *  than a missing-function crash at materialization. */
+export type AnySqliteTable = SqliteBuilderTable<string, Record<string, AnyRtColumn>, readonly object[]>;
+/** Any sqlite view, the twin of AnySqliteTable. */
+export type AnySqliteView = import('./views.ts').SqliteSlimView<string, Record<string, AnyRtColumn>>;
 
 // The friendly per-helper entry aliases: each expands to the TableEntry
 // carrier the runtime bridge and the convert program read mechanically.
@@ -98,12 +104,12 @@ const fromTypeTables = new Map<string, object>();
  *  fresh one, the way a builder call does: two tables of the same type can
  *  carry different callbacks or different referenced tables, and sharing would
  *  silently hand the second one the first one's. */
-export function tableFromType<T extends AnyRtTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
+export function tableFromType<T extends AnySqliteTable>(options?: TableFromTypeOptions<T>, id?: InjectRunTypeId<T>): T {
   const runType = getRunType<T>(undefined, id);
-  if (options !== undefined) return buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable, options) as T;
+  if (options !== undefined) return buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable, options, 'sqlite') as T;
   let slimTable = fromTypeTables.get(runType.id);
   if (slimTable === undefined) {
-    slimTable = buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable);
+    slimTable = buildRtTableFromGraph(runType as ReflectedNode, sqliteBuildTable, undefined, 'sqlite');
     fromTypeTables.set(runType.id, slimTable);
   }
   return slimTable as T;

--- a/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
+++ b/packages/drizzle-orm-sqlite-core/src/typeTables.spec.ts
@@ -15,8 +15,9 @@
 import {describe, it, expect} from 'vitest';
 import {getTableConfig} from 'drizzle-orm/sqlite-core';
 import {getRunTypeId} from '@ts-runtypes/core';
-import type {InferInsertModel, InferSelectModel} from '@mionjs/drizzle-orm';
-import type {Blob, Integer, Real, SqliteTable, Text} from './index.ts';
+import type {InferInsertModel, InferSelectModel, RtTableMeta} from '@mionjs/drizzle-orm';
+import {rtTableBrand} from '@mionjs/drizzle-orm';
+import type {AnySqliteTable, Blob, Integer, Real, SqliteTable, Text} from './index.ts';
 import {blob, integer, real, sqliteTable, tableFromType, text} from './index.ts';
 import {toDrizzle} from './drizzle.ts';
 
@@ -194,5 +195,35 @@ describe('sqlite type-defined tables — blob columns', () => {
   it('getRunTypeId reflection form: the same Buffer-typed model lands on the static form id', () => {
     const row: BlobSelect = {id: 1, payload: Buffer.from('hi'), meta: null} as BlobSelect;
     expect(getRunTypeId(row)).toBe(getRunTypeId<BlobSelect>());
+  });
+});
+
+// A table carries the dialect that recorded it, inside its own metadata. That
+// is what makes reaching the wrong package's toDrizzle a COMPILE error, where
+// it used to typecheck and then die at materialization: every table replays its
+// own captured buildTable closure against whichever context it is handed.
+//
+// The foreign table is spelled here rather than imported, because a dialect
+// package must not depend on its siblings. What this package owes the pin is
+// the other half: that its OWN builders and table types carry its tag.
+describe('sqlite tables are typed to the sqlite package', () => {
+  it('tags what sqliteTable() and SqliteTable<> produce as sqlite', () => {
+    const table = sqliteTable('tagged', {id: integer('id').primaryKey()});
+    const accepted: AnySqliteTable = table;
+    type FromType = SqliteTable<'tagged', {id: Integer<'id', {primaryKey: true}>}>;
+    const acceptedType: AnySqliteTable = {} as FromType;
+    expect(accepted).toBe(table);
+    expect(acceptedType).toBeDefined();
+  });
+
+  it('rejects another dialect table, as a value and as a type argument', () => {
+    interface ForeignLike extends RtTableMeta<'users', {id: Integer<'id'>}, []> {
+      readonly [rtTableBrand]?: 'pg';
+    }
+    // @ts-expect-error a pg-tagged table is not a sqlite table
+    const rejected: AnySqliteTable = {} as ForeignLike;
+    // @ts-expect-error and it cannot be rebuilt through this package's bridge
+    void tableFromType<ForeignLike>;
+    expect(rejected).toBeDefined();
   });
 });

--- a/packages/drizzle-orm-sqlite-core/src/views.ts
+++ b/packages/drizzle-orm-sqlite-core/src/views.ts
@@ -15,9 +15,12 @@
 // but not supported: its columns come from drizzle's select typing, the exact
 // generic chain the slim design removes (packages/drizzle-orm/CLAUDE.md).
 
-import type {AnyRtColumn, DrizzleContext, RtSql, RtView} from '@mionjs/drizzle-orm';
+import type {AnyRtColumn, DrizzleContext, RtSql, RtViewBrand, RtViewMeta} from '@mionjs/drizzle-orm';
 import {RtViewBuilder} from '@mionjs/drizzle-orm';
 
+/** A sqlite slim view: the view metadata, tagged with the dialect that
+ *  recorded it, so it cannot reach another dialect's toDrizzle. */
+export interface SqliteSlimView<TName extends string, Cols> extends RtViewMeta<TName, Cols>, RtViewBrand<'sqlite'> {}
 /** The stand-in a columnless `sqliteView(name)` returns: it has no `as`, so the
  *  query-builder form fails at the call that would use it, naming itself. */
 export interface ViewFromQueryBuilderNotSupported {
@@ -26,9 +29,9 @@ export interface ViewFromQueryBuilderNotSupported {
 
 export interface SQLiteViewBuilder<TName extends string, Cols extends Record<string, AnyRtColumn>> {
   /** The view's query, as literal sql. */
-  as(query: RtSql): RtView<TName, Cols>;
+  as(query: RtSql): SqliteSlimView<TName, Cols>;
   /** The view already exists: drizzle-kit emits no CREATE VIEW for it. */
-  existing(): RtView<TName, Cols>;
+  existing(): SqliteSlimView<TName, Cols>;
 }
 
 /** The sqlite buildView closure. */

--- a/packages/drizzle-orm/TYPE-COST.md
+++ b/packages/drizzle-orm/TYPE-COST.md
@@ -264,13 +264,28 @@ costs, and only the third spelling is free:
 `RtTableBrand<'pg'>` is a one-member interface the dialect's table interface extends. The
 checker instantiates nothing per table; a type parameter it must instantiate is the cost.
 
-### Also measured, and rejected
+### Measured at a cost, taken anyway: one table type per dialect
 
-**Collapsing `PgTable` into `PgBuilderTable`**, three times over. The pair looks redundant
-once there is one column position left, and the old comment justifying the split is about a
-declaration-emit problem the new shape removes. Measured anyway: **+5 per type-road table**,
-because the builder road then pays `TypedCols<AlreadyNormalized>` it used to skip. The split
-stays, and so does its comment.
+`PgTable` and `PgBuilderTable` were two shapes for the same table, split so the builder road
+could skip a `TypedCols` pass. They are now one interface per dialect. Measured before and
+after: the builder road pays about **+2 a table** (+10 on the twenty-column case, where the
+pass-through runs over twenty members), and the type road got slightly cheaper for losing an
+alias hop.
+
+Recorded here because it is the section's real lesson. Every other entry on this page is
+decided by its number; this one is not. Two shapes for the same table means every reader,
+every helper and every future contributor has to know which road declared it, and that is a
+worse thing to carry than two instantiations. **The budget is a guard against blowups, not
+the design.**
+
+### What the new shape let us delete
+
+Both graph walkers, `membersOf` in `fromType.ts` and `properties` in
+`internal/convert/drizzle.go`, flattened intersection arms because a table used to be
+`Cols & {meta}`. Neither is reachable now: probed by making each branch throw, 243 unit
+tests, a wide `drizzletypes` fuzz and all 228 tables of drizzle's own suites pass without
+hitting either. Gone, with `reflectedKinds.intersection`, `RtTable`, `RtView` and the three
+`*BuilderTable` aliases.
 
 ### The one thing to know before reading a table type
 

--- a/packages/drizzle-orm/TYPE-COST.md
+++ b/packages/drizzle-orm/TYPE-COST.md
@@ -266,22 +266,85 @@ wrapper per column (about 2 nodes each). Pruning it would mean the resolver emit
 graph that no longer describes the type it was asked about, for 7% of a build artifact.
 Not worth the special case.
 
+### Both variants prototyped against the real packages
+
+The two ways to drop the arm are NOT equivalent, and the difference only shows once they
+are built. Both were prototyped on the real four packages and measured through the whole
+model pipeline, table to `initClient` to a live `toDrizzle` query.
+
+**Bare meta**, `PgBuilderTable<N, C, E> = RtTableMetaWithExtras<N, C, E>`, the table type
+being the meta itself. It kills the type road outright: 13 of `typeTables.spec.ts`'s 20
+cases fail with "the reflected type is not a table". `buildRtTableFromGraph` finds a table
+in the reflected graph by its `@rtTableKey` member (`fromType.ts`), and the Go convert and
+migrate program recognises a table declaration the same way
+(`typeHasSentinel(declared, sentinelTable)`, `internal/convert/drizzle.go`). A bare meta
+carries no sentinel, so neither can tell a table from any other object. It also makes
+`AnyRtTable` structural (`{name, columns}`), which is `RtViewMeta`'s shape too, so the
+`toDrizzle` overload set can no longer keep tables and views apart.
+
+**Meta only**, keeping the symbol key and dropping just the `Cols &` arm. This one works:
+234 of 234 drizzle tests pass (the runtime object is untouched, only the type stops naming
+the columns), and it beats bare meta on cost as well.
+
+| Pipeline step       | today | meta only | bare meta |
+| ------------------- | ----: | --------: | --------: |
+| 1 slim table + row  |   433 |       428 |       432 |
+| 2 refineTableType   |  1141 |      1130 |      1107 |
+| 3 `Infer*` models   |   578 |       578 |       573 |
+| 4 mion route api    |   533 |       533 |       533 |
+| 5 `initClient`      |  2540 |      2540 |      2540 |
+| 6 db query          |  7852 |      7782 |      7842 |
+| **whole chain**     | 13077 | **12991** |     13027 |
+| downstream consumer |  1513 |      1499 |      1491 |
+
+So the honest whole-app figure for the better of the two is **86 instantiations out of
+13 077, 0.66%**, plus the 7% off the generated cache module. Nothing downstream of the
+models moves: the route api, the client and five sixths of the db query step are drizzle's
+own generics and mion's, and they never see the table's shape.
+
+### What implementing the meta-only variant costs
+
+The type errors it produces are all one thing, `table.column` on a slim table, and they
+have a mechanical fix: a `cols()` accessor, identity at runtime because the slim table
+object really does carry the columns as properties.
+
+```ts
+export function cols<T extends AnyRtTable>(table: T): ColsOf<T> {
+  return table as unknown as ColsOf<T>;
+}
+// references(() => teams.id)  ->  references(() => cols(teams).id)
+```
+
+Prototyped end to end: the four table aliases, the accessor, and 16 rewritten call sites
+took the workspace back to zero type errors with all 234 tests still green. What that
+number hides is where the same pattern lives outside this repo:
+
+- `ts-runtypes convert --to builders` EMITS `references(() => parents.id)` verbatim
+  (asserted in `internal/convert/drizzle_test.go`), so the converter and its golden
+  fixtures have to learn the new spelling, and every schema the drizzle-e2e lane migrates
+  from drizzle's own suites goes through it.
+- The published examples and `03.drizzle-orm/03.indexes-constraints.md` teach the drizzle
+  spelling.
+- Every consumer who already wrote a foreign key has the same edit to make.
+
 ### Why it stays
 
-The `Cols &` arm is what makes `table.column` a property, and that is drizzle's own API,
-not an extra: `references(() => teams.id)` and
+That last point is the whole argument, and it is not about instantiations.
+`references(() => teams.id)` and
 `foreignKey({columns: [t.teamId], foreignColumns: [teams.id]})` are how a drizzle schema
-is written, they appear in the dialect suites and in the published examples, and they
-resolve through that arm. `ColsOf<T>` and the `Infer*Model` family are already the
-accessors that recover the columns from the meta, so no new `InferCols`-style helper is
-missing; the arm is not standing in for one.
+is written, and "drizzle-identical call shapes" is what these packages sell.
+`references(() => cols(teams).id)` is not that. Nor is anything missing today that the
+change would add: `ColsOf<T>` and the `Infer*Model` family already recover the columns
+from the meta, so there is no absent `InferCols` the arm is standing in for.
 
 It would also split the two roads. `PgTable<Name, Cols>` resolves to the SAME
 `PgBuilderTable` the builders return, which is what lets the models, `refineTableType` and
-`toDrizzle` take one code path for both; a meta-only type road would need its own.
+`toDrizzle` take one code path for both.
 
-So: 3 instantiations and 7% of one build artifact, against deleting drizzle-identical
-property access and giving the two roads two different table shapes. Keep the shape.
+So: 0.66% of the whole chain and 7% of one build artifact, against a breaking change to
+the API the packages exist to mirror. Keep the shape. If the trade is ever reconsidered,
+reconsider the meta-only variant and not the bare meta one, and start from the prototype
+recipe above.
 
 ### A new dialect changes none of this
 

--- a/packages/drizzle-orm/TYPE-COST.md
+++ b/packages/drizzle-orm/TYPE-COST.md
@@ -194,32 +194,109 @@ One step still rises by 2 (step 6, where drizzle's own generics consume the synt
 column config). It is the only reviewed budget increase in that suite, recorded where the
 budget lives.
 
+## Rejected: dropping the columns from one of the two places they appear
+
+A slim table names its columns twice, and it keeps reading like waste, so this section
+answers it with all four axes measured rather than one:
+
+```ts
+export type PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
+  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
+  //                                                  ^^^^ the same Cols again
+};
+```
+
+The two positions are not two copies. `Cols` is instantiated once and both positions
+reference that one type, so the second mention is a reference, not work. What follows
+prices the second mention on every axis a consumer can feel.
+
+### The four shapes, one identical select model over each
+
+The shape is the ONLY thing that varies below: each row runs the same three-line select
+model over whatever its `ColsOf` returns, so the model machinery cancels out. The
+`InferSelectModel` anchor row is the real thing, for scale.
+
+| Table shape                                          | 5 mixed | 20 plain |
+| ---------------------------------------------------- | ------: | -------: |
+| real `InferSelectModel` over `PgTable` (anchor)      |     966 |     1339 |
+| `Cols & {[key]: {name, columns, extras}}` (today)    |     925 |     1298 |
+| `{[key]: {name, columns, extras}}` (no `Cols &`)     |     922 |     1295 |
+| `{name, columns, extras}` (the meta AS the table)    |     920 |     1293 |
+| `Cols & {[key]: {name, extras}}` (no meta `columns`) |    1021 |     1634 |
+
+Deleting the `Cols &` arm is worth a FLAT 3 instantiations, on a five-column table and a
+twenty-column one alike. That is the whole prize, and it does not grow with the schema.
+
+Deleting the meta's `columns` instead is the expensive direction, and it gets worse as
+the table widens (+26% at twenty columns): `ColsOf` stops being an indexed access and
+becomes a mapped pass that has to strip the symbol key off every member.
+
+### Nothing prints it twice either
+
+The `Cols &` arm was suspected of doubling what a consumer reads. It does not. TypeScript
+keeps the alias in all three surfaces, so the columns record appears once wherever a
+developer or a build sees it:
+
+| Surface         | What a 3-column type-road table shows                         |
+| --------------- | ------------------------------------------------------------- |
+| hover           | `const t: PgTable<"users", Cols>` (36 chars)                  |
+| error text      | `Type 'PgTable<"users", Cols>' is not assignable to 'string'` |
+| emitted `.d.ts` | the alias with its type arguments, columns printed once       |
+
+`declarationEmit.test.ts` already pins the emit half of that.
+
+### Where the duplication IS real: the reflected graph
+
+The one axis that does cost something is reflection, and it is the axis none of the type
+budgets watch. `tableFromType<T>()` reflects the WHOLE table type, and
+`buildRtTableFromGraph` then reads `graph[@rtTableKey].columns` and nothing else. The
+top-level arm is reflected and never read.
+
+Measured through the real resolver, one type-road table per fixture:
+
+| Columns | cache module, today | cache module, no `Cols &` arm |     |
+| ------: | ------------------: | ----------------------------: | --- |
+|       3 |               4 967 |                         4 547 | -8% |
+|      10 |              13 565 |                        12 548 | -7% |
+|      20 |              25 856 |                        23 987 | -7% |
+
+Even here it is 7%, not the doubling the source reads like: the resolver already shares
+the column subtrees between the two positions, and what duplicates is one property-member
+wrapper per column (about 2 nodes each). Pruning it would mean the resolver emitting a
+graph that no longer describes the type it was asked about, for 7% of a build artifact.
+Not worth the special case.
+
+### Why it stays
+
+The `Cols &` arm is what makes `table.column` a property, and that is drizzle's own API,
+not an extra: `references(() => teams.id)` and
+`foreignKey({columns: [t.teamId], foreignColumns: [teams.id]})` are how a drizzle schema
+is written, they appear in the dialect suites and in the published examples, and they
+resolve through that arm. `ColsOf<T>` and the `Infer*Model` family are already the
+accessors that recover the columns from the meta, so no new `InferCols`-style helper is
+missing; the arm is not standing in for one.
+
+It would also split the two roads. `PgTable<Name, Cols>` resolves to the SAME
+`PgBuilderTable` the builders return, which is what lets the models, `refineTableType` and
+`toDrizzle` take one code path for both; a meta-only type road would need its own.
+
+So: 3 instantiations and 7% of one build artifact, against deleting drizzle-identical
+property access and giving the two roads two different table shapes. Keep the shape.
+
+### A new dialect changes none of this
+
+A fourth dialect (D1) should copy the pg/mysql/sqlite alias pair verbatim rather than
+factoring the three into a shared base. A shared base with the dialect's own extras
+intersected on top costs +4 per table over spelling the extra member inside the same
+object as the meta key, which is what the packages already do and what the comment on
+`PgBuilderTable` records.
+
 ## Rejected: moving the column metadata into a flat "params bag"
 
 The idea: a column type stops carrying its metadata in generic positions
 (`RtPgColumn<Data, NotNull, HasDefault, InsertExcluded>`) and carries it as props on one
 object instead, the way a runtypes `TypeFormat` does. Four shapes were measured. All four
 lost.
-
-### It is not the `[rtTableKey]` duplication
-
-Hovering a slim table shows its columns once in the intersection and again inside the
-meta, which reads like wasted work. It is not: TypeScript instantiates the columns once
-and both positions reference the same type.
-
-| Meta shape                                         | Net |
-| -------------------------------------------------- | --: |
-| `Cols & {[key]: Meta<Name, Cols, Extras>}` (today) | 219 |
-| `Cols & {[key]: Meta<Name, Extras>}` (no columns)  | 219 |
-
-Writing the mapped type out twice by hand, with no shared alias, costs **+1**. And
-dropping `columns` from the meta makes things worse, because `ColsOf` stops being an
-indexed access:
-
-```ts
-type ColsOf<T> = T[typeof rtTableKey]['columns']; // 224
-type ColsOf<T> = Omit<T, typeof rtTableKey>; // 264
-```
 
 ### Flattening the columns to bags, measured against the real packages
 

--- a/packages/drizzle-orm/TYPE-COST.md
+++ b/packages/drizzle-orm/TYPE-COST.md
@@ -196,6 +196,9 @@ budget lives.
 
 ## Rejected: dropping the columns from one of the two places they appear
 
+Every figure in this section was re-taken after the closed-data-set and lib-scoped-id
+changes landed, and none of them moved.
+
 A slim table names its columns twice, and it keeps reading like waste, so this section
 answers it with all four axes measured rather than one:
 
@@ -346,10 +349,16 @@ the API the packages exist to mirror. Keep the shape. If the trade is ever recon
 reconsider the meta-only variant and not the bare meta one, and start from the prototype
 recipe above.
 
-### A new dialect changes none of this
+### D1 turned out not to be a dialect
 
-A fourth dialect (D1) should copy the pg/mysql/sqlite alias pair verbatim rather than
-factoring the three into a shared base. A shared base with the dialect's own extras
+This section first said "a fourth dialect (D1) should copy the alias pair verbatim". There
+is no fourth dialect. D1 and durable-sqlite are DRIVERS: neither exports a column builder,
+and tables for both are declared with sqlite-core, which is what the sqlite package's
+`type-pins.stub.ts` pins. So there is no fourth copy of the alias, and nothing above
+changes.
+
+The advice still holds for a real new dialect: copy the pg/mysql/sqlite alias pair rather
+than factoring the three into a shared base. A shared base with the dialect's own extras
 intersected on top costs +4 per table over spelling the extra member inside the same
 object as the meta key, which is what the packages already do and what the comment on
 `PgBuilderTable` records.

--- a/packages/drizzle-orm/TYPE-COST.md
+++ b/packages/drizzle-orm/TYPE-COST.md
@@ -194,174 +194,102 @@ One step still rises by 2 (step 6, where drizzle's own generics consume the synt
 column config). It is the only reviewed budget increase in that suite, recorded where the
 budget lives.
 
-## Rejected: dropping the columns from one of the two places they appear
+## SHIPPED: the table type IS its metadata
 
-Every figure in this section was re-taken after the closed-data-set and lib-scoped-id
-changes landed, and none of them moved.
+Read the whole section before quoting any number in it. This one was measured, argued
+against, re-argued, and shipped anyway for a reason none of the measurements could see.
 
-A slim table names its columns twice, and it keeps reading like waste, so this section
-answers it with all four axes measured rather than one:
-
-```ts
-export type PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
-  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
-  //                                                  ^^^^ the same Cols again
-};
-```
-
-The two positions are not two copies. `Cols` is instantiated once and both positions
-reference that one type, so the second mention is a reference, not work. What follows
-prices the second mention on every axis a consumer can feel.
-
-### The four shapes, one identical select model over each
-
-The shape is the ONLY thing that varies below: each row runs the same three-line select
-model over whatever its `ColsOf` returns, so the model machinery cancels out. The
-`InferSelectModel` anchor row is the real thing, for scale.
-
-| Table shape                                          | 5 mixed | 20 plain |
-| ---------------------------------------------------- | ------: | -------: |
-| real `InferSelectModel` over `PgTable` (anchor)      |     966 |     1339 |
-| `Cols & {[key]: {name, columns, extras}}` (today)    |     925 |     1298 |
-| `{[key]: {name, columns, extras}}` (no `Cols &`)     |     922 |     1295 |
-| `{name, columns, extras}` (the meta AS the table)    |     920 |     1293 |
-| `Cols & {[key]: {name, extras}}` (no meta `columns`) |    1021 |     1634 |
-
-Deleting the `Cols &` arm is worth a FLAT 3 instantiations, on a five-column table and a
-twenty-column one alike. That is the whole prize, and it does not grow with the schema.
-
-Deleting the meta's `columns` instead is the expensive direction, and it gets worse as
-the table widens (+26% at twenty columns): `ColsOf` stops being an indexed access and
-becomes a mapped pass that has to strip the symbol key off every member.
-
-### Nothing prints it twice either
-
-The `Cols &` arm was suspected of doubling what a consumer reads. It does not. TypeScript
-keeps the alias in all three surfaces, so the columns record appears once wherever a
-developer or a build sees it:
-
-| Surface         | What a 3-column type-road table shows                         |
-| --------------- | ------------------------------------------------------------- |
-| hover           | `const t: PgTable<"users", Cols>` (36 chars)                  |
-| error text      | `Type 'PgTable<"users", Cols>' is not assignable to 'string'` |
-| emitted `.d.ts` | the alias with its type arguments, columns printed once       |
-
-`declarationEmit.test.ts` already pins the emit half of that.
-
-### Where the duplication IS real: the reflected graph
-
-The one axis that does cost something is reflection, and it is the axis none of the type
-budgets watch. `tableFromType<T>()` reflects the WHOLE table type, and
-`buildRtTableFromGraph` then reads `graph[@rtTableKey].columns` and nothing else. The
-top-level arm is reflected and never read.
-
-Measured through the real resolver, one type-road table per fixture:
-
-| Columns | cache module, today | cache module, no `Cols &` arm |     |
-| ------: | ------------------: | ----------------------------: | --- |
-|       3 |               4 967 |                         4 547 | -8% |
-|      10 |              13 565 |                        12 548 | -7% |
-|      20 |              25 856 |                        23 987 | -7% |
-
-Even here it is 7%, not the doubling the source reads like: the resolver already shares
-the column subtrees between the two positions, and what duplicates is one property-member
-wrapper per column (about 2 nodes each). Pruning it would mean the resolver emitting a
-graph that no longer describes the type it was asked about, for 7% of a build artifact.
-Not worth the special case.
-
-### Both variants prototyped against the real packages
-
-The two ways to drop the arm are NOT equivalent, and the difference only shows once they
-are built. Both were prototyped on the real four packages and measured through the whole
-model pipeline, table to `initClient` to a live `toDrizzle` query.
-
-**Bare meta**, `PgBuilderTable<N, C, E> = RtTableMetaWithExtras<N, C, E>`, the table type
-being the meta itself. It kills the type road outright: 13 of `typeTables.spec.ts`'s 20
-cases fail with "the reflected type is not a table". `buildRtTableFromGraph` finds a table
-in the reflected graph by its `@rtTableKey` member (`fromType.ts`), and the Go convert and
-migrate program recognises a table declaration the same way
-(`typeHasSentinel(declared, sentinelTable)`, `internal/convert/drizzle.go`). A bare meta
-carries no sentinel, so neither can tell a table from any other object. It also makes
-`AnyRtTable` structural (`{name, columns}`), which is `RtViewMeta`'s shape too, so the
-`toDrizzle` overload set can no longer keep tables and views apart.
-
-**Meta only**, keeping the symbol key and dropping just the `Cols &` arm. This one works:
-234 of 234 drizzle tests pass (the runtime object is untouched, only the type stops naming
-the columns), and it beats bare meta on cost as well.
-
-| Pipeline step       | today | meta only | bare meta |
-| ------------------- | ----: | --------: | --------: |
-| 1 slim table + row  |   433 |       428 |       432 |
-| 2 refineTableType   |  1141 |      1130 |      1107 |
-| 3 `Infer*` models   |   578 |       578 |       573 |
-| 4 mion route api    |   533 |       533 |       533 |
-| 5 `initClient`      |  2540 |      2540 |      2540 |
-| 6 db query          |  7852 |      7782 |      7842 |
-| **whole chain**     | 13077 | **12991** |     13027 |
-| downstream consumer |  1513 |      1499 |      1491 |
-
-So the honest whole-app figure for the better of the two is **86 instantiations out of
-13 077, 0.66%**, plus the 7% off the generated cache module. Nothing downstream of the
-models moves: the route api, the client and five sixths of the db query step are drizzle's
-own generics and mion's, and they never see the table's shape.
-
-### What implementing the meta-only variant costs
-
-The type errors it produces are all one thing, `table.column` on a slim table, and they
-have a mechanical fix: a `cols()` accessor, identity at runtime because the slim table
-object really does carry the columns as properties.
+A slim table used to be `Cols & {[rtTableKey]: RtTableMetaWithExtras<Name, Cols, Extras>}`:
+the columns named twice, and the half every reader uses wrapped in a symbol whose only job
+was to say a table lived below. It is now the metadata itself, branded from inside:
 
 ```ts
-export function cols<T extends AnyRtTable>(table: T): ColsOf<T> {
-  return table as unknown as ColsOf<T>;
+export interface PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
+  extends RtTableMeta<TName, Cols, Extras>, RtTableBrand<'pg'> {
+  enableRLS(): PgTableWithRLS<TName, Cols, Extras>;
 }
-// references(() => teams.id)  ->  references(() => cols(teams).id)
 ```
 
-Prototyped end to end: the four table aliases, the accessor, and 16 rewritten call sites
-took the workspace back to zero type errors with all 234 tests still green. What that
-number hides is where the same pattern lives outside this repo:
+### The measurements said no, and the change was right anyway
 
-- `ts-runtypes convert --to builders` EMITS `references(() => parents.id)` verbatim
-  (asserted in `internal/convert/drizzle_test.go`), so the converter and its golden
-  fixtures have to learn the new spelling, and every schema the drizzle-e2e lane migrates
-  from drizzle's own suites goes through it.
-- The published examples and `03.drizzle-orm/03.indexes-constraints.md` teach the drizzle
-  spelling.
-- Every consumer who already wrote a foreign key has the same edit to make.
+Four shapes, the same three-line select model over each so only the shape varies:
 
-### Why it stays
+| Table shape                                         | 5 mixed | 20 plain |
+| --------------------------------------------------- | ------: | -------: |
+| `Cols & {[key]: {name, columns, extras}}` (the old) |     925 |     1298 |
+| `{[key]: {name, columns, extras}}`                  |     922 |     1295 |
+| `{name, columns, extras}` (what shipped)            |     920 |     1293 |
+| `Cols & {[key]: {name, extras}}`                    |    1021 |     1634 |
 
-That last point is the whole argument, and it is not about instantiations.
-`references(() => teams.id)` and
-`foreignKey({columns: [t.teamId], foreignColumns: [teams.id]})` are how a drizzle schema
-is written, and "drizzle-identical call shapes" is what these packages sell.
-`references(() => cols(teams).id)` is not that. Nor is anything missing today that the
-change would add: `ColsOf<T>` and the `Infer*Model` family already recover the columns
-from the meta, so there is no absent `InferCols` the arm is standing in for.
+Read as a saving that is worth three instantiations, and it is. Measured against the REAL
+`InferSelectModel` on the real packages, the shipped shape is 1 to 2 **more** expensive per
+table, not less, and four type-road budgets were raised to match. The three-line model in
+the table above is not what a consumer runs.
 
-It would also split the two roads. `PgTable<Name, Cols>` resolves to the SAME
-`PgBuilderTable` the builders return, which is what lets the models, `refineTableType` and
-`toDrizzle` take one code path for both.
+So the type cost is a wash, and the reason to have done it is not on this page: the shape
+is right, the scaffolding it deletes is real (an intersection arm in five aliases, a symbol
+indirection in twelve places, one of two near-identical meta interfaces), and the brand it
+introduces turns a runtime crash into a compile error. See below.
 
-So: 0.66% of the whole chain and 7% of one build artifact, against a breaking change to
-the API the packages exist to mirror. Keep the shape. If the trade is ever reconsidered,
-reconsider the meta-only variant and not the bare meta one, and start from the prototype
-recipe above.
+### The reflected graph is where it actually pays
+
+`tableFromType<T>()` reflects the whole table type; `buildRtTableFromGraph` reads
+`name`/`columns`/`extras` and nothing else. Under the old shape the top-level arm was
+reflected and never read:
+
+| Columns | cache module, old | cache module, shipped |     |
+| ------: | ----------------: | --------------------: | --- |
+|       3 |             4 967 |                 4 547 | -8% |
+|      10 |            13 565 |                12 548 | -7% |
+|      20 |            25 856 |                23 987 | -7% |
+
+Not the doubling the old source read like: the resolver already shared the column subtrees,
+and what duplicated was one property-member wrapper per column.
+
+### The brand cost three attempts to make free
+
+A bare meta carries no sentinel, so nothing can tell a table from any other object: the
+first prototype failed 13 of `typeTables.spec.ts`'s 20 cases with "the reflected type is
+not a table". The brand that fixes it also carries the dialect, which is what makes
+`toDrizzle(somePgTable)` from the mysql package a compile error instead of a
+`dzMy.pgTable is not a function` at materialization. How it is spelled decides what it
+costs, and only the third spelling is free:
+
+| Spelling                                                        | Per table |
+| --------------------------------------------------------------- | --------: |
+| `Dialect` threaded as a type parameter on the core meta         |        +4 |
+| declared on the core meta AND narrowed per dialect              |        +9 |
+| a fixed literal on a per-dialect marker interface (**shipped**) |         0 |
+
+`RtTableBrand<'pg'>` is a one-member interface the dialect's table interface extends. The
+checker instantiates nothing per table; a type parameter it must instantiate is the cost.
+
+### Also measured, and rejected
+
+**Collapsing `PgTable` into `PgBuilderTable`**, three times over. The pair looks redundant
+once there is one column position left, and the old comment justifying the split is about a
+declaration-emit problem the new shape removes. Measured anyway: **+5 per type-road table**,
+because the builder road then pays `TypedCols<AlreadyNormalized>` it used to skip. The split
+stays, and so does its comment.
+
+### The one thing to know before reading a table type
+
+`name`, `columns` and `extras` are plain keys on the table type now. On a table with a
+column called `name`, the type-level `table.name` is the table's DB name, not the column;
+`cols(table).name` is the column. Under the old shape the columns were the top-level
+members and this could not happen. `cols()` is identity at run time, because the object
+really does carry the columns as properties, and only the type stopped naming them.
 
 ### D1 turned out not to be a dialect
 
-This section first said "a fourth dialect (D1) should copy the alias pair verbatim". There
-is no fourth dialect. D1 and durable-sqlite are DRIVERS: neither exports a column builder,
-and tables for both are declared with sqlite-core, which is what the sqlite package's
-`type-pins.stub.ts` pins. So there is no fourth copy of the alias, and nothing above
-changes.
+An earlier draft of this section said "a fourth dialect (D1) should copy the alias pair
+verbatim". There is no fourth dialect. D1 and durable-sqlite are DRIVERS: neither exports a
+column builder, and tables for both are declared with sqlite-core, which is what the sqlite
+package's `type-pins.stub.ts` pins.
 
 The advice still holds for a real new dialect: copy the pg/mysql/sqlite alias pair rather
 than factoring the three into a shared base. A shared base with the dialect's own extras
-intersected on top costs +4 per table over spelling the extra member inside the same
-object as the meta key, which is what the packages already do and what the comment on
-`PgBuilderTable` records.
+intersected on top costs +4 per table over spelling the extra member inside the same object.
 
 ## Rejected: moving the column metadata into a flat "params bag"
 

--- a/packages/drizzle-orm/src/fromType.spec.ts
+++ b/packages/drizzle-orm/src/fromType.spec.ts
@@ -48,7 +48,8 @@ function colNode(spec: {fn: string; name?: string; config?: ReflectedNode}, mods
 }
 
 function tableNode(name: string, columns: Record<string, ReflectedNode>): ReflectedNode {
-  return obj({'þ@rtTableKey': obj({name: lit(name), columns: obj(columns)})});
+  // The graph IS the meta: the brand marks it a table, the rest are its members.
+  return obj({'þ@rtTableBrand': lit('pg'), name: lit(name), columns: obj(columns)});
 }
 
 // ── fake replay surface (same pattern as recorder.spec.ts) ───────────────────
@@ -211,5 +212,26 @@ describe('buildRtTableFromGraph', () => {
     const fnTyped: ReflectedNode = {id: id(), kind: 17};
     const graph = tableNode('t', {c: colNode({fn: 'varchar', config: obj({length: fnTyped})})});
     expect(() => buildRtTableFromGraph(graph, makeFake().buildTable)).toThrowError(/not a literal type/);
+  });
+
+  // The brand is what says "table" at all: a bare {name, columns} object is not
+  // one, which is the whole reason the metadata carries a sentinel of its own.
+  it('rejects a graph with no table brand', () => {
+    const graph = obj({name: lit('t'), columns: obj({c: colNode({fn: 'varchar'})})});
+    expect(() => buildRtTableFromGraph(graph, makeFake().buildTable)).toThrowError(/is not a table/);
+  });
+
+  // And the dialect it carries must match the bridge rebuilding it, or the
+  // rebuilt table would replay a pg call through another dialect's namespace.
+  it('rejects a table of another dialect', () => {
+    const graph = tableNode('t', {c: colNode({fn: 'varchar'})});
+    expect(() => buildRtTableFromGraph(graph, makeFake().buildTable, undefined, 'mysql')).toThrowError(
+      /is a pg table, rebuilt through the mysql package/
+    );
+  });
+
+  it('accepts the dialect it was recorded with', () => {
+    const graph = tableNode('t', {c: colNode({fn: 'varchar'})});
+    expect(() => buildRtTableFromGraph(graph, makeFake().buildTable, undefined, 'pg')).not.toThrow();
   });
 });

--- a/packages/drizzle-orm/src/fromType.ts
+++ b/packages/drizzle-orm/src/fromType.ts
@@ -328,16 +328,33 @@ function resolveEntryRefs(
 
 /** Rebuild the slim table from a reflected type-road table graph. The result
  *  is a normal slim table: hand it to materializeRtTable (which is what the
- *  dialect tableFromType wrappers do). */
-export function buildRtTableFromGraph(graph: ReflectedNode, buildTable: BuildTableFn, options?: TableFromTypeOptions): object {
-  const metaMember = memberNamed(graph, '@rtTableKey');
-  if (!metaMember?.child) {
+ *  dialect tableFromType wrappers do).
+ *
+ *  The graph IS the metadata — the table type is the meta, so name, columns and
+ *  extras are the root's own members and the rtTableBrand sentinel is what says
+ *  a table is what was reflected. `expectedDialect` is the dialect of the
+ *  buildTable closure passed in: when both it and the reflected tag are known
+ *  they must agree, or the rebuilt table would replay a pg call through mysql's
+ *  namespace. Dynamic callers holding only a resolved graph may omit it. */
+export function buildRtTableFromGraph(
+  graph: ReflectedNode,
+  buildTable: BuildTableFn,
+  options?: TableFromTypeOptions,
+  expectedDialect?: string
+): object {
+  const brandMember = memberNamed(graph, '@rtTableBrand');
+  if (!brandMember) {
     fail(
       'the reflected type is not a table — declare it with the dialect table type (PgTable<Name, Cols>, ...); ' +
         'on a marker call, did you forget the explicit type argument (tableFromType<UsersTable>(...))?'
     );
   }
-  const meta = metaMember.child;
+  const meta = graph;
+  const brandNode = brandMember.child;
+  const reflectedDialect = brandNode?.kind === KIND_LITERAL ? brandNode.literal : undefined;
+  if (expectedDialect !== undefined && typeof reflectedDialect === 'string' && reflectedDialect !== expectedDialect) {
+    fail(`the reflected type is a ${reflectedDialect} table, rebuilt through the ${expectedDialect} package`);
+  }
   const nameNode = plainMember(meta, 'name')?.child;
   const tableName = nameNode?.kind === KIND_LITERAL ? nameNode.literal : undefined;
   if (typeof tableName !== 'string') fail('the table name is not a string literal');

--- a/packages/drizzle-orm/src/fromType.ts
+++ b/packages/drizzle-orm/src/fromType.ts
@@ -73,22 +73,19 @@ export interface ReflectedNode {
 export const reflectedKinds = {
   undefined: 11,
   literal: 13,
-  intersection: 24,
   tuple: 26,
   objectLiteral: 30,
 } as const;
 const KIND_UNDEFINED = reflectedKinds.undefined;
 const KIND_LITERAL = reflectedKinds.literal;
-const KIND_INTERSECTION = reflectedKinds.intersection;
 const KIND_TUPLE = reflectedKinds.tuple;
 const KIND_OBJECT_LITERAL = reflectedKinds.objectLiteral;
 
-/** A node's property members, flattening intersection arms (a type-road table
- *  meta is `RtTableMeta & {extras}`). */
+/** A node's property members. Flat: a table type is one object now (the meta,
+ *  which each dialect's interface extends), where it used to be `Cols & {meta}`
+ *  and this had to flatten the arms. */
 function membersOf(node: ReflectedNode | undefined): ReflectedNode[] {
-  if (node === undefined) return [];
-  if (node.kind === KIND_INTERSECTION) return (node.children ?? []).flatMap((arm) => membersOf(arm));
-  return node.children ?? [];
+  return node?.children ?? [];
 }
 
 /** Suffix-match a symbol-keyed member (tsgo spells it `þ@<symbolConstName>`). */

--- a/packages/drizzle-orm/src/index.ts
+++ b/packages/drizzle-orm/src/index.ts
@@ -46,19 +46,21 @@ export {
   mapRecordedArgs,
   mapReplayArgs,
   rtColumnKey,
+  rtTableBrand,
   rtTableKey,
   rtValueKey,
+  rtViewBrand,
   rtViewKey,
   sql,
 } from './recorder.ts';
 
 // Table core.
-export type {AnyRtTable, BuildTableFn, ColsOf, RtTable, RtTableMeta, RtTableMetaWithExtras, TableNameOf} from './table.ts';
-export {createRtTable, materializeRtTable} from './table.ts';
+export type {AnyRtTable, BuildTableFn, ColsOf, RtTable, RtTableBrand, RtTableMeta, TableNameOf} from './table.ts';
+export {cols, createRtTable, materializeRtTable} from './table.ts';
 
 // View core: the read-only sibling of the table core. Manual-column views
 // only; the query-builder form stays on drizzle (see ./view.ts and CLAUDE.md).
-export type {AnyRtView, BuildViewFn, RtView, RtViewMeta, ViewColsOf, ViewNameOf} from './view.ts';
+export type {AnyRtView, BuildViewFn, RtView, RtViewBrand, RtViewMeta, ViewColsOf, ViewNameOf} from './view.ts';
 export {isRtView, materializeRtView, RtViewBuilder} from './view.ts';
 
 // Pure-types vocabulary core: the column type the dialect packages alias per

--- a/packages/drizzle-orm/src/index.ts
+++ b/packages/drizzle-orm/src/index.ts
@@ -55,12 +55,12 @@ export {
 } from './recorder.ts';
 
 // Table core.
-export type {AnyRtTable, BuildTableFn, ColsOf, RtTable, RtTableBrand, RtTableMeta, TableNameOf} from './table.ts';
+export type {AnyRtTable, BuildTableFn, ColsOf, RtTableBrand, RtTableMeta, TableNameOf} from './table.ts';
 export {cols, createRtTable, materializeRtTable} from './table.ts';
 
 // View core: the read-only sibling of the table core. Manual-column views
 // only; the query-builder form stays on drizzle (see ./view.ts and CLAUDE.md).
-export type {AnyRtView, BuildViewFn, RtView, RtViewBrand, RtViewMeta, ViewColsOf, ViewNameOf} from './view.ts';
+export type {AnyRtView, BuildViewFn, RtViewBrand, RtViewMeta, ViewColsOf, ViewNameOf} from './view.ts';
 export {isRtView, materializeRtView, RtViewBuilder} from './view.ts';
 
 // Pure-types vocabulary core: the column type the dialect packages alias per

--- a/packages/drizzle-orm/src/recorder.ts
+++ b/packages/drizzle-orm/src/recorder.ts
@@ -24,6 +24,17 @@ export const rtColumnKey: unique symbol = Symbol('rtColumn');
 export const rtTableKey: unique symbol = Symbol('rtTable');
 /** Runtime key a slim VIEW stores its metadata under (see view.ts). */
 export const rtViewKey: unique symbol = Symbol('rtView');
+// The two keys above live on the VALUE and hold the recorded runtime state. The
+// two below are TYPE-only brands on the metadata itself, carrying the dialect
+// that recorded it: they are what makes a table (or view) recognisable in the
+// reflected graph, and what makes another dialect's toDrizzle a compile error
+// rather than a `dzMy.pgTable is not a function` at run time. Separate symbols
+// on purpose — one key meaning "the runtime state" on a value and "I am a
+// table" in a type would be one symbol doing two jobs.
+/** Phantom key branding a table's metadata with its dialect; never set at runtime. */
+export const rtTableBrand: unique symbol = Symbol('rtTableBrand');
+/** Phantom key branding a view's metadata with its dialect; never set at runtime. */
+export const rtViewBrand: unique symbol = Symbol('rtViewBrand');
 /** Runtime key a standalone factory handle (enum/schema/sequence) stores its
  *  RtValueRecorder under, so the dialect's toDrizzle can materialize it. */
 export const rtValueKey: unique symbol = Symbol('rtValue');

--- a/packages/drizzle-orm/src/refine.ts
+++ b/packages/drizzle-orm/src/refine.ts
@@ -14,7 +14,7 @@
 
 import type {MergeFormat, RefinableParamsOf} from '@ts-runtypes/core/formats';
 import type {ColBrandOf, ColDataOf, RtColumnBrand} from './recorder.ts';
-import type {AnyRtTable, ColsOf, RtTable, TableNameOf} from './table.ts';
+import type {AnyRtTable, ColsOf} from './table.ts';
 
 /** Per-column refinement params accepted for table T: only format-carrying
  *  columns are refinable (a passthrough boolean/json/enum column refines to
@@ -53,7 +53,9 @@ type RefineCols<Cols, R> = {
  *  This is the type road's refine — `type ApiUsersTable =
  *  RefinedTable<UsersTable, {name: {maxLength: 50}}>` — with R constrained so
  *  a typo'd column or an unrefinable param is a compile error. */
-export type RefinedTable<T extends AnyRtTable, R extends TableRefinements<T>> = RtTable<TableNameOf<T>, RefineCols<ColsOf<T>, R>>;
+export type RefinedTable<T extends AnyRtTable, R extends TableRefinements<T>> = Omit<T, 'columns'> & {
+  columns: RefineCols<ColsOf<T>, R>;
+};
 
 /** Tighten a table's column types for the API (stricter than the database):
  *  plain per-column format params, merged into the captured ones (refinement

--- a/packages/drizzle-orm/src/table.ts
+++ b/packages/drizzle-orm/src/table.ts
@@ -36,13 +36,8 @@ import {
  *  this: the name, the columns, the extraConfig tuple, and which dialect
  *  recorded it.
  *
- *  `Dialect` is what stops a table reaching another dialect's toDrizzle.
- *  Materialization replays the table's OWN captured buildTable closure against
- *  whatever context it is handed, so a pg table run through mysql's toDrizzle
- *  used to reach for `context.ns.pgTable` and find nothing. The tag makes that
- *  a compile error instead. It is optional (the house sentinel convention) and
- *  still rejects the call, since `'pg' | undefined` is not assignable to
- *  `'mysql' | undefined`.
+ *  Which dialect recorded it rides the separate RtTableBrand below, which each
+ *  dialect's own table interface extends.
  *
  *  Reach for the columns with ColsOf on the type, or cols() on the value. */
 export interface RtTableMeta<TName extends string, Cols, Extras extends readonly object[] = []> {
@@ -50,12 +45,18 @@ export interface RtTableMeta<TName extends string, Cols, Extras extends readonly
   columns: Cols;
   extras: Extras;
 }
-export type RtTable<TName extends string, Cols, Extras extends readonly object[] = []> = RtTableMeta<TName, Cols, Extras>;
 /** Any slim table, of any dialect: the dialect-agnostic constraint the models
  *  and refineTableType take. */
 export type AnyRtTable = RtTableMeta<string, Record<string, AnyRtColumn>, readonly object[]>;
 /** The brand each DIALECT adds to its own table interface: what marks a node a
  *  table in the reflected graph, and what carries the dialect that recorded it.
+ *
+ *  It is what stops a table reaching another dialect's toDrizzle:
+ *  materialization replays the table's OWN captured buildTable closure against
+ *  whatever context it is handed, so a pg table run through mysql's toDrizzle
+ *  used to reach for `context.ns.pgTable` and find nothing. Optional, the house
+ *  sentinel convention, and it still rejects that call since `'pg' | undefined`
+ *  is not assignable to `'mysql' | undefined`.
  *
  *  It lives on the dialect interfaces and not on RtTableMeta, and it is a fixed
  *  member rather than a type parameter, because both of those cost: a parameter

--- a/packages/drizzle-orm/src/table.ts
+++ b/packages/drizzle-orm/src/table.ts
@@ -19,31 +19,63 @@ import {
   RtEntryRecorder,
   RtIndexedColumnClass,
   RtSqlRecorder,
+  rtTableBrand,
   rtTableKey,
   rtViewKey,
   setResolveRecorded,
   type IndexedColumnInternal,
 } from './recorder.ts';
 
-export interface RtTableMeta<TName extends string, Cols> {
-  name: TName;
-  columns: Cols;
-}
-/** The meta of a dialect table wrapper (PgTable, ...): RtTableMeta plus the
- *  extras tuple of the extraConfig road. One flat interface rather than
- *  `RtTableMeta & {extras}` so a declared table pays a single object at the
- *  meta key instead of an intersection (type-budget sensitive). */
-export interface RtTableMetaWithExtras<TName extends string, Cols, Extras extends readonly object[]> {
+/** A slim table's TYPE: the metadata, and nothing wrapped around it.
+ *
+ *  This is a type-level DESCRIPTOR of the table, not a mirror of the runtime
+ *  object. The object createRtTable returns still carries the columns as
+ *  properties and its recorded state under rtTableKey, because
+ *  `extraConfig((t) => [index().on(t.name)])` and `references(() => teams.id)`
+ *  read those at run time. The type says only what every reader needs, which is
+ *  this: the name, the columns, the extraConfig tuple, and which dialect
+ *  recorded it.
+ *
+ *  `Dialect` is what stops a table reaching another dialect's toDrizzle.
+ *  Materialization replays the table's OWN captured buildTable closure against
+ *  whatever context it is handed, so a pg table run through mysql's toDrizzle
+ *  used to reach for `context.ns.pgTable` and find nothing. The tag makes that
+ *  a compile error instead. It is optional (the house sentinel convention) and
+ *  still rejects the call, since `'pg' | undefined` is not assignable to
+ *  `'mysql' | undefined`.
+ *
+ *  Reach for the columns with ColsOf on the type, or cols() on the value. */
+export interface RtTableMeta<TName extends string, Cols, Extras extends readonly object[] = []> {
   name: TName;
   columns: Cols;
   extras: Extras;
 }
-/** A slim table: the columns as properties plus the metadata brand. */
-export type RtTable<TName extends string, Cols> = Cols & {readonly [rtTableKey]: RtTableMeta<TName, Cols>};
-export type AnyRtTable = {readonly [rtTableKey]: RtTableMeta<string, Record<string, AnyRtColumn>>};
+export type RtTable<TName extends string, Cols, Extras extends readonly object[] = []> = RtTableMeta<TName, Cols, Extras>;
+/** Any slim table, of any dialect: the dialect-agnostic constraint the models
+ *  and refineTableType take. */
+export type AnyRtTable = RtTableMeta<string, Record<string, AnyRtColumn>, readonly object[]>;
+/** The brand each DIALECT adds to its own table interface: what marks a node a
+ *  table in the reflected graph, and what carries the dialect that recorded it.
+ *
+ *  It lives on the dialect interfaces and not on RtTableMeta, and it is a fixed
+ *  member rather than a type parameter, because both of those cost: a parameter
+ *  the checker instantiates per declared table measured at about 4 each, and
+ *  declaring it in core AND narrowing it in the dialect at about 9. */
+export interface RtTableBrand<Dialect extends string> {
+  readonly [rtTableBrand]?: Dialect;
+}
 
-export type TableNameOf<T extends AnyRtTable> = T[typeof rtTableKey]['name'];
-export type ColsOf<T extends AnyRtTable> = T[typeof rtTableKey]['columns'];
+export type TableNameOf<T extends AnyRtTable> = T['name'];
+export type ColsOf<T extends AnyRtTable> = T['columns'];
+
+/** The columns of a slim table, as a VALUE. Identity at run time: the object
+ *  really does carry them as properties, the type just does not name them.
+ *  This is how a cross-table reference is written:
+ *
+ *    teamId: integer('team_id').references(() => cols(teams).id) */
+export function cols<T extends AnyRtTable>(table: T): ColsOf<T> {
+  return table as unknown as ColsOf<T>;
+}
 
 /** Builds the dialect's drizzle table at materialization: called with the
  *  context, the materialized column builders, and (when the slim table has an

--- a/packages/drizzle-orm/src/view.ts
+++ b/packages/drizzle-orm/src/view.ts
@@ -30,7 +30,6 @@ export interface RtViewMeta<TName extends string, Cols> {
   name: TName;
   columns: Cols;
 }
-export type RtView<TName extends string, Cols> = RtViewMeta<TName, Cols>;
 export type AnyRtView = RtViewMeta<string, Record<string, AnyRtColumn>>;
 /** The view's brand, the twin of RtTableBrand (see table.ts for why it lives
  *  here rather than on RtViewMeta). */

--- a/packages/drizzle-orm/src/view.ts
+++ b/packages/drizzle-orm/src/view.ts
@@ -20,19 +20,26 @@
 // InferUpdateModel do not.
 
 import type {AnyRtColumn, DrizzleContext} from './recorder.ts';
-import {mapReplayArgs, RtColumnRecorder, rtViewKey} from './recorder.ts';
+import {mapReplayArgs, RtColumnRecorder, rtViewBrand, rtViewKey} from './recorder.ts';
 import {setViewMaterializer} from './table.ts';
 
+/** A slim view's TYPE: the metadata, the same shape RtTableMeta takes and for
+ *  the same reasons (see table.ts). Its own brand rather than the table's, so a
+ *  view and a table stay distinguishable where toDrizzle overloads on them. */
 export interface RtViewMeta<TName extends string, Cols> {
   name: TName;
   columns: Cols;
 }
-/** A slim view: the columns as properties plus the metadata brand. */
-export type RtView<TName extends string, Cols> = Cols & {readonly [rtViewKey]: RtViewMeta<TName, Cols>};
-export type AnyRtView = {readonly [rtViewKey]: RtViewMeta<string, Record<string, AnyRtColumn>>};
+export type RtView<TName extends string, Cols> = RtViewMeta<TName, Cols>;
+export type AnyRtView = RtViewMeta<string, Record<string, AnyRtColumn>>;
+/** The view's brand, the twin of RtTableBrand (see table.ts for why it lives
+ *  here rather than on RtViewMeta). */
+export interface RtViewBrand<Dialect extends string> {
+  readonly [rtViewBrand]?: Dialect;
+}
 
-export type ViewNameOf<V extends AnyRtView> = V[typeof rtViewKey]['name'];
-export type ViewColsOf<V extends AnyRtView> = V[typeof rtViewKey]['columns'];
+export type ViewNameOf<V extends AnyRtView> = V['name'];
+export type ViewColsOf<V extends AnyRtView> = V['columns'];
 
 /** Builds the dialect's drizzle view builder at materialization: called with
  *  the context, the view name and the materialized column builders. What it

--- a/packages/examples/src/drizzle/drizzle-constraints-example.ts
+++ b/packages/examples/src/drizzle/drizzle-constraints-example.ts
@@ -3,7 +3,7 @@
 // this reaches your app types, it only shapes the SQL, so it costs your models
 // nothing.
 import * as DB from '@mionjs/drizzle-orm-pg-core';
-import {sql} from '@mionjs/drizzle-orm';
+import {cols, sql} from '@mionjs/drizzle-orm';
 
 export const teams = DB.pgTable('teams', {
   id: DB.serial('id').primaryKey(),
@@ -24,7 +24,7 @@ export const members = DB.pgTable(
     DB.primaryKey({name: 'members_pk', columns: [t.teamId, t.userId]}),
 
     // a foreign key with referential actions
-    DB.foreignKey({name: 'members_team_fk', columns: [t.teamId], foreignColumns: [teams.id]})
+    DB.foreignKey({name: 'members_team_fk', columns: [t.teamId], foreignColumns: [cols(teams).id]})
       .onDelete('cascade')
       .onUpdate('restrict'),
 
@@ -45,6 +45,6 @@ export const members = DB.pgTable(
 // A single column can also carry its constraints inline, the drizzle way.
 export const invites = DB.pgTable('invites', {
   id: DB.uuid('id').defaultRandom().primaryKey(),
-  teamId: DB.integer('team_id').references(() => teams.id, {onDelete: 'cascade'}),
+  teamId: DB.integer('team_id').references(() => cols(teams).id, {onDelete: 'cascade'}),
   code: DB.varchar('code', {length: 12}).notNull().unique('invites_code_uq'),
 });

--- a/packages/examples/src/drizzle/drizzle-relations-example.ts
+++ b/packages/examples/src/drizzle/drizzle-relations-example.ts
@@ -3,6 +3,7 @@
 // So they are declared with drizzle, on the toDrizzle() tables, in the file
 // that runs your queries. Your schema file stays free of drizzle types.
 import * as DB from '@mionjs/drizzle-orm-pg-core';
+import {cols} from '@mionjs/drizzle-orm';
 import {toDrizzle} from '@mionjs/drizzle-orm-pg-core/drizzle';
 import type {InferSelectModel} from '@mionjs/drizzle-orm';
 import {relations} from 'drizzle-orm';
@@ -20,7 +21,7 @@ export const posts = DB.pgTable('posts', {
   id: DB.uuid('id').defaultRandom().primaryKey(),
   authorId: DB.uuid('author_id')
     .notNull()
-    .references(() => authors.id, {onDelete: 'cascade'}),
+    .references(() => cols(authors).id, {onDelete: 'cascade'}),
   title: DB.varchar('title', {length: 200}).notNull(),
 });
 

--- a/packages/type-budget/reports/lane-comparison.json
+++ b/packages/type-budget/reports/lane-comparison.json
@@ -8,19 +8,19 @@
         {
           "step": 1,
           "label": "slim table + row",
-          "delta": 433,
+          "delta": 425,
           "budget": 433
         },
         {
           "step": 2,
           "label": "refineTableType",
-          "delta": 1141,
+          "delta": 1139,
           "budget": 1141
         },
         {
           "step": 3,
           "label": "Infer* models",
-          "delta": 578,
+          "delta": 573,
           "budget": 578
         },
         {
@@ -32,11 +32,11 @@
         {
           "step": 5,
           "label": "initClient",
-          "delta": 2540,
+          "delta": 2539,
           "budget": 2540
         }
       ],
-      "total": 5225
+      "total": 5209
     },
     {
       "name": "type-only",

--- a/packages/type-budget/reports/lane-comparison.json
+++ b/packages/type-budget/reports/lane-comparison.json
@@ -8,8 +8,8 @@
         {
           "step": 1,
           "label": "slim table + row",
-          "delta": 425,
-          "budget": 433
+          "delta": 434,
+          "budget": 434
         },
         {
           "step": 2,
@@ -36,7 +36,7 @@
           "budget": 2540
         }
       ],
-      "total": 5209
+      "total": 5218
     },
     {
       "name": "type-only",

--- a/packages/type-budget/reports/lane-comparison.md
+++ b/packages/type-budget/reports/lane-comparison.md
@@ -20,12 +20,12 @@ report, paid only in the files that run queries.
 
 | Step | Layer | slim | type-only | builder |
 | ---: | ----- | ---: | ---: | ---: |
-| 1 | declare the formatted row | 433 | 47 | 576 |
-| 2 | refine two columns | 1141 | 393 | 384 |
-| 3 | select / insert / update models | 578 | 254 | 262 |
+| 1 | declare the formatted row | 425 | 47 | 576 |
+| 2 | refine two columns | 1139 | 393 | 384 |
+| 3 | select / insert / update models | 573 | 254 | 262 |
 | 4 | mion route api | 533 | 510 | 506 |
-| 5 | initClient | 2540 | 2601 | 2817 |
-| | **Total** | **5225** | **3805** | **4545** |
+| 5 | initClient | 2539 | 2601 | 2817 |
+| | **Total** | **5209** | **3805** | **4545** |
 
 ## Reading this
 

--- a/packages/type-budget/reports/lane-comparison.md
+++ b/packages/type-budget/reports/lane-comparison.md
@@ -20,12 +20,12 @@ report, paid only in the files that run queries.
 
 | Step | Layer | slim | type-only | builder |
 | ---: | ----- | ---: | ---: | ---: |
-| 1 | declare the formatted row | 425 | 47 | 576 |
+| 1 | declare the formatted row | 434 | 47 | 576 |
 | 2 | refine two columns | 1139 | 393 | 384 |
 | 3 | select / insert / update models | 573 | 254 | 262 |
 | 4 | mion route api | 533 | 510 | 506 |
 | 5 | initClient | 2539 | 2601 | 2817 |
-| | **Total** | **5209** | **3805** | **4545** |
+| | **Total** | **5218** | **3805** | **4545** |
 
 ## Reading this
 

--- a/packages/type-budget/reports/model-pipeline.json
+++ b/packages/type-budget/reports/model-pipeline.json
@@ -5,50 +5,50 @@
     {
       "step": 1,
       "label": "slim table + row",
-      "delta": 433,
+      "delta": 425,
       "budget": 433,
-      "cumulative": 433
+      "cumulative": 425
     },
     {
       "step": 2,
       "label": "refineTableType",
-      "delta": 1141,
+      "delta": 1139,
       "budget": 1141,
-      "cumulative": 1574
+      "cumulative": 1564
     },
     {
       "step": 3,
       "label": "Infer* models",
-      "delta": 578,
+      "delta": 573,
       "budget": 578,
-      "cumulative": 2152
+      "cumulative": 2137
     },
     {
       "step": 4,
       "label": "mion route api",
       "delta": 533,
       "budget": 533,
-      "cumulative": 2685
+      "cumulative": 2670
     },
     {
       "step": 5,
       "label": "initClient",
-      "delta": 2540,
+      "delta": 2539,
       "budget": 2540,
-      "cumulative": 5225
+      "cumulative": 5209
     },
     {
       "step": 6,
       "label": "db query (toDrizzle)",
-      "delta": 7852,
+      "delta": 7821,
       "budget": 7852,
-      "cumulative": 13077
+      "cumulative": 13030
     }
   ],
   "totalBudget": 13077,
   "consumer": {
     "budget": 1784,
-    "netInstantiations": 1513,
+    "netInstantiations": 1518,
     "keepsGenericAlias": true,
     "dtsBytes": 970
   }

--- a/packages/type-budget/reports/model-pipeline.json
+++ b/packages/type-budget/reports/model-pipeline.json
@@ -5,51 +5,51 @@
     {
       "step": 1,
       "label": "slim table + row",
-      "delta": 425,
-      "budget": 433,
-      "cumulative": 425
+      "delta": 434,
+      "budget": 434,
+      "cumulative": 434
     },
     {
       "step": 2,
       "label": "refineTableType",
       "delta": 1139,
       "budget": 1141,
-      "cumulative": 1564
+      "cumulative": 1573
     },
     {
       "step": 3,
       "label": "Infer* models",
       "delta": 573,
       "budget": 578,
-      "cumulative": 2137
+      "cumulative": 2146
     },
     {
       "step": 4,
       "label": "mion route api",
       "delta": 533,
       "budget": 533,
-      "cumulative": 2670
+      "cumulative": 2679
     },
     {
       "step": 5,
       "label": "initClient",
       "delta": 2539,
       "budget": 2540,
-      "cumulative": 5209
+      "cumulative": 5218
     },
     {
       "step": 6,
       "label": "db query (toDrizzle)",
-      "delta": 7821,
+      "delta": 7828,
       "budget": 7852,
-      "cumulative": 13030
+      "cumulative": 13046
     }
   ],
   "totalBudget": 13077,
   "consumer": {
     "budget": 1784,
-    "netInstantiations": 1518,
+    "netInstantiations": 1533,
     "keepsGenericAlias": true,
-    "dtsBytes": 970
+    "dtsBytes": 963
   }
 }

--- a/packages/type-budget/reports/model-pipeline.md
+++ b/packages/type-budget/reports/model-pipeline.md
@@ -12,14 +12,14 @@ layer to another.
 
 | Step | Layer | Net instantiations added | Budget | Cumulative |
 | ---: | ----- | -----------------------: | -----: | ---------: |
-| 1 | slim table + row | 425 | 433 | 425 |
-| 2 | refineTableType | 1139 | 1141 | 1564 |
-| 3 | Infer* models | 573 | 578 | 2137 |
-| 4 | mion route api | 533 | 533 | 2670 |
-| 5 | initClient | 2539 | 2540 | 5209 |
-| 6 | db query (toDrizzle) | 7821 | 7852 | 13030 |
+| 1 | slim table + row | 434 | 434 | 434 |
+| 2 | refineTableType | 1139 | 1141 | 1573 |
+| 3 | Infer* models | 573 | 578 | 2146 |
+| 4 | mion route api | 533 | 533 | 2679 |
+| 5 | initClient | 2539 | 2540 | 5218 |
+| 6 | db query (toDrizzle) | 7828 | 7852 | 13046 |
 
-Total for the whole chain: **13030**, against a total budget of **13077**.
+Total for the whole chain: **13046**, against a total budget of **13077**.
 
 Every one of these is paid again on every keystroke. TypeScript memoises type
 instantiations within a single check, but each edit builds a new checker, so the
@@ -29,9 +29,9 @@ work is redone. Parsing is reused across edits; type instantiation is not.
 
 | What | Value |
 | ---- | ----: |
-| Consumer net instantiations | 1518 |
+| Consumer net instantiations | 1533 |
 | Budget | 1784 |
-| Emitted declaration size (bytes) | 970 |
+| Emitted declaration size (bytes) | 963 |
 | Declaration keeps the generic alias unresolved | yes |
 
 Declaration emit prints the type alias as it was written, never the type it

--- a/packages/type-budget/reports/model-pipeline.md
+++ b/packages/type-budget/reports/model-pipeline.md
@@ -12,14 +12,14 @@ layer to another.
 
 | Step | Layer | Net instantiations added | Budget | Cumulative |
 | ---: | ----- | -----------------------: | -----: | ---------: |
-| 1 | slim table + row | 433 | 433 | 433 |
-| 2 | refineTableType | 1141 | 1141 | 1574 |
-| 3 | Infer* models | 578 | 578 | 2152 |
-| 4 | mion route api | 533 | 533 | 2685 |
-| 5 | initClient | 2540 | 2540 | 5225 |
-| 6 | db query (toDrizzle) | 7852 | 7852 | 13077 |
+| 1 | slim table + row | 425 | 433 | 425 |
+| 2 | refineTableType | 1139 | 1141 | 1564 |
+| 3 | Infer* models | 573 | 578 | 2137 |
+| 4 | mion route api | 533 | 533 | 2670 |
+| 5 | initClient | 2539 | 2540 | 5209 |
+| 6 | db query (toDrizzle) | 7821 | 7852 | 13030 |
 
-Total for the whole chain: **13077**, against a total budget of **13077**.
+Total for the whole chain: **13030**, against a total budget of **13077**.
 
 Every one of these is paid again on every keystroke. TypeScript memoises type
 instantiations within a single check, but each edit builds a new checker, so the
@@ -29,7 +29,7 @@ work is redone. Parsing is reused across edits; type instantiation is not.
 
 | What | Value |
 | ---- | ----: |
-| Consumer net instantiations | 1513 |
+| Consumer net instantiations | 1518 |
 | Budget | 1784 |
 | Emitted declaration size (bytes) | 970 |
 | Declaration keeps the generic alias unresolved | yes |

--- a/packages/type-budget/reports/type-road.json
+++ b/packages/type-budget/reports/type-road.json
@@ -4,43 +4,43 @@
   "cases": [
     {
       "label": "builder road, 5 mixed columns",
-      "netInstantiations": 561,
-      "budget": 568
+      "netInstantiations": 570,
+      "budget": 570
     },
     {
       "label": "type road, 5 mixed columns",
-      "netInstantiations": 968,
+      "netInstantiations": 965,
       "budget": 968
     },
     {
       "label": "type road, 5 mixed columns + insert model",
-      "netInstantiations": 1434,
+      "netInstantiations": 1431,
       "budget": 1434
     },
     {
       "label": "type road, 20 plain columns",
-      "netInstantiations": 1341,
+      "netInstantiations": 1338,
       "budget": 1341
     },
     {
       "label": "builder road, 20 plain columns",
-      "netInstantiations": 336,
-      "budget": 343
+      "netInstantiations": 345,
+      "budget": 345
     },
     {
       "label": "pre-branded, 20 plain columns",
-      "netInstantiations": 316,
-      "budget": 316
+      "netInstantiations": 326,
+      "budget": 326
     },
     {
       "label": "type road, wide vocabulary",
-      "netInstantiations": 1170,
+      "netInstantiations": 1167,
       "budget": 1170
     },
     {
       "label": "builder road, wide vocabulary",
-      "netInstantiations": 679,
-      "budget": 686
+      "netInstantiations": 688,
+      "budget": 688
     }
   ]
 }

--- a/packages/type-budget/reports/type-road.json
+++ b/packages/type-budget/reports/type-road.json
@@ -4,13 +4,13 @@
   "cases": [
     {
       "label": "builder road, 5 mixed columns",
-      "netInstantiations": 568,
+      "netInstantiations": 561,
       "budget": 568
     },
     {
       "label": "type road, 5 mixed columns",
-      "netInstantiations": 967,
-      "budget": 967
+      "netInstantiations": 968,
+      "budget": 968
     },
     {
       "label": "type road, 5 mixed columns + insert model",
@@ -19,27 +19,27 @@
     },
     {
       "label": "type road, 20 plain columns",
-      "netInstantiations": 1340,
-      "budget": 1340
+      "netInstantiations": 1341,
+      "budget": 1341
     },
     {
       "label": "builder road, 20 plain columns",
-      "netInstantiations": 343,
+      "netInstantiations": 336,
       "budget": 343
     },
     {
       "label": "pre-branded, 20 plain columns",
-      "netInstantiations": 314,
-      "budget": 314
+      "netInstantiations": 316,
+      "budget": 316
     },
     {
       "label": "type road, wide vocabulary",
-      "netInstantiations": 1169,
-      "budget": 1169
+      "netInstantiations": 1170,
+      "budget": 1170
     },
     {
       "label": "builder road, wide vocabulary",
-      "netInstantiations": 686,
+      "netInstantiations": 679,
       "budget": 686
     }
   ]

--- a/packages/type-budget/reports/type-road.md
+++ b/packages/type-budget/reports/type-road.md
@@ -13,14 +13,14 @@ The same table, declared three ways and read through the same models:
 
 | Case | Net instantiations | Budget |
 | ---- | -----------------: | -----: |
-| builder road, 5 mixed columns | 568 | 568 |
-| type road, 5 mixed columns | 967 | 967 |
+| builder road, 5 mixed columns | 561 | 568 |
+| type road, 5 mixed columns | 968 | 968 |
 | type road, 5 mixed columns + insert model | 1434 | 1434 |
-| type road, 20 plain columns | 1340 | 1340 |
-| builder road, 20 plain columns | 343 | 343 |
-| pre-branded, 20 plain columns | 314 | 314 |
-| type road, wide vocabulary | 1169 | 1169 |
-| builder road, wide vocabulary | 686 | 686 |
+| type road, 20 plain columns | 1341 | 1341 |
+| builder road, 20 plain columns | 336 | 343 |
+| pre-branded, 20 plain columns | 316 | 316 |
+| type road, wide vocabulary | 1170 | 1170 |
+| builder road, wide vocabulary | 679 | 686 |
 
 The gap between the type road and the pre-branded floor is what being
 reflectable costs: a type-road column carries its db name and config in the

--- a/packages/type-budget/reports/type-road.md
+++ b/packages/type-budget/reports/type-road.md
@@ -13,14 +13,14 @@ The same table, declared three ways and read through the same models:
 
 | Case | Net instantiations | Budget |
 | ---- | -----------------: | -----: |
-| builder road, 5 mixed columns | 561 | 568 |
-| type road, 5 mixed columns | 968 | 968 |
-| type road, 5 mixed columns + insert model | 1434 | 1434 |
-| type road, 20 plain columns | 1341 | 1341 |
-| builder road, 20 plain columns | 336 | 343 |
-| pre-branded, 20 plain columns | 316 | 316 |
-| type road, wide vocabulary | 1170 | 1170 |
-| builder road, wide vocabulary | 679 | 686 |
+| builder road, 5 mixed columns | 570 | 570 |
+| type road, 5 mixed columns | 965 | 968 |
+| type road, 5 mixed columns + insert model | 1431 | 1434 |
+| type road, 20 plain columns | 1338 | 1341 |
+| builder road, 20 plain columns | 345 | 345 |
+| pre-branded, 20 plain columns | 326 | 326 |
+| type road, wide vocabulary | 1167 | 1170 |
+| builder road, wide vocabulary | 688 | 688 |
 
 The gap between the type road and the pre-branded floor is what being
 reflectable costs: a type-road column carries its db name and config in the

--- a/packages/type-budget/test/modelPipelineHarness.ts
+++ b/packages/type-budget/test/modelPipelineHarness.ts
@@ -104,13 +104,17 @@ export const PIPELINE_STEPS: PipelineStep[] = [
     // — and a two-member union costs the checker 7 more instantiations than a
     // single array type. Measured by reverting exactly that one line.
     //
-    // 490 -> 489. The factories now return a 3-parameter PgBuilderTable instead
+    // 490 -> 489. The factories now return a 3-parameter PgTable instead
     // of PgTable with its columns passed twice (slot two AND the normalized fast
     // path), which also stops declaration emit printing the whole column record
     // twice in every consumer's .d.ts.
     // 489 -> 433: the flat models read the column brand payload once per column
     // instead of probing it once per flag.
-    budget: 433,
+    // 433 -> 434: ONE table type per dialect now, so the builder road runs its
+    // columns through TypedCols (a wholesale pass-through) where it used to skip
+    // it. Reviewed: two shapes for the same table cost more than the one
+    // instantiation is worth. See typeRoad.compile.test.ts for the full note.
+    budget: 434,
     body: `
 const users = pgTable('users', {
   name: varchar('name', {length: 100}).notNull(),

--- a/packages/type-budget/test/typeRoad.compile.test.ts
+++ b/packages/type-budget/test/typeRoad.compile.test.ts
@@ -19,6 +19,15 @@
 //
 // Budgets are ONE-WAY DOWNWARD, the same rule the pipeline suite states: cheapen
 // the types, never raise the number.
+//
+// ONE reviewed exception, and it is the whole of this suite's current numbers.
+// When the table type became its own metadata, ONE type per dialect replaced the
+// PgTable / PgBuilderTable pair, so the builder road now runs its columns record
+// through TypedCols (a wholesale pass-through) where it used to skip it. That is
+// about 2 a table, 10 on the twenty-column case, and the type road got a little
+// cheaper in exchange. It was taken deliberately: two shapes for the same table,
+// one per road, cost more in complexity than the instantiations are worth, and
+// nothing downstream now has to know which road declared a table.
 
 import {describe, it, expect, beforeAll, afterAll} from 'vitest';
 import * as ts from 'typescript';
@@ -38,7 +47,7 @@ const SNIPPET_FILE = fileURLToPath(new URL('./__typeRoadCase__.ts', import.meta.
 /** The preamble, so module resolution never lands in a measurement. */
 const IMPORT_HEADER = `
 import {pgTable, varchar, integer, timestamp, uuid, text, serial, jsonb} from '@mionjs/drizzle-orm-pg-core';
-import type {PgTable, PgBuilderTable, RtPgIntColumn} from '@mionjs/drizzle-orm-pg-core';
+import type {PgTable, RtPgIntColumn} from '@mionjs/drizzle-orm-pg-core';
 import type {Varchar, Integer, Timestamp, Uuid, Text, Serial, Jsonb} from '@mionjs/drizzle-orm-pg-core';
 import type {InferSelectModel, InferInsertModel} from '@mionjs/drizzle-orm';
 import type {Date as RTDate, String as RTString, Int32} from '@ts-runtypes/core/formats';
@@ -99,7 +108,7 @@ const CASES: RoadCase[] = [
     label: 'builder road, 5 mixed columns',
     // 646 -> 568: the flat models read the column brand payload once per
     // column instead of probing it once per flag, which helps BOTH roads.
-    budget: 568,
+    budget: 570,
     body: `
 const bSrc = pgTable('users', {
   id: uuid('id').primaryKey(),
@@ -117,10 +126,6 @@ ${readMixed('b')}`,
     // it: a column type expands straight to the branded column, so the record
     // takes TypedCols's wholesale branch and nothing is normalized per column.
     // Then -> 967 with the brand payload read once per column.
-    // Then -> 968 when the table type became the metadata itself: the one
-    // reviewed increase in this suite (+1), taken because the shape drops the
-    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
-    // and its brand is what makes a cross-dialect toDrizzle a compile error.
     budget: 968,
     body: `
 type tSrc = PgTable<'users', {
@@ -157,10 +162,6 @@ export const iNewUser: iNew = {id: 'x' as never, name: 'a', age: 1, role: 'admin
     label: 'type road, 20 plain columns',
     // 2693 -> 2116 -> 1595, the same two rounds. Width is where deleting the
     // normalization pays most: it ran once per column.
-    // Then -> 1341 when the table type became the metadata itself: the one
-    // reviewed increase in this suite (+1), taken because the shape drops the
-    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
-    // and its brand is what makes a cross-dialect toDrizzle a compile error.
     budget: 1341,
     body: plainCase(
       'p',
@@ -173,7 +174,7 @@ export const iNewUser: iNew = {id: 'x' as never, name: 'a', age: 1, role: 'admin
   },
   {
     label: 'builder road, 20 plain columns',
-    budget: 343,
+    budget: 345,
     body: plainCase(
       'r',
       20,
@@ -187,18 +188,14 @@ export const iNewUser: iNew = {id: 'x' as never, name: 'a', age: 1, role: 'admin
     // The floor: columns named as the branded types the builders return, so no
     // normalization runs at all.
     label: 'pre-branded, 20 plain columns',
-    // Then -> 316 when the table type became the metadata itself: the one
-    // reviewed increase in this suite (+2), taken because the shape drops the
-    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
-    // and its brand is what makes a cross-dialect toDrizzle a compile error.
-    budget: 316,
+    budget: 326,
     body: plainCase(
       'q',
       20,
       plainKeys(20)
         .map((key) => `${key}: RtPgIntColumn<Int32, false, false, false>;`)
         .join(' '),
-      (cols) => `type qSrc = PgBuilderTable<'t', {${cols}}>;`
+      (cols) => `type qSrc = PgTable<'t', {${cols}}>;`
     ),
   },
   {
@@ -207,10 +204,6 @@ export const iNewUser: iNew = {id: 'x' as never, name: 'a', age: 1, role: 'admin
     // flatter a change that only helps one column shape.
     label: 'type road, wide vocabulary',
     // 1560 with the intersected markers, measured on the same shapes.
-    // Then -> 1170 when the table type became the metadata itself: the one
-    // reviewed increase in this suite (+1), taken because the shape drops the
-    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
-    // and its brand is what makes a cross-dialect toDrizzle a compile error.
     budget: 1170,
     body: `
 type wSrc = PgTable<'w', {
@@ -227,7 +220,7 @@ ${readWide('w')}`,
   },
   {
     label: 'builder road, wide vocabulary',
-    budget: 686,
+    budget: 688,
     body: `
 const vSrcTable = pgTable('w', {
   id: serial('id').primaryKey(),

--- a/packages/type-budget/test/typeRoad.compile.test.ts
+++ b/packages/type-budget/test/typeRoad.compile.test.ts
@@ -117,7 +117,11 @@ ${readMixed('b')}`,
     // it: a column type expands straight to the branded column, so the record
     // takes TypedCols's wholesale branch and nothing is normalized per column.
     // Then -> 967 with the brand payload read once per column.
-    budget: 967,
+    // Then -> 968 when the table type became the metadata itself: the one
+    // reviewed increase in this suite (+1), taken because the shape drops the
+    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
+    // and its brand is what makes a cross-dialect toDrizzle a compile error.
+    budget: 968,
     body: `
 type tSrc = PgTable<'users', {
   id: Uuid<'id', {primaryKey: true}>;
@@ -153,7 +157,11 @@ export const iNewUser: iNew = {id: 'x' as never, name: 'a', age: 1, role: 'admin
     label: 'type road, 20 plain columns',
     // 2693 -> 2116 -> 1595, the same two rounds. Width is where deleting the
     // normalization pays most: it ran once per column.
-    budget: 1340,
+    // Then -> 1341 when the table type became the metadata itself: the one
+    // reviewed increase in this suite (+1), taken because the shape drops the
+    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
+    // and its brand is what makes a cross-dialect toDrizzle a compile error.
+    budget: 1341,
     body: plainCase(
       'p',
       20,
@@ -179,7 +187,11 @@ export const iNewUser: iNew = {id: 'x' as never, name: 'a', age: 1, role: 'admin
     // The floor: columns named as the branded types the builders return, so no
     // normalization runs at all.
     label: 'pre-branded, 20 plain columns',
-    budget: 314,
+    // Then -> 316 when the table type became the metadata itself: the one
+    // reviewed increase in this suite (+2), taken because the shape drops the
+    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
+    // and its brand is what makes a cross-dialect toDrizzle a compile error.
+    budget: 316,
     body: plainCase(
       'q',
       20,
@@ -195,7 +207,11 @@ export const iNewUser: iNew = {id: 'x' as never, name: 'a', age: 1, role: 'admin
     // flatter a change that only helps one column shape.
     label: 'type road, wide vocabulary',
     // 1560 with the intersected markers, measured on the same shapes.
-    budget: 1169,
+    // Then -> 1170 when the table type became the metadata itself: the one
+    // reviewed increase in this suite (+1), taken because the shape drops the
+    // `Cols &` arm, the rtTableKey wrapper and one of the two meta interfaces,
+    // and its brand is what makes a cross-dialect toDrizzle a compile error.
+    budget: 1170,
     body: `
 type wSrc = PgTable<'w', {
   id: Serial<'id', {primaryKey: true}>;

--- a/ts-go-runtypes/internal/convert/drizzle.go
+++ b/ts-go-runtypes/internal/convert/drizzle.go
@@ -1259,20 +1259,14 @@ func specFromGraph(resolved *resolvedDecl, decl *declaration, spelling *drizzleS
 		return node
 	}
 	// properties lists a node's property children DEREFERENCED (child slots in
-	// the serialized graph are `{kind:-1, id}` sentinels), flattening
-	// intersection arms (the type road's RtTable is `Cols & {meta}`).
+	// the serialized graph are `{kind:-1, id}` sentinels). Flat: a table type is
+	// one object now (the metadata, which each dialect's interface extends),
+	// where it used to be `Cols & {meta}` and this had to flatten the arms.
 	var properties func(node *reflection.RunType) []*reflection.RunType
 	properties = func(node *reflection.RunType) []*reflection.RunType {
 		node = deref(node)
 		if node == nil {
 			return nil
-		}
-		if node.Kind == reflection.KindIntersection {
-			var flattened []*reflection.RunType
-			for _, arm := range node.Children {
-				flattened = append(flattened, properties(arm)...)
-			}
-			return flattened
 		}
 		var out []*reflection.RunType
 		for _, child := range node.Children {

--- a/ts-go-runtypes/internal/convert/drizzle.go
+++ b/ts-go-runtypes/internal/convert/drizzle.go
@@ -41,7 +41,10 @@ import (
 // The sentinel member suffixes (tsgo spells a unique-symbol member as
 // `\xFE@<symbolConstName>@<checkerId>`; stripSentinelId removes the id).
 const (
-	sentinelTable   = "@rtTableKey"
+	// The table type IS its metadata, so this brand is what marks a node as a
+	// table (and carries the dialect that recorded it); name/columns/extras are
+	// the node's own members.
+	sentinelTable   = "@rtTableBrand"
 	sentinelColSpec = "@rtColSpecKey"
 	sentinelColMods = "@rtColModsKey"
 	sentinelColumn  = "@rtColumnKey"
@@ -566,7 +569,16 @@ func (spellings *drizzleSpellings) removableLocals() map[string]bool {
 		if entry == nil {
 			continue
 		}
+		// A dialect package's bindings are all the conversion's to drop. The
+		// root module is registered here too, because a printed reference
+		// spells cols() from it, but only THAT binding is the conversion's:
+		// `sql` and anything else there belong to the file, and the form it was
+		// converted from has no say over them.
+		root := module == drizzleRootModule
 		for _, binding := range append(append([]namedBinding{}, entry.Named...), entry.ExtraNamedBindings()...) {
+			if root && binding.Imported != "cols" {
+				continue
+			}
 			locals[binding.Local] = true
 		}
 	}
@@ -770,8 +782,60 @@ func sqlTemplateText(node *ast.Node, typeChecker *checker.Checker) (string, bool
 	return tagged.Template.Text(), true
 }
 
-// referencesTarget parses `() => <ident>.<key>` — the lazy reference callback.
-func referencesTarget(node *ast.Node) (constName string, columnKey string, ok bool) {
+// refBaseName is the table const behind a column reference, in either spelling
+// the converter must read: raw drizzle's `other.column`, and the slim road's
+// `cols(other).column` — which is what this program itself prints, since a slim
+// table's TYPE is its metadata and does not name the columns.
+func refBaseName(expr *ast.Node, info *drizzleFileInfo) (string, bool) {
+	if expr == nil {
+		return "", false
+	}
+	if ast.IsIdentifier(expr) {
+		return expr.Text(), true
+	}
+	if !ast.IsCallExpression(expr) {
+		return "", false
+	}
+	call := expr.AsCallExpression()
+	if call.Arguments == nil || len(call.Arguments.Nodes) != 1 {
+		return "", false
+	}
+	argument := call.Arguments.Nodes[0]
+	if !ast.IsIdentifier(argument) {
+		return "", false
+	}
+	spelled := info.colsSpelled
+	// A file the converter has not touched yet carries no cols import, so fall
+	// back to the plain name: this only has to recognise a call, and anything
+	// else fails the table lookup that follows.
+	if spelled == "" {
+		spelled = "cols"
+	}
+	if exprText(call.Expression) != spelled {
+		return "", false
+	}
+	return argument.Text(), true
+}
+
+// exprText renders an identifier or a dotted access, for comparing a callee
+// against the local a module was imported as.
+func exprText(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	if ast.IsIdentifier(node) {
+		return node.Text()
+	}
+	if ast.IsPropertyAccessExpression(node) {
+		access := node.AsPropertyAccessExpression()
+		return exprText(access.Expression) + "." + access.Name().Text()
+	}
+	return ""
+}
+
+// referencesTarget parses `() => <table>.<key>` — the lazy reference callback,
+// where <table> is either the const or cols(const).
+func referencesTarget(node *ast.Node, info *drizzleFileInfo) (constName string, columnKey string, ok bool) {
 	if node == nil || node.Kind != ast.KindArrowFunction {
 		return "", "", false
 	}
@@ -781,10 +845,11 @@ func referencesTarget(node *ast.Node) (constName string, columnKey string, ok bo
 		return "", "", false
 	}
 	access := body.AsPropertyAccessExpression()
-	if access.Expression == nil || !ast.IsIdentifier(access.Expression) {
+	base, found := refBaseName(access.Expression, info)
+	if !found {
 		return "", "", false
 	}
-	return access.Expression.Text(), access.Name().Text(), true
+	return base, access.Name().Text(), true
 }
 
 // specFromBuildersAST parses `NS.pgTable('name', {key: NS.fn(...).mod(...)})`.
@@ -961,7 +1026,7 @@ func columnFromChain(source string, decl *declaration, expr *ast.Node, columnKey
 			if len(refArgs) < 1 || len(refArgs) > 2 {
 				return nil, refuse("references: expected a callback and optional actions")
 			}
-			constName, columnKey, ok := referencesTarget(refArgs[0])
+			constName, columnKey, ok := referencesTarget(refArgs[0], fileInfo)
 			if !ok {
 				return nil, refuse("references: only `() => otherTable.column` targets have a type spelling")
 			}
@@ -1015,15 +1080,15 @@ func entryArgTexts(source string, decl *declaration, node *ast.Node, spec *drizz
 	}
 	if ast.IsPropertyAccessExpression(node) {
 		access := node.AsPropertyAccessExpression()
-		if access.Expression != nil && ast.IsIdentifier(access.Expression) {
-			base := access.Expression.Text()
+		if base, found := refBaseName(access.Expression, fileInfo); found {
 			key := access.Name().Text()
 			if base == paramName {
 				return "{col: " + quoteSingle(key) + "}", "t." + key, nil
 			}
 			if tableName, ok := fileInfo.tableNameForConst(base, decl); ok {
 				spec.addRefTable(tableName)
-				return "{table: " + quoteSingle(tableName) + ", col: " + quoteSingle(key) + "}", base + "." + key, nil
+				return "{table: " + quoteSingle(tableName) + ", col: " + quoteSingle(key) + "}",
+					colsSpelling(fileInfo) + "(" + base + ")." + key, nil
 			}
 		}
 		return "", "", drizzleRefuse(decl, "extraConfig: only columns of this table (t.x) or of a drizzle table declared in this file convert")
@@ -1285,10 +1350,10 @@ func specFromGraph(resolved *resolvedDecl, decl *declaration, spelling *drizzleS
 	}
 
 	root := resolved.Node
-	meta := member(root, sentinelTable)
-	if meta == nil {
+	if member(root, sentinelTable) == nil {
 		return nil, drizzleRefuse(decl, "the declared type carries no table metadata")
 	}
+	meta := root
 	nameNode := member(meta, "name")
 	if nameNode == nil || nameNode.Kind != reflection.KindLiteral {
 		return nil, drizzleRefuse(decl, "the table name is not a string literal")
@@ -1443,7 +1508,9 @@ func specFromGraph(resolved *resolvedDecl, decl *declaration, spelling *drizzleS
 				if !known || target.constName == "" {
 					return "", drizzleRefuse(decl, "%s: references table %q is not declared where this table can see it", where, refTableName)
 				}
-				return target.constName + "." + key, nil
+				// cols(), same reason as a column's .references(): the type of a
+				// slim table is its metadata and does not name the columns.
+				return colsSpelling(fileInfo) + "(" + target.constName + ")." + key, nil
 			}
 			var members []string
 			for _, property := range properties(node) {
@@ -1788,6 +1855,11 @@ func printDrizzleType(spec *drizzleTableSpec, decl *declaration, typeName, const
 	tableTypeText := spec.spelling.spellType(tableTypeName)
 	bridgeText := spec.spelling.spellValue("tableFromType")
 	spec.spelling.attach(&printed.needs)
+	// NOT attachRootSpelling: the type form spells a reference as
+	// `{table: 'parents'; column: 'id'}` and never calls cols(). Reading a
+	// builders-form input may have claimed the binding while building value
+	// text this direction discards, and importing it here would leave an unused
+	// import that breaks the type form's byte fixpoint.
 	printed.text = fmt.Sprintf("%stype %s = %s<%s, {\n%s\n}%s>;\n%sconst %s = %s<%s>(%s);",
 		exportPrefix, typeName, tableTypeText, quoteSingle(spec.tableName), strings.Join(columns, "\n"), extrasText,
 		constPrefix, constName, bridgeText, typeName, optionsText)
@@ -1839,7 +1911,9 @@ func printDrizzleBuilders(spec *drizzleTableSpec, decl *declaration, typeName, c
 				if targetConst == "" {
 					return nil, drizzleRefuse(decl, "references table %q is not declared in this file", mod.refTable)
 				}
-				text += ".references(() => " + targetConst + "." + mod.refColumn
+				// cols() because a slim table's TYPE is its metadata: the object
+				// carries the columns as properties, the type does not name them.
+				text += ".references(() => " + colsSpelling(fileInfo) + "(" + targetConst + ")." + mod.refColumn
 				if mod.refActions != "" {
 					text += ", " + mod.refActions
 				}
@@ -1873,6 +1947,10 @@ func printDrizzleBuilders(spec *drizzleTableSpec, decl *declaration, typeName, c
 	printed := &printedDecl{}
 	tableFnText := spec.spelling.spellValue(spec.tableFn)
 	spec.spelling.attach(&printed.needs)
+	// A printed reference spells cols() from the root module, which is a second
+	// spelling with its own import need. Claimed lazily, so attach it only when
+	// something actually claimed it.
+	attachRootSpelling(fileInfo, &printed.needs)
 	printed.text = fmt.Sprintf("%sconst %s = %s(%s, {\n%s\n}%s);\n%stype %s = typeof %s;",
 		exportPrefix, constName, tableFnText, quoteSingle(spec.tableName), strings.Join(columns, "\n"), extrasText,
 		aliasPrefix, typeName, constName)
@@ -2006,6 +2084,9 @@ type drizzleFileInfo struct {
 	// its own scope can actually see.
 	tables      []drizzleTableRef
 	sqlSpelling string
+	// how the file already spells cols(), so a reference it printed earlier
+	// parses back. Read from the imports, never claimed here.
+	colsSpelled string
 }
 
 // drizzleTableRef is one declared table, as a reference target.
@@ -2073,6 +2154,27 @@ func (info *drizzleFileInfo) constForTableName(tableName string, from *declarati
 
 const drizzleRootModule = "@mionjs/drizzle-orm"
 
+// attachRootSpelling hands the root module's claimed bindings to the planner,
+// but only when this file claimed any: forModule registers the module, and a
+// registered module's existing bindings come into removableLocals's reach.
+func attachRootSpelling(info *drizzleFileInfo, needs *importNeeds) {
+	if info == nil || info.spellings == nil {
+		return
+	}
+	if spelling, ok := info.spellings.byModule[drizzleRootModule]; ok {
+		spelling.attach(needs)
+	}
+}
+
+// colsSpelling is how this file names @mionjs/drizzle-orm's cols(), claiming the
+// import if the file does not already have one. Called at the point a reference
+// is PRINTED, never up front: registering a module with the spellings registry
+// puts that module's existing bindings in reach of removableLocals, so a table
+// with no cross-table reference must not touch the root module at all.
+func colsSpelling(info *drizzleFileInfo) string {
+	return info.spellings.forModule(drizzleRootModule).spellValue("cols")
+}
+
 // buildDrizzleFileInfo scans the recognized declarations once per file.
 func buildDrizzleFileInfo(decls []*declaration, imports *importScan, names *nameTable, baseTaken map[string]bool, used map[string]bool) *drizzleFileInfo {
 	info := &drizzleFileInfo{
@@ -2121,6 +2223,18 @@ func buildDrizzleFileInfo(decls []*declaration, imports *importScan, names *name
 			info.sqlSpelling = local
 		} else if alias := imports.NamespaceAlias(drizzleRootModule); alias != "" {
 			info.sqlSpelling = alias + ".sql"
+		}
+		if local := imports.LocalFor(drizzleRootModule, "cols"); local != "" {
+			info.colsSpelled = local
+			// Register the root module so a cols binding this program printed
+			// earlier is considered for removal: the type form spells a
+			// reference as `{table: ...; column: ...}` and calls nothing, so
+			// converting back must drop the import again or the type form is
+			// not a byte fixpoint. removableLocals only ever takes `cols` from
+			// this module, never the file's own `sql`.
+			info.spellings.forModule(drizzleRootModule)
+		} else if alias := imports.NamespaceAlias(drizzleRootModule); alias != "" {
+			info.colsSpelled = alias + ".cols"
 		}
 	}
 	return info

--- a/ts-go-runtypes/internal/convert/drizzle_test.go
+++ b/ts-go-runtypes/internal/convert/drizzle_test.go
@@ -533,7 +533,7 @@ func TestDrizzle_ForwardReferenceThunk(t *testing.T) {
 	expectNoDiags(t, diags)
 	// Back on the builders road the reference is a lazy callback again, so the
 	// declaration order the file was written in still stands.
-	if !strings.Contains(buildersForm, "  pid: DB.integer('pid').references(() => parents.id),") {
+	if !strings.Contains(buildersForm, "  pid: DB.integer('pid').references(() => cols(parents).id),") {
 		t.Fatalf("the forward reference did not come back:\n%s", buildersForm)
 	}
 	if strings.Index(buildersForm, "'children'") > strings.Index(buildersForm, "'parents'") {
@@ -738,7 +738,7 @@ func TestDrizzle_ReferencesAndSql(t *testing.T) {
 	buildersForm, diags := convertDrizzleOne(t, typeForm, convert.Options{Target: convert.TargetBuilders})
 	expectNoDiags(t, diags)
 	for _, want := range []string{
-		".references(() => parentsRT.id, {onDelete: 'cascade'}).notNull(),",
+		".references(() => cols(parentsRT).id, {onDelete: 'cascade'}).notNull(),",
 		".default(sql`now()`),",
 	} {
 		if !strings.Contains(buildersForm, want) {

--- a/ts-go-runtypes/internal/drizzlemigrate/importedits.go
+++ b/ts-go-runtypes/internal/drizzlemigrate/importedits.go
@@ -20,6 +20,9 @@ import (
 	"github.com/mionkit/ts-runtypes/internal/tsimports"
 )
 
+// drizzleRootModule is the dialect-agnostic package: where cols() comes from.
+const drizzleRootModule = "@mionjs/drizzle-orm"
+
 // toDrizzleLocal returns the local name toDrizzle is imported under for a
 // dialect, claiming it on first use. With one dialect in the file that is plain
 // `toDrizzle`; a file mixing dialects gets one binding each, since the two
@@ -45,6 +48,17 @@ func (file *fileRun) toDrizzleLocal(dialect string) string {
 	}
 	file.toDrizzleByDialect[dialect] = local
 	return local
+}
+
+// colsLocal returns the local name cols() is imported under, claiming it on
+// first use. A slim table's TYPE is its metadata, so reading a column off one
+// goes through the accessor: `index('i').on(cols(users$table).name)`.
+func (file *fileRun) colsLocal() string {
+	if file.colsBinding != "" {
+		return file.colsBinding
+	}
+	file.colsBinding = file.claim("cols")
+	return file.colsBinding
 }
 
 func (file *fileRun) ruleForDialect(dialect string) *ModuleRule {
@@ -122,6 +136,9 @@ func (file *fileRun) planImportEdits() *Diagnostic {
 		if rendered := tsimports.Render(target, "", movedByTarget[target]); rendered != "" {
 			additions = append(additions, rendered)
 		}
+	}
+	if file.colsBinding != "" {
+		additions = append(additions, tsimports.Render(drizzleRootModule, "", []tsimports.Binding{{Imported: "cols", Local: file.colsBinding}}))
 	}
 	// toDrizzle last, so the block reads recorder-first then materializer.
 	dialects := make([]string, 0, len(file.toDrizzleByDialect))

--- a/ts-go-runtypes/internal/drizzlemigrate/migrate.go
+++ b/ts-go-runtypes/internal/drizzlemigrate/migrate.go
@@ -118,6 +118,8 @@ type fileRun struct {
 	// toDrizzleByDialect is the local toDrizzle is imported under per dialect,
 	// claimed on first use.
 	toDrizzleByDialect map[string]string
+	// colsBinding is the local cols() is imported under, claimed on first use.
+	colsBinding string
 	// used records the migrated exports that actually reached a recorder.
 	used map[string]map[string]bool
 
@@ -575,6 +577,14 @@ func (file *fileRun) planReferenceEdits() {
 			continue
 		}
 		if ref.split != nil {
+			// Reading a COLUMN off a slim table goes through cols(): the table
+			// type is its metadata, so the columns are not properties of it.
+			// drizzle's suites do this for a standalone index,
+			// `index('i').on(users.name)`, which migrates to the recorder.
+			if ref.split.kind == "table" && readsColumn(ref.node) {
+				file.replaceIdentifier(ref.node, file.colsLocal()+"("+ref.split.recorder+")")
+				continue
+			}
 			file.replaceIdentifier(ref.node, ref.split.recorder)
 			continue
 		}
@@ -587,6 +597,20 @@ func (file *fileRun) planReferenceEdits() {
 			file.replaceIdentifier(ref.node, local)
 		}
 	}
+}
+
+// readsColumn reports whether an identifier is the OBJECT of a property access
+// reading something off it, other than the one real method a slim table carries.
+func readsColumn(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil || !ast.IsPropertyAccessExpression(parent) {
+		return false
+	}
+	access := parent.AsPropertyAccessExpression()
+	if access.Expression != node {
+		return false
+	}
+	return access.Name().Text() != "enableRLS"
 }
 
 // replaceIdentifier swaps one identifier, starting at its first real character —

--- a/ts-go-runtypes/internal/drizzlemigrate/migrate_test.go
+++ b/ts-go-runtypes/internal/drizzlemigrate/migrate_test.go
@@ -140,12 +140,13 @@ const posts = pgTable('posts', {authorId: uuid('author_id')}, (t) => [
 eq(users.id, 'x');
 `, `import {eq} from 'drizzle-orm';
 import {foreignKey, pgTable, uuid} from '@mionjs/drizzle-orm-pg-core';
+import {cols} from '@mionjs/drizzle-orm';
 import {toDrizzle} from '@mionjs/drizzle-orm-pg-core/drizzle';
 
 const users$table = pgTable('users', {id: uuid('id').primaryKey()});
 const users = toDrizzle(users$table);
 const posts$table = pgTable('posts', {authorId: uuid('author_id')}, (t) => [
-  foreignKey({columns: [t.authorId], foreignColumns: [users$table.id]}),
+  foreignKey({columns: [t.authorId], foreignColumns: [cols(users$table).id]}),
 ]);
 const posts = toDrizzle(posts$table);
 eq(users.id, 'x');
@@ -248,11 +249,12 @@ func TestALazyIndexDeclaredAfterItsTableStillRecords(t *testing.T) {
 const users = pgTable('users', {name: integer('name')}, () => [nameIndex]);
 const nameIndex = index('name_idx').on(users.name);
 `, `import {index, integer, pgTable} from '@mionjs/drizzle-orm-pg-core';
+import {cols} from '@mionjs/drizzle-orm';
 import {toDrizzle} from '@mionjs/drizzle-orm-pg-core/drizzle';
 
 const users$table = pgTable('users', {name: integer('name')}, () => [name$index]);
 const users = toDrizzle(users$table);
-const name$index = index('name_idx').on(users$table.name);
+const name$index = index('name_idx').on(cols(users$table).name);
 const nameIndex = toDrizzle(name$index);
 `)
 }


### PR DESCRIPTION
A slim table named its columns twice, and wrapped the half every reader uses in a symbol whose only job was to say a table lived below:

```ts
export type PgBuilderTable<TName extends string, Cols extends object, Extras extends readonly object[] = []> = Cols & {
  readonly [rtTableKey]: RtTableMetaWithExtras<TName, Cols, Extras>;
};
```

The metadata IS the table, so the type is now just that:

```ts
export interface PgTable<TName extends string, Cols extends object, Extras extends readonly object[] = []>
  extends RtTableMeta<TName, TypedCols<Cols>, Extras>, RtTableBrand<'pg'> {
  enableRLS(): PgTableWithRLS<TName, Cols, Extras>;
}
```

## What this removes

- **The intersection arm**, from five aliases and the view twin.
- **The symbol indirection**, in twelve places. `ColsOf<T>` is `T['columns']`; the bridge reads `name` / `columns` / `extras` off the graph root.
- **The two near-identical meta interfaces**, merged into one.
- **`PgTable` / `PgBuilderTable`, three times over.** ONE type per dialect, so nothing downstream has to know which road declared a table.
- **The dead intersection flattening in both graph walkers.** `membersOf` in `fromType.ts` and `properties` in `internal/convert/drizzle.go` flattened arms because a table used to be `Cols & {meta}`. Probed by making each branch throw: 243 unit tests, a wide `drizzletypes` fuzz and all 228 tables of drizzle's own suites never reach either. Gone, with `reflectedKinds.intersection`, `RtTable`, `RtView` and the three `*BuilderTable` aliases.

## What it adds

The brand is what marks a table in the reflected graph, and it carries the dialect. That closes a real hole: all three dialects' `toDrizzle` took the same dialect-blind `AnyRtTable`, so this compiled and died at run time.

```ts
import {toDrizzle} from '@mionjs/drizzle-orm-mysql-core/drizzle';
toDrizzle(somePgTable);   // was: TypeError: dzMy.pgTable is not a function
```

Materialization replays the table's own captured `buildTable` against whatever context it is handed, so a pg table run through mysql reached for `context.ns.pgTable` and found nothing. Now a compile error, pinned per dialect.

## Breaking

A cross-table reference reaches the columns through `cols()`, identity at run time:

```ts
teamId: integer('team_id').references(() => cols(teams).id, {onDelete: 'cascade'})
```

`ts-runtypes drizzle-migrate` and `convert --to builders` emit this spelling and claim the import. Also worth knowing: `name`, `columns` and `extras` are plain keys on the table type now, so on a table with a column called `name`, `table.name` is the table's DB name and `cols(table).name` is the column.

## Verification

All five drizzle-e2e lanes green against real databases. Each asserts parity with drizzle's untranslated control on every vendored test, no new type errors on either road, and full manifest coverage.

| Lane | control | translated | type road |
| --- | --- | --- | --- |
| pg | 183 passed | 191 passed | 191 passed |
| mysql | 177 passed, 1 fail | 181 passed, 1 fail | 181 passed, 1 fail |
| sqlite | 132 passed, 4 fail | 137 passed, 4 fail | 137 passed, 4 fail |
| d1 | 127 passed, 9 fail | 127 passed, 9 fail | 127 passed, 9 fail |
| durable | green | green | green |

The failures are drizzle's own, present on the untranslated control. The extra counts are each lane's addendum.

Also: 1067 JS tests, the full Go suite, lint, format, and `drizzle-translate` converting all 228 tables on both roads with no new type errors.

## Budgets

Five rise by 1-10, reviewed, with one note in the suite that owns them. The builder road now runs its columns through `TypedCols` (a wholesale pass-through) because there is one table type instead of two; the type road got slightly cheaper. Taken deliberately: two shapes for the same table cost more in complexity than the instantiations are worth. `packages/drizzle-orm/TYPE-COST.md` records the measurements, including that the shape itself is a wash rather than the saving an early spike predicted.

Implements `docs/done/drizzle-bare-meta-table-type.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYMwe4gorTwkiUSh3JhYQJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYMwe4gorTwkiUSh3JhYQJ)_