### PR TITLE
fix(runtypes): guard the unknown-keys descent against non-conforming values

### DIFF
--- a/container/website/sites/runtypes/content/02.guide/03.validation.md
+++ b/container/website/sites/runtypes/content/02.guide/03.validation.md
@@ -72,6 +72,8 @@ Three tools for properties that aren't in your declared type. These check for *e
 | `createCloneExactShapeFn` | A proper deep clone of the declared shape: undeclared keys are dropped by construction, the input is never mutated, and `clone(x) !== x` for every object-typed value (a class keeps its prototype; only primitives and opaque handles pass through). |
 | `createUnknownKeyErrorsFn` | One `{path, expected: 'never'}` per undeclared key, the same shape as `createGetValidationErrorsFn`. |
 
+All three look at keys, never at shape. When the value is not an object of the declared type (null, a primitive, an array, or the wrong thing nested inside), there are no undeclared keys to report, so `createUnknownKeyErrorsFn` returns an empty list and `createHasUnknownKeysFn` returns false. Shape is what `createGetValidationErrorsFn` reports, so joining the two lists gives you one strict report with the shape named exactly once.
+
 <code-import path="packages/examples/src/guide/unknown-keys-has.ts" lang="ts" />
 
 After `validate`, opt the predicate into the key-count fast path. It applies at every depth, so nested objects get it too, whether they are written inline or named as their own type:

--- a/docs/done/unknownkeyerrors-no-object-guard.md
+++ b/docs/done/unknownkeyerrors-no-object-guard.md
@@ -1,0 +1,173 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-08-31
+---
+
+# createUnknownKeyErrorsFn throws on null and invents keys on a primitive
+
+## Intent
+
+`createUnknownKeyErrorsFn<T>()` descends into `T`'s declared properties with no
+object guard at the root. Given anything that is not a non-null object it either
+throws or fabricates entries:
+
+```ts
+type Address = {street: string; city: string};
+type Person = {name: string; age: number; address: Address};
+const keyErrors = createUnknownKeyErrorsFn<Person>();
+
+keyErrors(null);        // TypeError: Cannot read properties of null (reading 'address')
+keyErrors(undefined);   // TypeError: Cannot read properties of undefined (reading 'address')
+keyErrors('a string');  // 8 entries: {path:['0'],expected:'never'} … {path:['7'],expected:'never'}
+```
+
+The string case is the nastier one: it returns confidently wrong data rather than
+failing, one bogus `{expected: 'never'}` per character index.
+
+`createHasUnknownKeysFn` does not have this problem, and neither does the fused
+`{checkUnknowns: true}` validator (its key check sits inside the object guard's
+`else`), so this is specific to the `unknownKeyErrors` (`uke`) family.
+
+## Evidence
+
+Found while building the `checkUnknowns` fused validators. The parity test there
+compares the fused report against `[...typeErrors(v), ...keyErrors(v)]`, and the
+composition blew up on exactly these inputs while the fused family returned the
+correct `[{path: [], expected: 'objectLiteral'}]`. The test now restricts its
+oracle to guard-admitted values and says why, so it will keep passing after this
+fix; see `packages/ts-runtypes/test/features/checkUnknowns.test.ts`, the
+"parity with the two-call composition" suite.
+
+The crash is in the CHILD descent, `unknownKeysChildrenCode` (reached from
+`emitObjectUnknownKeyErrors`,
+`ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_errors.go`), which
+emits `v.address`-style property reads with nothing above them asserting `v` is an
+object. Compare `emitObjectValidationErrors`
+(`typefunctions/validationerrors.go`), which wraps the whole child body in
+`if (!(typeof v === 'object' && v !== null)) {...} else {...}`.
+
+Pre-existing, not introduced by the `checkUnknowns` work: the only edit that
+landed in `unknownkeys_errors.go` there was extracting the PARENT-level block into
+`emitParentUnknownKeyErrors`, which is behaviour-identical and does not touch the
+child path.
+
+## Direction
+
+The implementer plans it. The open question worth settling first is what the
+family should DO for a guard-rejected value, because there is a real choice:
+
+- Return `[]` (nothing was undeclared, because nothing is there). Simple, and
+  consistent with `createHasUnknownKeysFn` returning false.
+- Return a single shape error, matching what the fused family reports.
+
+Prefer whichever keeps `uke` composable with `verr`, since concatenating the two
+is the documented way to build a strict report today.
+
+Note this family sits in the same "caller promises a validated value" tradition as
+`hasUnknownKeys`'s `runsAfterValidation`, so an alternative reading is that the
+input is simply out of contract. Even then, silently returning per-character
+entries is not an acceptable failure mode; pick a defined answer.
+
+## Done when
+
+`keyErrors(null)`, `keyErrors(undefined)`, `keyErrors('a string')` and
+`keyErrors(42)` all return the chosen defined result and never throw; a test pins
+each; the choice is reflected in the `createUnknownKeyErrorsFn` doc comment in
+`packages/ts-runtypes/src/createRTFunctions.ts`; `pnpm test` and
+`go -C ts-go-runtypes test ./internal/...` green.
+
+---
+
+## What shipped (2026-08-31)
+
+### The decision the spec left open
+
+**A guard-rejected value yields the family's NEUTRAL answer: `unknownKeyErrors`
+returns `[]`, `hasUnknownKeys` returns `false`.** Not a shape error.
+
+The reason is the composition the spec asked to protect. `getValidationErrors`
+already reports the shape, so a shape error from `unknownKeyErrors` would make
+the documented strict report name it twice:
+
+```ts
+// null, with uke returning a shape error:  DUPLICATED
+[...typeErrors(null), ...keyErrors(null)];
+// [{path: [], expected: 'objectLiteral'}, {path: [], expected: 'objectLiteral'}]
+
+// null, with uke returning []:  what shipped
+[...typeErrors(null), ...keyErrors(null)];
+// [{path: [], expected: 'objectLiteral'}]
+```
+
+Returning `[]` also lines the family up with `hasUnknownKeys` returning `false`,
+and states the honest thing: this family answers "which keys are undeclared",
+and a value that is not the declared shape has none.
+
+### The bug was wider than the spec knew
+
+Two claims in the Intent section above did not survive contact with the code:
+
+- **`createHasUnknownKeysFn` has the SAME bug.** Its parent key scan is guarded,
+  but the `||` chain does not short-circuit the CHILD descent away, so
+  `has(null)` on a shape with a nested object still read `v.address` and threw.
+- **It is not only the object node.** Every composite descent was unguarded:
+  an array root read `null.length`, a tuple root read `null[0]`, and a Map / Set
+  root bailed with a bare `return`, which — inlined into the parent closure —
+  abandoned the whole walk and handed back `undefined` where the contract
+  promises an array.
+
+All of it is one defect (the unknown-keys descent assumes a shape nothing
+asserts) on one code path, so all of it is fixed here.
+
+### The fix
+
+Every composite unknown-keys node renders its body under a shape guard, the
+same predicate the merged-union emit already used:
+
+```go
+// object node                                    array / tuple node
+typeof v === 'object' && v !== null            Array.isArray(v)
+  && !Array.isArray(v)
+```
+
+Touched, all in `ts-go-runtypes/internal/cachegen/typefunctions/`:
+
+- `unknownkeys_shared.go` — the two guard helpers plus `guardStatement`; tuple
+  descent guarded.
+- `unknownkeys_errors.go` — object node guarded; Map / Set bail turned into a
+  positive wrap so the errors array is always returned.
+- `unknownkeys_arms.go` — array element descent guarded.
+- `unknownkeys_has.go` — the whole `||` chain guarded, and the parent scan's own
+  now-redundant copy of the guard dropped.
+
+`hasUnknownKeys`'s `runsAfterValidation` variant stays guardless: its contract is
+that the caller already validated the value, and that is the point of the option.
+
+### Tests
+
+- `packages/ts-runtypes/test/features/unknownKeys.test.ts` — behaviour: every
+  rejected value across both families, at the root and nested, on object / array
+  / tuple / Map / Set / index-signature roots; that real unknown keys are still
+  reported at both depths; that the strict report never double-names the shape;
+  and both factory call shapes (static and value-first).
+- `ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_guard_test.go` —
+  the guard is present in the emitted source and opens the body, so a key scan
+  can never run ahead of it.
+
+### Docs
+
+- `createUnknownKeyErrorsFn`'s doc comment in
+  `packages/ts-runtypes/src/createRTFunctions.ts` states the keys-only contract.
+- `container/website/sites/runtypes/content/02.guide/03.validation.md` and the
+  `packages/examples/src/guide/unknown-keys-errors.ts` example say the same for
+  readers, and show the two lists being joined.
+
+### Not done here
+
+The parity suite the spec points at (`test/features/checkUnknowns.test.ts`) does
+not exist on `main`; it belongs to the unmerged `checkUnknowns` work. Widening
+its oracle back out is that branch's to do, and the fix here is what makes it
+possible.
+

--- a/packages/examples/src/guide/unknown-keys-errors.ts
+++ b/packages/examples/src/guide/unknown-keys-errors.ts
@@ -1,4 +1,4 @@
-import {createUnknownKeyErrorsFn} from '@ts-runtypes/core';
+import {createGetValidationErrorsFn, createUnknownKeyErrorsFn} from '@ts-runtypes/core';
 
 type User = {id: number; name: string};
 
@@ -9,4 +9,12 @@ unknownKeyErrors({id: 1, name: 'Ada'}); // []
 unknownKeyErrors({id: 1, name: 'Ada', admin: true});
 // [{path: ['admin'], expected: 'never'}]
 
-export {unknownKeyErrors};
+// Keys only, never shape: a value that is not a User has no undeclared keys.
+unknownKeyErrors(null as unknown as User); // []
+unknownKeyErrors('not a user' as unknown as User); // []
+
+// Join it with the type errors for one strict report.
+const typeErrors = createGetValidationErrorsFn<User>();
+const strictErrors = (value: User) => [...typeErrors(value), ...unknownKeyErrors(value)];
+
+export {unknownKeyErrors, strictErrors};

--- a/packages/ts-runtypes/src/createRTFunctions.ts
+++ b/packages/ts-runtypes/src/createRTFunctions.ts
@@ -160,7 +160,19 @@ export type HasUnknownKeysFn = (value: unknown, options?: HasUnknownKeysOptions)
 export type CloneExactShapeFn<T = unknown> = (value: T) => T;
 
 /** Validator returned by `createUnknownKeyErrorsFn<T>()`. Each unknown key
- *  produces one `{path, expected: 'never'}` entry. **/
+ *  produces one `{path, expected: 'never'}` entry.
+ *
+ *  Reports UNDECLARED KEYS ONLY, never shape. A value the schema does not
+ *  admit at all — `null`, `undefined`, a primitive, an array where an object
+ *  is declared, and the same at any nested position — has no undeclared keys
+ *  to report, so it yields `[]` rather than throwing or inventing one entry
+ *  per character / index. `createHasUnknownKeysFn` answers `false` on the
+ *  same values. Shape is `createGetValidationErrorsFn`'s job, which is what
+ *  lets the two compose into a strict report —
+ *  `[...typeErrors(v), ...keyErrors(v)]` — with the shape reported exactly
+ *  once. (The one exception is `createHasUnknownKeysFn`'s
+ *  `runsAfterValidation` option, whose contract is that the caller already
+ *  validated the value; it drops the guards deliberately.) **/
 export type UnknownKeyErrorsFn = (
   value: unknown,
   path?: RTValidationErrorPathSegment[],

--- a/packages/ts-runtypes/test/features/unknownKeys.test.ts
+++ b/packages/ts-runtypes/test/features/unknownKeys.test.ts
@@ -8,7 +8,14 @@
 // test/suites/cloning/.
 
 import {describe, expect, it} from 'vitest';
-import {createHasUnknownKeysFn, createUnknownKeyErrorsFn, createValidateFn, getFnHash} from '@ts-runtypes/core';
+import {
+  createGetValidationErrorsFn,
+  createHasUnknownKeysFn,
+  createUnknownKeyErrorsFn,
+  createValidateFn,
+  getFnHash,
+  getRunType,
+} from '@ts-runtypes/core';
 
 describe('hasUnknownKeys', () => {
   it('returns false when the value matches the schema', () => {
@@ -317,5 +324,161 @@ describe('iterables — Set<T> unknown-keys', () => {
     expect(out).toHaveLength(1);
     expect(out[0].expected).toBe('never');
     expect(out[0].path).toContain('extra');
+  });
+});
+
+// A value that is not the shape the schema declares carries no "declared vs
+// undeclared key" question at all, so both families answer NEUTRALLY: no
+// errors from unknownKeyErrors, false from hasUnknownKeys. Reporting the
+// shape is getValidationErrors' job. That split is what keeps the documented
+// strict report — `[...verr(v), ...uke(v)]` — carrying exactly ONE shape
+// error instead of a duplicate pair.
+//
+// Before the guard landed, the descent ran anyway: it read `v.address`
+// against null (a TypeError), and `for (const k in v)` over a string or an
+// array yielded one bogus `{expected: 'never'}` entry per character / index.
+describe('unknown keys on a value the schema does not admit', () => {
+  interface Nested {
+    street: string;
+    city: string;
+  }
+  interface Shape {
+    name: string;
+    age: number;
+    address: Nested;
+  }
+
+  const notObjects: [string, unknown][] = [
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'a string'],
+    ['a number', 42],
+    ['a boolean', true],
+    ['an array', [1, 2, 3]],
+  ];
+
+  describe.each(notObjects)('%s', (_label, value) => {
+    it('unknownKeyErrors returns an empty array and never throws', () => {
+      const keyErrors = createUnknownKeyErrorsFn<Shape>();
+      expect(keyErrors(value as never)).toEqual([]);
+    });
+
+    it('hasUnknownKeys returns false and never throws', () => {
+      const has = createHasUnknownKeysFn<Shape>();
+      expect(has(value)).toBe(false);
+    });
+
+    it('the strict report says only what getValidationErrors says', () => {
+      // uke adds nothing, so concatenating the two never double-reports the
+      // shape. (An array IS an object, so getValidationErrors descends into
+      // it and reports the missing props rather than one root error — either
+      // way the composition is exactly its own output.)
+      const typeErrors = createGetValidationErrorsFn<Shape>();
+      const keyErrors = createUnknownKeyErrorsFn<Shape>();
+      expect([...typeErrors(value as never), ...keyErrors(value as never)]).toEqual(typeErrors(value as never));
+    });
+  });
+
+  it('a non-object root reports one shape error and nothing else', () => {
+    const typeErrors = createGetValidationErrorsFn<Shape>();
+    const keyErrors = createUnknownKeyErrorsFn<Shape>();
+    for (const value of [null, undefined, 'a string', 42, true]) {
+      expect([...typeErrors(value as never), ...keyErrors(value as never)]).toEqual([{path: [], expected: 'objectLiteral'}]);
+    }
+  });
+
+  it('guards a NESTED position too, not just the root', () => {
+    const keyErrors = createUnknownKeyErrorsFn<Shape>();
+    const has = createHasUnknownKeysFn<Shape>();
+    for (const address of ['oops', null, 42]) {
+      const value = {name: 'jane', age: 1, address};
+      expect(keyErrors(value as never)).toEqual([]);
+      expect(has(value)).toBe(false);
+    }
+  });
+
+  it('still reports real unknown keys at both depths', () => {
+    const keyErrors = createUnknownKeyErrorsFn<Shape>();
+    const has = createHasUnknownKeysFn<Shape>();
+    const good = {name: 'jane', age: 1, address: {street: '10', city: 'sf'}};
+    expect(keyErrors(good as never)).toEqual([]);
+    expect(has(good)).toBe(false);
+    expect(keyErrors({...good, extra: 1} as never)).toEqual([{path: ['extra'], expected: 'never'}]);
+    expect(has({...good, extra: 1})).toBe(true);
+    const dirtyNested = {...good, address: {street: '10', city: 'sf', zip: 9}};
+    expect(keyErrors(dirtyNested as never)).toEqual([{path: ['address', 'zip'], expected: 'never'}]);
+    expect(has(dirtyNested)).toBe(true);
+  });
+
+  // Both call shapes of the factory (static `<T>()` and value-first, passing
+  // the RunType handle) resolve to the same compiled entry, so the guard has
+  // to hold for both.
+  it('(static form) answers []/false on a rejected value', () => {
+    const keyErrors = createUnknownKeyErrorsFn<Shape>();
+    const has = createHasUnknownKeysFn<Shape>();
+    expect(keyErrors(null as never)).toEqual([]);
+    expect(has(null)).toBe(false);
+  });
+
+  it('(value-first form) answers []/false on a rejected value', () => {
+    const keyErrors = createUnknownKeyErrorsFn(getRunType<Shape>());
+    const has = createHasUnknownKeysFn(getRunType<Shape>());
+    expect(keyErrors(null as never)).toEqual([]);
+    expect(has(null)).toBe(false);
+  });
+});
+
+// Container roots read `v.length`, `v[0]` or iterate the value, all of which
+// throw on null/undefined. A Map / Set root additionally used to bail with a
+// bare `return`, which — inlined into the parent closure — abandoned the whole
+// walk and handed back `undefined` where the contract promises an array.
+describe('unknown keys on a container root the value does not match', () => {
+  interface Item {
+    a: string;
+    nested: {b: string};
+  }
+
+  const rejected: unknown[] = [null, undefined, 'a string', 42];
+
+  it('array root', () => {
+    const keyErrors = createUnknownKeyErrorsFn<Item[]>();
+    const has = createHasUnknownKeysFn<Item[]>();
+    for (const value of rejected) {
+      expect(keyErrors(value as never)).toEqual([]);
+      expect(has(value)).toBe(false);
+    }
+    expect(keyErrors([{a: 'x', nested: {b: 'y'}, extra: 1}] as never)).toEqual([{path: [0, 'extra'], expected: 'never'}]);
+  });
+
+  it('tuple root', () => {
+    const keyErrors = createUnknownKeyErrorsFn<[Item, Item]>();
+    const has = createHasUnknownKeysFn<[Item, Item]>();
+    for (const value of rejected) {
+      expect(keyErrors(value as never)).toEqual([]);
+      expect(has(value)).toBe(false);
+    }
+  });
+
+  it('Map root returns the errors array, not undefined', () => {
+    const keyErrors = createUnknownKeyErrorsFn<Map<string, Item>>();
+    for (const value of rejected) {
+      expect(keyErrors(value as never)).toEqual([]);
+    }
+  });
+
+  it('Set root returns the errors array, not undefined', () => {
+    const keyErrors = createUnknownKeyErrorsFn<Set<Item>>();
+    for (const value of rejected) {
+      expect(keyErrors(value as never)).toEqual([]);
+    }
+  });
+
+  it('index-signature root', () => {
+    const keyErrors = createUnknownKeyErrorsFn<Record<string, Item>>();
+    const has = createHasUnknownKeysFn<Record<string, Item>>();
+    for (const value of rejected) {
+      expect(keyErrors(value as never)).toEqual([]);
+      expect(has(value)).toBe(false);
+    }
   });
 });

--- a/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_arms.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_arms.go
@@ -81,7 +81,10 @@ func emitArrayUnknownKeys(rt *reflection.RunType, ctx *EmitContext, trackPath bo
 	if childRT.Code == "" {
 		return RTCode{Code: "", Type: CodeS}
 	}
-	body := "for (let " + iVar + " = 0; " + iVar + " < " + v + ".length; " + iVar + "++) {" + childRT.Code + "}"
+	// `v.length` throws on null/undefined and walks a string's characters,
+	// so the element descent runs only over a real array.
+	body := guardStatement(unknownKeysArrayGuard(v),
+		"for (let "+iVar+" = 0; "+iVar+" < "+v+".length; "+iVar+"++) {"+childRT.Code+"}")
 	return RTCode{Code: body, Type: CodeS}
 }
 

--- a/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_errors.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_errors.go
@@ -121,7 +121,11 @@ func emitObjectUnknownKeyErrors(rt *reflection.RunType, ctx *EmitContext) RTCode
 	if combined == "" {
 		return RTCode{Code: "", Type: CodeS}
 	}
-	return RTCode{Code: combined, Type: CodeS}
+	// Nothing above this point asserts `v` is an object, and both halves of
+	// the body assume it is: the parent scan walks `for (const k in v)` and
+	// the child descent reads `v.address`. See unknownKeysObjectGuard.
+	body := guardStatement(unknownKeysObjectGuard(ctx.Vλl), combined)
+	return RTCode{Code: body, Type: CodeS}
 }
 
 // emitIndexSignatureUnknownKeyErrors ports
@@ -238,7 +242,11 @@ func emitMapUnknownKeyErrors(rt *reflection.RunType, ctx *EmitContext, v string)
 	}
 	inner.WriteString(idxVar)
 	inner.WriteString("++;}")
-	body := "if (!(" + v + " instanceof Map)) return;" + inner.String()
+	// A positive wrap, not `if (!(v instanceof Map)) return;`: this body is
+	// inlined into the parent closure, so a bare return abandons the whole
+	// walk and hands back `undefined` where the contract promises the errors
+	// array.
+	body := guardStatement(v+" instanceof Map", inner.String())
 	return RTCode{Code: body, Type: CodeS}
 }
 
@@ -268,9 +276,10 @@ func emitSetUnknownKeyErrors(rt *reflection.RunType, ctx *EmitContext, v string)
 	if last := itemRT.Code[len(itemRT.Code)-1]; last != ';' && last != '}' {
 		sep = ";"
 	}
-	body := "if (!(" + v + " instanceof Set)) return;" +
-		"let " + idxVar + " = 0; for (const " + itemVar + " of " + v + ") {" +
-		itemRT.Code + sep + idxVar + "++;}"
+	// Positive wrap — see emitMapUnknownKeyErrors.
+	body := guardStatement(v+" instanceof Set",
+		"let "+idxVar+" = 0; for (const "+itemVar+" of "+v+") {"+
+			itemRT.Code+sep+idxVar+"++;}")
 	return RTCode{Code: body, Type: CodeS}
 }
 

--- a/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_guard_test.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_guard_test.go
@@ -1,0 +1,125 @@
+package typefunctions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mionkit/ts-runtypes/internal/cachegen/operations"
+	"github.com/mionkit/ts-runtypes/internal/protocol"
+	"github.com/mionkit/ts-runtypes/internal/reflection"
+)
+
+// The unknown-keys descent assumes the value has the shape the schema
+// declares: it reads `v.address` and walks `for (const k in v)`. Neither is
+// meaningful otherwise — against null it throws, and over a string or an array
+// it invents one entry per character / index. So every composite node renders
+// its body under a shape guard, and the family answers neutrally when the
+// guard rejects. These tests pin the guard in the emitted source; the
+// behaviour it buys is pinned end-to-end in
+// packages/ts-runtypes/test/features/unknownKeys.test.ts.
+
+// ukeKey returns the plain unknownKeyErrors cache key for a type id.
+func ukeKey(id string) string { return operations.PlainHash("unknownKeyErrors") + "_" + id }
+
+// renderUkeToString collects the unknownKeyErrors family for a dump.
+func renderUkeToString(t *testing.T, dump protocol.Dump) string {
+	t.Helper()
+	return joinEntries(t, FamilyByKey("unknownKeyErrors").Collect(dump, RenderOpts{EmitMode: "both"}, nil))
+}
+
+// ukeSite builds one createUnknownKeyErrorsFn call site.
+func ukeSite(pos int, id string) protocol.Site {
+	return protocol.Site{File: "call.ts", Pos: pos, ID: id, Demand: []protocol.SiteDemand{{FamilyTag: "uke"}}}
+}
+
+// buildGuardFixture is `type Inline = {inner: {a: string; b: string}}` plus an
+// array and a tuple over the same object, so one dump covers every composite
+// node kind the guard touches.
+func buildGuardFixture() []*reflection.RunType {
+	tuplePos := 0
+	return []*reflection.RunType{
+		{ID: "str", Kind: reflection.KindString},
+		{ID: "pa", Kind: reflection.KindProperty, Name: "a", IsSafeName: true, Child: makeRef("str")},
+		{ID: "pb", Kind: reflection.KindProperty, Name: "b", IsSafeName: true, Child: makeRef("str")},
+		{ID: "anon", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("pa"), makeRef("pb")}},
+		{ID: "panon", Kind: reflection.KindProperty, Name: "inner", IsSafeName: true, Child: makeRef("anon")},
+		{ID: "inline", Kind: reflection.KindObjectLiteral, TypeName: "Inline", Children: []*reflection.RunType{makeRef("panon")}},
+		{ID: "arr", Kind: reflection.KindArray, TypeName: "Arr", Child: makeRef("anon")},
+		{ID: "tm0", Kind: reflection.KindTupleMember, Position: &tuplePos, Child: makeRef("anon")},
+		{ID: "tup", Kind: reflection.KindTuple, TypeName: "Tup", Children: []*reflection.RunType{makeRef("tm0")}},
+	}
+}
+
+// TestUnknownKeyErrors_ObjectNodeCarriesShapeGuard — the object body runs only
+// for a non-null, non-array object, at the root AND at the inlined child.
+func TestUnknownKeyErrors_ObjectNodeCarriesShapeGuard(t *testing.T) {
+	dump := protocol.Dump{RunTypes: buildGuardFixture(), Sites: []protocol.Site{ukeSite(0, "inline")}}
+	out := renderUkeToString(t, dump)
+
+	line := extractInitLine(out, ukeKey("inline"))
+	if line == "" {
+		t.Fatalf("no unknownKeyErrors entry in:\n%s", out)
+	}
+	// Two object nodes (root + inlined child) → two guards.
+	if got := strings.Count(line, "!== null && !Array.isArray("); got < 2 {
+		t.Errorf("expected a shape guard at both object depths, got %d in:\n%s", got, line)
+	}
+	// The guard must be the FIRST thing the body does — a key scan ahead of
+	// it would already have walked a string's character indices.
+	if !strings.HasPrefix(bodyAfter(line, "(v,pth=[],er=[]){"), "if (typeof v === ") {
+		t.Errorf("the shape guard must open the body, got:\n%s", line)
+	}
+}
+
+// TestUnknownKeyErrors_ContainerRootsCarryShapeGuard — an array or tuple root
+// reads `v.length` / `v[0]`, so its descent is guarded by Array.isArray.
+func TestUnknownKeyErrors_ContainerRootsCarryShapeGuard(t *testing.T) {
+	dump := protocol.Dump{
+		RunTypes: buildGuardFixture(),
+		Sites:    []protocol.Site{ukeSite(0, "arr"), ukeSite(40, "tup")},
+	}
+	out := renderUkeToString(t, dump)
+
+	for _, id := range []string{"arr", "tup"} {
+		line := extractInitLine(out, ukeKey(id))
+		if line == "" {
+			t.Fatalf("no unknownKeyErrors entry for %q in:\n%s", id, out)
+		}
+		if !strings.Contains(line, "Array.isArray(v)") {
+			t.Errorf("%q root must guard its element descent with Array.isArray, got:\n%s", id, line)
+		}
+	}
+}
+
+// TestHasUnknownKeys_ObjectNodeCarriesShapeGuard — the `||` chain does not
+// short-circuit the child descent away, so the plain predicate guards the whole
+// chain. The runsAfterValidation variant stays guardless by contract (pinned in
+// unknownkeys_has_variant_test.go).
+func TestHasUnknownKeys_ObjectNodeCarriesShapeGuard(t *testing.T) {
+	dump := protocol.Dump{RunTypes: buildGuardFixture(), Sites: []protocol.Site{hukSite(0, "inline", nil)}}
+	out := renderHukToString(t, dump)
+
+	line := extractInitLine(out, hukKey("inline"))
+	if line == "" {
+		t.Fatalf("no hasUnknownKeys entry in:\n%s", out)
+	}
+	if got := strings.Count(line, "!== null && !Array.isArray("); got < 2 {
+		t.Errorf("expected a shape guard at both object depths, got %d in:\n%s", got, line)
+	}
+	// The guard opens the chain, so `v.inner` is never read against null.
+	if !strings.HasPrefix(bodyAfter(line, "(v,opts={}){"), "return (typeof v === ") {
+		t.Errorf("the shape guard must open the OR chain, got:\n%s", line)
+	}
+}
+
+// bodyAfter returns what a rendered entry line holds right after `marker`, the
+// closure's own argument list — everything before it is the shared prologue.
+// The body arrives as a JS string literal, so its quotes are backslash-escaped;
+// callers match on the quote-free part of a snippet.
+func bodyAfter(line, marker string) string {
+	idx := strings.Index(line, marker)
+	if idx < 0 {
+		return ""
+	}
+	return line[idx+len(marker):]
+}

--- a/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_has.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_has.go
@@ -170,7 +170,9 @@ func emitInterfaceHasUnknownKeys(rt *reflection.RunType, ctx *EmitContext) RTCod
 				parentExpr = callCheckUnknownPropertiesForHas(rt, ctx, false, false)
 			}
 		} else {
-			parentExpr = callCheckUnknownPropertiesForHas(rt, ctx, false, true)
+			// The shape guard now sits around the WHOLE chain below, so the
+			// parent scan no longer carries its own copy.
+			parentExpr = callCheckUnknownPropertiesForHas(rt, ctx, false, false)
 		}
 	}
 	expressions := []string{}
@@ -181,7 +183,15 @@ func emitInterfaceHasUnknownKeys(rt *reflection.RunType, ctx *EmitContext) RTCod
 	if len(expressions) == 0 {
 		return RTCode{Code: "", Type: CodeE}
 	}
-	return RTCode{Code: joinOr(expressions), Type: CodeE}
+	chain := joinOr(expressions)
+	// The `||` chain does NOT short-circuit away the child descent when the
+	// parent scan says false, so `v.address` still gets read — against null
+	// that throws. Under runsAfterValidation the caller has already promised
+	// a validated value, and that variant is guardless by contract.
+	if ctx.HasVariantOption("runsAfterValidation") {
+		return RTCode{Code: chain, Type: CodeE}
+	}
+	return RTCode{Code: "(" + unknownKeysObjectGuard(ctx.Vλl) + " && " + chain + ")", Type: CodeE}
 }
 
 // emitPropertyHasUnknownKeys handles KindProperty / KindPropertySignature.
@@ -275,7 +285,8 @@ func emitTupleHasUnknownKeys(rt *reflection.RunType, ctx *EmitContext) RTCode {
 	if len(parts) == 0 {
 		return RTCode{Code: "", Type: CodeE}
 	}
-	return RTCode{Code: joinOr(parts), Type: CodeE}
+	// Member accessors are `v[0]`, `v[1]`, … — unreadable on null/undefined.
+	return RTCode{Code: "(" + unknownKeysArrayGuard(ctx.Vλl) + " && " + joinOr(parts) + ")", Type: CodeE}
 }
 
 // emitTupleMemberHasUnknownKeys: descend into the wrapped child. Rest

--- a/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_shared.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_shared.go
@@ -345,6 +345,32 @@ func joinOr(parts []string) string {
 	return "(" + strings.Join(parts, " || ") + ")"
 }
 
+// unknownKeysObjectGuard is the shape precondition every OBJECT-node
+// unknown-keys emit runs under. A key scan only means "declared vs
+// undeclared" when the value actually is a plain object: on anything else
+// the descent either throws (`v.address` against null/undefined) or invents
+// keys, because `for (const k in v)` walks a string's character indices and
+// an array's element indices. Guarded out, the node contributes nothing and
+// the family reports its neutral answer — no errors for unknownKeyErrors,
+// false for hasUnknownKeys. Reporting the SHAPE is validationErrors' job,
+// which is what keeps the documented `[...verr(v), ...uke(v)]` report free
+// of duplicate shape errors. Same predicate the merged-union emit already
+// gates on (emitUnionUnknownKeysMerged).
+func unknownKeysObjectGuard(v string) string {
+	return "typeof " + v + " === 'object' && " + v + " !== null && !Array.isArray(" + v + ")"
+}
+
+// unknownKeysArrayGuard is the same precondition for an ARRAY / TUPLE node,
+// whose descent reads `v.length` and `v[i]`.
+func unknownKeysArrayGuard(v string) string {
+	return "Array.isArray(" + v + ")"
+}
+
+// guardStatement wraps a statement-shaped body in a shape guard.
+func guardStatement(guard, body string) string {
+	return "if (" + guard + ") {" + body + "}"
+}
+
 // trimWhitespace removes leading + trailing whitespace and the trailing
 // semicolon. Used inside Finalize-detection helpers to recognise
 // "essentially empty" bodies.
@@ -678,5 +704,6 @@ func emitTupleUnknownKeysRecurse(rt *reflection.RunType, ctx *EmitContext) RTCod
 	if len(parts) == 0 {
 		return RTCode{Code: "", Type: CodeS}
 	}
-	return RTCode{Code: strings.Join(parts, ";"), Type: CodeS}
+	body := guardStatement(unknownKeysArrayGuard(ctx.Vλl), strings.Join(parts, ";"))
+	return RTCode{Code: body, Type: CodeS}
 }


### PR DESCRIPTION
Implements `docs/todos/unknownkeyerrors-no-object-guard.md` (moved to `docs/done/`).

## The bug

The unknown-keys emitters descended into a value's declared properties with nothing asserting the value actually had that shape:

```ts
type Address = {street: string; city: string};
type Person = {name: string; age: number; address: Address};
const keyErrors = createUnknownKeyErrorsFn<Person>();

keyErrors(null);       // TypeError: Cannot read properties of null (reading 'address')
keyErrors('a string'); // 8 entries: {path:['0'],expected:'never'} … {path:['7'],expected:'never'}
```

The string case is the nastier one: confidently wrong data rather than a failure, one bogus `{expected: 'never'}` per character index.

## Two things the spec did not know

- **`createHasUnknownKeysFn` has the same bug.** Its parent key scan was guarded, but the `||` chain does not short-circuit the child descent away, so `has(null)` on a shape with a nested object still read `v.address` and threw.
- **It is not only the object node.** Every composite descent was unguarded: an array root read `null.length`, a tuple root read `null[0]`, and a Map / Set root bailed with a bare `return`, which (inlined into the parent closure) abandoned the whole walk and returned `undefined` where the contract promises an array.

One defect on one code path, so it is all fixed here.

## The decision the spec left open

A guard-rejected value gets the family's **neutral** answer: `unknownKeyErrors` returns `[]`, `hasUnknownKeys` returns `false`. Not a shape error.

The spec asked to prefer whatever keeps `uke` composable with `verr`, and that settles it. `getValidationErrors` already reports the shape, so a shape error from `unknownKeyErrors` would make the documented strict report name it twice:

```ts
// with uke returning a shape error:  DUPLICATED
[...typeErrors(null), ...keyErrors(null)];
// [{path: [], expected: 'objectLiteral'}, {path: [], expected: 'objectLiteral'}]

// with uke returning []:  what shipped
[...typeErrors(null), ...keyErrors(null)];
// [{path: [], expected: 'objectLiteral'}]
```

It also lines up with `hasUnknownKeys` returning `false`, and states the honest thing: this family answers "which keys are undeclared", and a value that is not the declared shape has none.

## The fix

Every composite node renders its body under a shape guard, the same predicate the merged-union emit already used:

```
object node                                array / tuple node
typeof v === 'object' && v !== null        Array.isArray(v)
  && !Array.isArray(v)
```

Under `ts-go-runtypes/internal/cachegen/typefunctions/`:

- `unknownkeys_shared.go` — the two guard helpers plus `guardStatement`; tuple descent guarded.
- `unknownkeys_errors.go` — object node guarded; Map / Set bail turned into a positive wrap so the errors array is always returned.
- `unknownkeys_arms.go` — array element descent guarded.
- `unknownkeys_has.go` — the whole `||` chain guarded, and the parent scan's now-redundant copy of the guard dropped.

`hasUnknownKeys`'s `runsAfterValidation` variant stays guardless: its contract is that the caller already validated the value, and that is the point of the option.

## Tests

- `packages/ts-runtypes/test/features/unknownKeys.test.ts` — every rejected value across both families, at the root and nested, on object / array / tuple / Map / Set / index-signature roots; that real unknown keys are still reported at both depths; that the strict report never double-names the shape; and both factory call shapes (static and value-first).
- `ts-go-runtypes/internal/cachegen/typefunctions/unknownkeys_guard_test.go` — the guard is present in the emitted source and opens the body, so a key scan can never run ahead of it.

Green locally: `pnpm test` (10687 passed, 40 skipped), `go -C ts-go-runtypes test ./internal/...`, `pnpm run lint`, `pnpm run check-format`.

## Docs

- `createUnknownKeyErrorsFn`'s doc comment states the keys-only contract.
- `container/website/sites/runtypes/content/02.guide/03.validation.md` and the `unknown-keys-errors.ts` example say the same for readers, and show the two lists being joined.

## Note for the `checkUnknowns` branch

The parity suite that spec points at does not exist on `main`; it belongs to the unmerged `checkUnknowns` work. Its oracle is currently restricted to guard-admitted values because of this bug. This fix makes the composition well defined on primitives too, so widening that oracle back out is now possible on that branch.

## Unrelated finding, delegated

While running the gate I found that `pnpm run test:ci` names 16 vitest projects, all on the mion side, and never names the 5 runtypes ones. It comes back green having skipped 309 of the 397 test files `pnpm test` runs, which is everything this change touches. It is pre-existing and CI is not exposed (`release-gate.yml` runs the full `pnpm test`); the damage is to contributors trusting the line in `CLAUDE.md`.

Filed as `docs/todos/test-ci-skips-runtypes-projects.md` on branch `todo/test-ci-missing-runtypes-projects` and delegated to a parallel session, which will open its own PR. No merge-order dependency on this PR: the two changes share no files, and this one was verified with the full `pnpm test`, not `test:ci`.