### PR TITLE
fix(runtypes): resolve the union error delegate under the caller's validate variant

### DIFF
--- a/docs/done/union-errors-ignore-validate-variants.md
+++ b/docs/done/union-errors-ignore-validate-variants.md
@@ -1,0 +1,140 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-08-31
+---
+
+# A validate variant plus a union makes getValidationErrors contradict validate
+
+## Intent
+
+`createGetValidationErrorsFn` reports `{path: [], expected: 'union'}` for values
+that the matching `createValidateFn` accepts, whenever a validate OPTION is set
+and the type is a union. The two functions are supposed to be two views of one
+decision, so a caller that validates, gets `true`, then asks for a report anyway
+is handed a contradiction.
+
+Reproduced with real compiled functions on `main`:
+
+```ts
+type U = {a: 'x'} | {b: number};
+createValidateFn<U>(undefined, {noLiterals: true})({a: 'zzz'});            // true
+createGetValidationErrorsFn<U>(undefined, {noLiterals: true})({a: 'zzz'}); // [{path: [], expected: 'union'}]
+
+type N = {n: number} | {s: string};
+createValidateFn<N>(undefined, {numberMode: 'typeof'})({n: NaN});            // true
+createGetValidationErrorsFn<N>(undefined, {numberMode: 'typeof'})({n: NaN}); // [{path: [], expected: 'union'}]
+```
+
+## Cause
+
+`emitUnionValidationErrors`
+(`ts-go-runtypes/internal/cachegen/typefunctions/validationerrors.go`) has no
+union logic of its own: it delegates the verdict to a validator and records one
+`'union'` error when that validator says no. The hash it resolves is
+`operations.PlainHash("validate")` — always the PLAIN entry. Under a validate
+variant (`noLiterals`, `numberMode`, `rejectCircularRefs`) the error function is
+therefore asking a validator compiled with different options than the one the
+caller holds.
+
+PR #187 fixed the `checkUnknowns` half of this same line: it now picks
+`validateStrict` when `ctx.ChecksUnknownKeys()`. The VARIANT half is untouched
+and is what this spec is about.
+
+## Direction
+
+Resolve the hash from the walker's current variant rather than from
+`PlainHash`. `variantKey` / `operations.FnHashFor` in `module.go` already take
+the option names + `rejectCircular` and produce exactly that key.
+
+Two things to check before assuming it is a one-line change:
+
+- **Demand plumbing.** The comment above `emitUnionValidationErrors` explains
+  that it deliberately does NOT add the hash to `walker.RTDependencies`, and
+  leans on the plain validate entry always being populated by load order. A
+  VARIANT validate entry has no such guarantee: a site that only ever calls
+  `createGetValidationErrorsFn<U>(undefined, {noLiterals: true})` may never
+  demand the matching validate variant. Verify, and demand it if not.
+- **Variants are root-scoped.** `HasVariantOption` is only true at the variant
+  root, and a root-scoped variant's children dispatch to PLAIN entries
+  (`entryInnerPrefix`). Make sure the fix reads the variant that is actually in
+  force at this node rather than assuming the root's.
+
+## Tests
+
+- A Go emit test per variant: the union arm's resolved hash must be the variant's
+  validate entry, not the plain one, and that entry must exist in the emitted
+  modules.
+- A JS test pairing `createValidateFn` and `createGetValidationErrorsFn` under
+  each validate option over a union, asserting `errors(v).length === 0` exactly
+  when `validate(v)` is true. Both repros above belong in it.
+- Worth a fuzz oracle if one does not already cover it: the plain error family
+  and its validator must agree, the same property O21 pins for the strict pair.
+
+## Plan — resolve the delegate under the walker's own variant (approved 2026-08-31)
+
+What shipped, in three pieces.
+
+**1. The union arm reads the walker's variant.** `emitUnionValidationErrors` no
+longer hard-codes `operations.PlainHash("validate")`. A new
+`EmitContext.CrossFamilyVariantHash("validate")` mints the hash from the
+ValidateOptions names in force on the current walker, so a `noLiterals` /
+`numberMode` error function asks the validator the caller actually holds.
+
+`rejectCircularRefs` is deliberately NOT folded in. The armed guard is emitted
+once at the variant ROOT, so at every node the walker inlines the armed fork
+behaves exactly like the plain one, while the armed ENTRY for that node's own
+type would carry a guard of its own. Naming the plain hash is what keeps the two
+sides in step. The armed root still reports a cycle: its own guard fires and
+returns before the union body runs.
+
+The spec's second check ("read the variant in force at this node") resolves to
+the walker's option set. `HasVariantOption` is walker-scoped, and root-scoping is
+enforced by dep-call dispatch, not by the node: a child the walker INLINES sees
+the option (which is why `noLiterals` bites on a literal nested in a union arm at
+all), and a child it does NOT inline is dep-called as a plain entry whose own
+body resolves the plain hash. Validate's walker inlines at the same positions, so
+the two stay in step at every node.
+
+**2. Demand plumbing, as the spec suspected.** A verr-only variant site never
+demands the matching validate variant. The plain lane was already carried by the
+resolver's cross-family fixpoint (`registerRTLookup` records the edge, the entry
+rides `SoftDeps`), but that fixpoint routed edges through a PLAIN-fnHash-only
+reverse map and collected every missing edge as a plain root.
+
+- `operations.AllFnVariants()` enumerates the closed (operation, args) set once;
+  the collision guard and a new `VariantForFnHash` reverse map both read it, so
+  they cannot drift.
+- `familyByFnHash` (dispatch.go) replaces `familyByPlainHash`, routing an
+  option-carrying hash to its family AND its variant. Only the option axes are
+  enumerated, so the plain rows are unchanged.
+- `typefunctions.ExtraRoot` replaces the bare `[]string` extra roots, so the
+  fixpoint can ask a family for a VARIANT root rather than only a plain one.
+
+**3. Tests.**
+
+- `ts-go-runtypes/internal/cachegen/typefunctions/union_verr_variant_test.go` —
+  the union arm's resolved hash is the variant's validate entry across plain /
+  noLiterals / numberTypeof / a two-option combo, the edge lands in
+  `CrossFamilyDeps`, and following that edge the way the fixpoint does actually
+  renders the entry. Confirmed to fail on the unfixed emitter.
+- `ts-go-runtypes/internal/compiler/resolver/cross_family_variant_route_internal_test.go`
+  — the routing map sends every validate variant to the validate family with the
+  right suffix, and the reverse map covers every minted hash.
+- `packages/ts-runtypes/test/features/validateOptionsDispatch.test.ts` — a new
+  describe block pairing `createValidateFn` and `createGetValidationErrorsFn`
+  over unions under each option, asserting `errors(v).length === 0` exactly when
+  `validate(v)` is true. Both repros from this spec are in it, plus the
+  value-first call shape per the marker coverage rule.
+
+**No fuzz suite added.** Oracle O4 (`packages/ts-runtypes/test/fuzz/value/fuzzOracle.ts`)
+already states this property; its targets are built schema-form with no options,
+so the variant lane is out of its reach. Widening the fuzz harness to option
+variants is its own change, not this fix. The value matrix in the new JS test
+covers the same property deterministically.
+
+**No docs change.** The guide already states the contract this restores ("Same
+checks, but instead of a boolean you get an array of what failed") and already
+documents every option as applying to both factories. Nothing on the site
+described the broken behaviour.

--- a/packages/ts-runtypes/test/features/validateOptionsDispatch.test.ts
+++ b/packages/ts-runtypes/test/features/validateOptionsDispatch.test.ts
@@ -256,3 +256,82 @@ describe('ValidateOptions — numberMode reaches format-annotated numbers (Float
     expect(getRunTypeId<TF.Float>()).toBe(getRunTypeId(sample));
   });
 });
+
+// A union's getValidationErrors body has no per-arm error breakdown: it asks a
+// validator for the verdict and records one `{expected:'union'}` entry when the
+// answer is no. That delegate has to be the validator compiled with the SAME
+// options as the error function, or the two contradict each other — the caller
+// validates, gets `true`, asks for a report anyway and is handed an error.
+describe('ValidateOptions — a union error function agrees with its own validator', () => {
+  type LiteralUnion = {a: 'x'} | {b: number};
+  type NumberUnion = {n: number} | {s: string};
+  type ArrayUnion = string[] | {b: number};
+
+  // The contract, checked value by value: an empty error list exactly when the
+  // paired validator says true.
+  const expectAgreement = (validate: (value: unknown) => boolean, errors: (value: unknown) => unknown[], values: unknown[]) => {
+    for (const value of values) {
+      expect({value, empty: errors(value).length === 0}).toEqual({value, empty: validate(value)});
+    }
+  };
+
+  const literalValues = [{a: 'x'}, {a: 'zzz'}, {b: 1}, {b: NaN}, {c: 1}, 'nope', null];
+  const numberValues = [{n: 1}, {n: NaN}, {n: Infinity}, {s: 'x'}, {s: 1}, undefined];
+
+  it('plain: union errors agree with the plain validator', () => {
+    expectAgreement(createValidateFn<LiteralUnion>(), createGetValidationErrorsFn<LiteralUnion>(), literalValues);
+  });
+
+  it('noLiterals: `{a: "zzz"}` validates, so the report must be empty', () => {
+    const validate = createValidateFn<LiteralUnion>(undefined, {noLiterals: true});
+    const errors = createGetValidationErrorsFn<LiteralUnion>(undefined, {noLiterals: true});
+    // The repro: plain rejects the off-literal, noLiterals accepts it.
+    expect(createValidateFn<LiteralUnion>()({a: 'zzz'})).toBe(false);
+    expect(validate({a: 'zzz'})).toBe(true);
+    expect(errors({a: 'zzz'})).toEqual([]);
+    expectAgreement(validate, errors, literalValues);
+  });
+
+  it('numberMode typeof: `{n: NaN}` validates, so the report must be empty', () => {
+    const validate = createValidateFn<NumberUnion>(undefined, {numberMode: 'typeof'});
+    const errors = createGetValidationErrorsFn<NumberUnion>(undefined, {numberMode: 'typeof'});
+    expect(createValidateFn<NumberUnion>()({n: NaN})).toBe(false);
+    expect(validate({n: NaN})).toBe(true);
+    expect(errors({n: NaN})).toEqual([]);
+    expectAgreement(validate, errors, numberValues);
+  });
+
+  it('numberMode notNaN: NaN still fails, Infinity passes, and both views agree', () => {
+    const validate = createValidateFn<NumberUnion>(undefined, {numberMode: 'notNaN'});
+    const errors = createGetValidationErrorsFn<NumberUnion>(undefined, {numberMode: 'notNaN'});
+    expect(validate({n: Infinity})).toBe(true);
+    expect(validate({n: NaN})).toBe(false);
+    expectAgreement(validate, errors, numberValues);
+  });
+
+  it('noIsArrayCheck: the union arm that skips the array guard agrees too', () => {
+    const validate = createValidateFn<ArrayUnion>(undefined, {noIsArrayCheck: true});
+    const errors = createGetValidationErrorsFn<ArrayUnion>(undefined, {noIsArrayCheck: true});
+    expectAgreement(validate, errors, [['x'], [42], {b: 1}, {b: 'x'}, 42, 'nope']);
+  });
+
+  it('combined options: noLiterals + numberMode resolve one shared variant', () => {
+    const options = {noLiterals: true, numberMode: 'typeof'} as const;
+    const validate = createValidateFn<LiteralUnion>(undefined, options);
+    const errors = createGetValidationErrorsFn<LiteralUnion>(undefined, options);
+    expect(validate({a: 'zzz'})).toBe(true);
+    expect(validate({b: NaN})).toBe(true);
+    expectAgreement(validate, errors, literalValues);
+  });
+
+  it('marker coverage: the value-first call shape agrees the same way', () => {
+    const sample: LiteralUnion = {a: 'x'};
+    const validate = createValidateFn(sample, {noLiterals: true});
+    const errors = createGetValidationErrorsFn(sample, {noLiterals: true});
+    expect(validate({a: 'zzz'})).toBe(true);
+    expect(errors({a: 'zzz'})).toEqual([]);
+    expectAgreement(validate, errors, literalValues);
+    // The options never fold into the id — static and value-first agree.
+    expect(getRunTypeId<LiteralUnion>()).toBe(getRunTypeId(sample));
+  });
+});

--- a/ts-go-runtypes/internal/cachegen/operations/fnhash.go
+++ b/ts-go-runtypes/internal/cachegen/operations/fnhash.go
@@ -112,13 +112,48 @@ func PlainHash(name string) string {
 	return FnHashFor(op, nil, "", false)
 }
 
-// allCanonicalKeys enumerates every canonical key the registry can produce: each
-// AxisNone op once, each AxisValidateOptions op over all ValidateOptions subsets, and
-// each AxisJsonStrategy op over all its strategies — and, for every CircularGuarded
-// op, the same set again with rejectCircular armed. The collision guard hashes
-// this whole set.
-func allCanonicalKeys() []string {
-	var keys []string
+// VariantHash returns the fnHash of an operation's variant for a set of option
+// NAMES — the option-carrying sibling of PlainHash. Used by a cross-family
+// reference that must target the SAME variant the referring walker renders (the
+// validationErrors union arm delegating its verdict to a validate entry). An
+// empty name set reduces to PlainHash. Panics on an unknown operation.
+func VariantHash(name string, optionNames []string) string {
+	op, ok := byName[name]
+	if !ok {
+		panic(fmt.Sprintf("operations.VariantHash: unknown operation %q", name))
+	}
+	return FnHashFor(op, optionNames, "", false)
+}
+
+// FnVariant is one concrete (operation + call-site args) combination the
+// registry can mint an fnHash for. Every axis is closed and finite, so the whole
+// set is enumerable — which is what lets an emitted fnHash be read BACK to the
+// variant that produced it (VariantForFnHash).
+type FnVariant struct {
+	Op             Operation
+	Options        []string
+	Strategy       string
+	RejectCircular bool
+	FnHash         string
+}
+
+// AllFnVariants enumerates every (operation, call-site args) combination the
+// registry can produce: each AxisNone op once, each AxisValidateOptions /
+// AxisHasUnknownKeysOptions op over all its option subsets, and each
+// AxisJsonStrategy op over all its strategies — and, for every CircularGuarded
+// op, the same set again with rejectCircular armed. Both the collision guard and
+// the fnHash reverse map read this one enumeration so they can never drift.
+func AllFnVariants() []FnVariant {
+	var variants []FnVariant
+	add := func(op Operation, options []string, strategy string, rejectCircular bool) {
+		variants = append(variants, FnVariant{
+			Op:             op,
+			Options:        options,
+			Strategy:       strategy,
+			RejectCircular: rejectCircular,
+			FnHash:         FnHashFor(op, options, strategy, rejectCircular),
+		})
+	}
 	for _, op := range registry {
 		// CircularGuarded ops fork on rejectCircular; enumerate both plain and armed.
 		circularVariants := []bool{false}
@@ -129,20 +164,51 @@ func allCanonicalKeys() []string {
 			switch op.Axis {
 			case AxisValidateOptions:
 				for _, subset := range optionSubsets(constants.ValidateOptions) {
-					keys = append(keys, Canonical(op, subset, "", rejectCircular))
+					add(op, subset, "", rejectCircular)
 				}
 			case AxisHasUnknownKeysOptions:
 				for _, subset := range optionSubsets(constants.HasUnknownKeysOptions) {
-					keys = append(keys, Canonical(op, subset, "", rejectCircular))
+					add(op, subset, "", rejectCircular)
 				}
 			case AxisJsonStrategy:
 				for _, strategy := range op.Strategies {
-					keys = append(keys, Canonical(op, nil, strategy, rejectCircular))
+					add(op, nil, strategy, rejectCircular)
 				}
 			default:
-				keys = append(keys, Canonical(op, nil, "", rejectCircular))
+				add(op, nil, "", rejectCircular)
 			}
 		}
+	}
+	return variants
+}
+
+// variantByFnHash is the reverse of FnHashFor over the closed variant set.
+// Well-defined because mustBeCollisionFree proves the hash is injective there;
+// it is built from the same AllFnVariants enumeration the guard hashes.
+var variantByFnHash = func() map[string]FnVariant {
+	out := make(map[string]FnVariant)
+	for _, variant := range AllFnVariants() {
+		out[variant.FnHash] = variant
+	}
+	return out
+}()
+
+// VariantForFnHash reads an emitted fnHash back to the operation + call-site
+// args it was minted from. Reports false for anything that is not a registry
+// fnHash. The cross-family fixpoint uses it to route a missing `<fnHash>_<id>`
+// dep to the family AND the variant that renders it.
+func VariantForFnHash(fnHash string) (FnVariant, bool) {
+	variant, ok := variantByFnHash[fnHash]
+	return variant, ok
+}
+
+// allCanonicalKeys projects AllFnVariants onto the canonical keys the collision
+// guard hashes.
+func allCanonicalKeys() []string {
+	variants := AllFnVariants()
+	keys := make([]string, 0, len(variants))
+	for _, variant := range variants {
+		keys = append(keys, Canonical(variant.Op, variant.Options, variant.Strategy, variant.RejectCircular))
 	}
 	return keys
 }

--- a/ts-go-runtypes/internal/cachegen/typefunctions/emitter.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/emitter.go
@@ -3,6 +3,7 @@ package typefunctions
 import (
 	"strconv"
 
+	"github.com/mionkit/ts-runtypes/internal/cachegen/operations"
 	"github.com/mionkit/ts-runtypes/internal/constants"
 	"github.com/mionkit/ts-runtypes/internal/jsengine"
 	"github.com/mionkit/ts-runtypes/internal/reflection"
@@ -171,6 +172,39 @@ func (ctx *EmitContext) HasVariantOption(name string) bool {
 		return false
 	}
 	return ctx.walker.VariantOptions[name]
+}
+
+// VariantOptionNames returns the ValidateOptions names in force on the current
+// walker, in ValidateOptions DECLARATION order — the order Canonical /
+// FnHashFor expect. Empty for a plain walker. Walker-scoped exactly like
+// HasVariantOption: it is the option set in force over everything this walker
+// inlines, which is what a cross-family reference must match (see
+// CrossFamilyVariantHash).
+func (ctx *EmitContext) VariantOptionNames() []string {
+	if ctx.walker == nil || len(ctx.walker.VariantOptions) == 0 {
+		return nil
+	}
+	var names []string
+	for _, opt := range constants.ValidateOptions {
+		if ctx.walker.VariantOptions[opt.Name] {
+			names = append(names, opt.Name)
+		}
+	}
+	return names
+}
+
+// CrossFamilyVariantHash returns the fnHash another family's operation is keyed
+// by UNDER THIS WALKER'S VARIANT — the hash a cross-family reference must name
+// so the entry it resolves was compiled with the same options as the body
+// referring to it. Reduces to PlainHash on a plain walker.
+//
+// rejectCircularRefs is deliberately NOT folded in. The armed guard is emitted
+// once at the variant ROOT, so at any node the walker inlines the armed fork
+// behaves exactly like the plain one — while the armed ENTRY for that node's own
+// type would carry a guard of its own. Naming the plain hash is what keeps the
+// two sides in step.
+func (ctx *EmitContext) CrossFamilyVariantHash(opName string) string {
+	return operations.VariantHash(opName, ctx.VariantOptionNames())
 }
 
 // NumberMode returns the numberMode (validateOptions.numberMode) the current

--- a/ts-go-runtypes/internal/cachegen/typefunctions/families.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/families.go
@@ -94,9 +94,10 @@ func FamilyByKey(key string) FamilySpec {
 }
 
 // Collect compiles the family's demanded entries into per-entry virtual-module
-// records (see CollectFamilyEntries). extraRoots seed plain roots beyond the
-// family's own call-site demand — the resolver's cross-family fixpoint path.
-func (spec FamilySpec) Collect(dump protocol.Dump, opts RenderOpts, extraRoots []string) entrymodules.Graph {
+// records (see CollectFamilyEntries). extraRoots seed (type-id, variant) roots
+// beyond the family's own call-site demand — the resolver's cross-family
+// fixpoint path.
+func (spec FamilySpec) Collect(dump protocol.Dump, opts RenderOpts, extraRoots []ExtraRoot) entrymodules.Graph {
 	return CollectFamilyEntries(dump, spec.Settings, spec.Emitter, innerPrefix(spec.Settings), opts, extraRoots)
 }
 

--- a/ts-go-runtypes/internal/cachegen/typefunctions/module.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/module.go
@@ -164,6 +164,17 @@ type childDemand struct {
 	options []string
 }
 
+// ExtraRoot is one (type id, variant) the resolver's cross-family fixpoint asks
+// a family to render beyond its own call-site demand. The variant fields are
+// empty for the common plain edge (`val_<member>`); they carry the referring
+// walker's option set when the edge names a VARIANT entry, as the
+// validationErrors union arm's delegate does.
+type ExtraRoot struct {
+	ID            string
+	VariantSuffix string
+	Options       []string
+}
+
 // entryInnerPrefix is the namespace an entry's CHILD dep calls are keyed under.
 // It is the family's plain prefix for a plain entry and for a root-scoped
 // variant (whose children are the plain family's entries), and the variant's
@@ -202,10 +213,12 @@ func variantFactoryName(settings constants.CacheModuleSettings, suffix string, o
 // seeding pass, and the resolver's cross-family fixpoint renders the foreign
 // entries those edges name.
 //
-// extraRoots seeds additional BARE type-ids as plain roots beyond the family's
-// own call-site demand — the resolver's cross-family fixpoint uses it to
-// render `val_<member>` entries other families' bodies reference. Each extra
-// root is collected as a plain (no-variant) entry plus its same-family closure.
+// extraRoots seeds additional (type-id, variant) roots beyond the family's own
+// call-site demand — the resolver's cross-family fixpoint uses it to render the
+// `val_<member>` entries other families' bodies reference. Each extra root is
+// collected as its own entry plus its same-family closure; the variant fields
+// are empty for a plain edge and carry the referring walker's options when the
+// edge names a variant entry.
 //
 // When dump.Sites is empty AND no extraRoots are given, the collector falls
 // back to emitting a factory for every interned RunType the emitter supports —
@@ -215,7 +228,7 @@ func variantFactoryName(settings constants.CacheModuleSettings, suffix string, o
 // reaches register themselves at their own `registerPureFnFactory` call sites
 // (binding-injected by the plugin, or live factories without it) when the
 // defining module is imported — always before any factory materializes.
-func CollectFamilyEntries(dump protocol.Dump, settings constants.CacheModuleSettings, emitter Emitter, innerPrefix string, opts RenderOpts, extraRoots []string) entrymodules.Graph {
+func CollectFamilyEntries(dump protocol.Dump, settings constants.CacheModuleSettings, emitter Emitter, innerPrefix string, opts RenderOpts, extraRoots []ExtraRoot) entrymodules.Graph {
 	// Single-pass id→RunType index used by the walker to deref
 	// KindRef sentinels at descent time. Cache entries store every
 	// child slot as a ref (`{kind: -1, id: …}`) per protocol.go;
@@ -358,24 +371,29 @@ func CollectFamilyEntries(dump protocol.Dump, settings constants.CacheModuleSett
 				}
 			}
 		}
-		// extraRoots seed plain roots beyond the family's own call sites (the
+		// extraRoots seed roots beyond the family's own call sites (the
 		// resolver's cross-family fixpoint). Treated exactly like worklist
 		// roots so their transitive same-family closure is pulled too. Sorted
 		// (copy) for the same determinism reason as the demand roots.
-		sortedExtra := append([]string(nil), extraRoots...)
-		sort.Strings(sortedExtra)
-		for _, rootID := range sortedExtra {
-			key := "\x00" + rootID
+		sortedExtra := append([]ExtraRoot(nil), extraRoots...)
+		sort.Slice(sortedExtra, func(i, j int) bool {
+			if sortedExtra[i].ID != sortedExtra[j].ID {
+				return sortedExtra[i].ID < sortedExtra[j].ID
+			}
+			return sortedExtra[i].VariantSuffix < sortedExtra[j].VariantSuffix
+		})
+		for _, extra := range sortedExtra {
+			key := extra.VariantSuffix + "\x00" + extra.ID
 			if queued[key] {
 				continue
 			}
 			queued[key] = true
-			root := refTable[rootID]
+			root := refTable[extra.ID]
 			if root == nil {
 				continue
 			}
-			if deps, ok := renderEntry(root, "", nil, false); ok {
-				enqueueChildren(deps, "", nil, false)
+			if deps, ok := renderEntry(root, extra.VariantSuffix, extra.Options, false); ok {
+				enqueueChildren(deps, extra.VariantSuffix, extra.Options, false)
 			}
 		}
 		for len(childQueue) > 0 {

--- a/ts-go-runtypes/internal/cachegen/typefunctions/union_verr_variant_test.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/union_verr_variant_test.go
@@ -1,0 +1,118 @@
+package typefunctions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mionkit/ts-runtypes/internal/constants"
+	"github.com/mionkit/ts-runtypes/internal/protocol"
+	"github.com/mionkit/ts-runtypes/internal/reflection"
+)
+
+// buildLiteralUnionFixture builds `{a: 'x'} | {b: number}` — the shape the
+// union-vs-validate-variant defect reproduces on. Object members (not atomic
+// leaves) keep the union arm as a real delegate: an all-leaf union is inlined
+// into the dispatch and emits no `val_<id>` edge at all.
+func buildLiteralUnionFixture() ([]*reflection.RunType, string) {
+	litX := &reflection.RunType{ID: "lix", Kind: reflection.KindLiteral, Literal: "x"}
+	num := &reflection.RunType{ID: "num", Kind: reflection.KindNumber}
+	propA := &reflection.RunType{ID: "ppa", Kind: reflection.KindPropertySignature, Name: "a", IsSafeName: true, Child: makeRef("lix")}
+	propB := &reflection.RunType{ID: "ppb", Kind: reflection.KindPropertySignature, Name: "b", IsSafeName: true, Child: makeRef("num")}
+	objA := &reflection.RunType{ID: "oba", Kind: reflection.KindObjectLiteral, TypeName: "A", Children: []*reflection.RunType{makeRef("ppa")}}
+	objB := &reflection.RunType{ID: "obb", Kind: reflection.KindObjectLiteral, TypeName: "B", Children: []*reflection.RunType{makeRef("ppb")}}
+	union := &reflection.RunType{
+		ID:                "uvv",
+		Kind:              reflection.KindUnion,
+		Children:          []*reflection.RunType{makeRef("oba"), makeRef("obb")},
+		SafeUnionChildren: []*reflection.RunType{makeRef("oba"), makeRef("obb")},
+	}
+	return []*reflection.RunType{litX, num, propA, propB, objA, objB, union}, "uvv"
+}
+
+// TestUnionValidationErrors_ResolvesVariantValidate — the validationErrors union
+// arm delegates its verdict to a validator, and under a ValidateOptions variant
+// that delegate MUST be the variant's validate entry. Resolving the plain hash
+// instead makes `createGetValidationErrorsFn<U>(v, opts)` report
+// `{expected:'union'}` for values `createValidateFn<U>(v, opts)` accepts.
+func TestUnionValidationErrors_ResolvesVariantValidate(t *testing.T) {
+	runTypes, rootID := buildLiteralUnionFixture()
+	refTable := buildRefTable(runTypes)
+	settings := constants.CacheModules["validationErrors"]
+	prefix := innerPrefix(settings)
+
+	for _, tc := range []struct {
+		name    string
+		options []string
+	}{
+		{"plain", nil},
+		{"noLiterals", []string{"noLiterals"}},
+		{"numberTypeof", []string{"numberTypeof"}},
+		{"noLiterals+numberNotNaN", []string{"noLiterals", "numberNotNaN"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			suffix := constants.ValidateVariantSuffix(tc.options)
+			rendered := renderEntryWithDeps(refTable[rootID], settings, ValidationErrorsEmitter{}, prefix, refTable, RenderOpts{}, suffix, tc.options, false)
+			if rendered.argsText == "" {
+				t.Fatal("expected a non-empty validationErrors entry for the union root")
+			}
+			want := itVariantKey(tc.options, rootID)
+			if !strings.Contains(rendered.argsText, want+".fn(") {
+				t.Errorf("union arm must delegate to %q, got:\n%s", want, rendered.argsText)
+			}
+			if !containsStr(rendered.crossFamilyDeps, want) {
+				t.Errorf("CrossFamilyDeps %v missing the variant validate edge %q", rendered.crossFamilyDeps, want)
+			}
+			// A variant must never fall back to the plain validator — that is the
+			// defect itself.
+			if plain := valKey(rootID); want != plain && strings.Contains(rendered.argsText, plain) {
+				t.Errorf("variant %v must not reference the plain validate entry %q, got:\n%s", tc.options, plain, rendered.argsText)
+			}
+		})
+	}
+}
+
+// TestUnionValidationErrors_VariantValidateEntryIsRendered — naming the variant
+// validate entry is only half the fix: the entry has to EXIST. A site that only
+// ever calls `createGetValidationErrorsFn<U>(v, opts)` never demands the matching
+// validate variant itself, so the cross-family edge is what pulls it in.
+func TestUnionValidationErrors_VariantValidateEntryIsRendered(t *testing.T) {
+	runTypes, rootID := buildLiteralUnionFixture()
+	options := []string{"noLiterals"}
+	dump := protocol.Dump{
+		RunTypes: runTypes,
+		Sites: []protocol.Site{{
+			File: "call.ts", Pos: 0, ID: rootID,
+			Demand: []protocol.SiteDemand{{FamilyTag: "verr", VariantSuffix: constants.ValidateVariantSuffix(options), Options: options}},
+		}},
+	}
+	verrGraph := FamilyByKey("validationErrors").Collect(dump, RenderOpts{EmitMode: "both"}, nil)
+	want := itVariantKey(options, rootID)
+
+	// The verr entry names the variant validate entry as a SOFT (cross-family)
+	// dep — the edge the resolver's fixpoint follows.
+	var found bool
+	for _, entry := range verrGraph {
+		for _, dep := range entry.SoftDeps {
+			if dep == want {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no validationErrors entry carries the cross-family edge %q", want)
+	}
+
+	// Following that edge the way the fixpoint does must produce the entry.
+	valGraph := FamilyByKey("validate").Collect(
+		protocol.Dump{RunTypes: runTypes},
+		RenderOpts{EmitMode: "both"},
+		[]ExtraRoot{{ID: rootID, VariantSuffix: constants.ValidateVariantSuffix(options), Options: options}},
+	)
+	if _, ok := valGraph[want]; !ok {
+		keys := make([]string, 0, len(valGraph))
+		for key := range valGraph {
+			keys = append(keys, key)
+		}
+		t.Fatalf("cross-family fixpoint did not render the variant validate entry %q; got %v", want, keys)
+	}
+}

--- a/ts-go-runtypes/internal/cachegen/typefunctions/validationerrors.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/validationerrors.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mionkit/ts-runtypes/internal/cachegen/operations"
 	"github.com/mionkit/ts-runtypes/internal/cachegen/typefunctions/formats"
 	"github.com/mionkit/ts-runtypes/internal/jsquote"
 	"github.com/mionkit/ts-runtypes/internal/reflection"
@@ -1123,16 +1122,25 @@ func emitTemplateLiteralValidationErrors(rt *reflection.RunType, ctx *EmitContex
 // Per-arm error breakdown is explicitly NOT a feature of
 // validationErrors (a union failure is one error, not N).
 //
+// The delegate is resolved under THIS WALKER'S VARIANT, not the plain one: a
+// `{noLiterals: true}` / `{numberMode: …}` error function must ask the validator
+// the caller actually holds, or it reports `{expected:'union'}` for a value its
+// own createValidateFn accepts. Walker-scoped is the right scope — the options
+// are in force over everything this walker inlines, and a union the walker does
+// NOT inline is dep-called as a plain child entry whose own body resolves the
+// plain hash.
+//
 // The cross-fn lookup happens at runtime via the shared rtUtils
 // cache. We register a closure-prologue context item but DO NOT add
 // the validate hash to walker.RTDependencies — the dangling-dep
 // cascade in module.go operates per-fn (entries map only carries
 // validationErrors entries), so a validationErrors entry can't satisfy an
-// validate dep ref. The runtime load order (validate cache → validationErrors
-// cache) means the entry is always populated by the time the
-// validationErrors closure invokes `utl.getRT('val_<hash>')`.
+// validate dep ref. registerRTLookup records it as a CROSS-family edge instead,
+// and the resolver's cross-family fixpoint (dispatch.go) renders the named
+// entry — variant included, which is why a variant delegate needs no demand
+// plumbing of its own here.
 func emitUnionValidationErrors(rt *reflection.RunType, ctx *EmitContext, v string) RTCode {
-	validateHash := operations.PlainHash("validate") + "_" + rt.ID
+	validateHash := ctx.CrossFamilyVariantHash("validate") + "_" + rt.ID
 	ctx.registerRTLookup(validateHash)
 	return RTCode{
 		Code: "if (!" + validateHash + ".fn(" + v + ")) " + callRTErr(ctx, "union", ""),

--- a/ts-go-runtypes/internal/compiler/resolver/cross_family_variant_route_internal_test.go
+++ b/ts-go-runtypes/internal/compiler/resolver/cross_family_variant_route_internal_test.go
@@ -1,0 +1,52 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/mionkit/ts-runtypes/internal/cachegen/operations"
+	"github.com/mionkit/ts-runtypes/internal/constants"
+)
+
+// TestFamilyByFnHash_RoutesValidateVariants — the cross-family fixpoint routes a
+// missing `<fnHash>_<id>` dep by its fnHash. The validationErrors union arm names
+// the validate entry compiled under ITS OWN ValidateOptions, so an
+// option-carrying hash has to route to the validate family AND carry the variant
+// forward; routing it as a plain root would render the wrong entry and leave the
+// named one missing.
+func TestFamilyByFnHash_RoutesValidateVariants(t *testing.T) {
+	validate, ok := operations.ByName("validate")
+	if !ok {
+		t.Fatal("no `validate` operation in the registry")
+	}
+	for _, options := range [][]string{nil, {"noLiterals"}, {"numberTypeof"}, {"noLiterals", "noIsArrayCheck"}} {
+		hash := operations.FnHashFor(validate, options, "", false)
+		target, routed := familyByFnHash[hash]
+		if !routed {
+			t.Fatalf("validate variant %v (hash %q) does not route to a family", options, hash)
+		}
+		if target.spec.Key != "validate" {
+			t.Errorf("validate variant %v routed to family %q, want \"validate\"", options, target.spec.Key)
+		}
+		if want := constants.ValidateVariantSuffix(options); target.variantSuffix != want {
+			t.Errorf("validate variant %v routed with suffix %q, want %q", options, target.variantSuffix, want)
+		}
+	}
+}
+
+// TestVariantForFnHash_ReversesEveryMintedHash — the reverse map is only sound if
+// it covers the whole closed variant set; mustBeCollisionFree already proves the
+// mapping is injective there.
+func TestVariantForFnHash_ReversesEveryMintedHash(t *testing.T) {
+	for _, variant := range operations.AllFnVariants() {
+		got, ok := operations.VariantForFnHash(variant.FnHash)
+		if !ok {
+			t.Fatalf("fnHash %q (%s %v) has no reverse entry", variant.FnHash, variant.Op.Name, variant.Options)
+		}
+		if got.Op.Name != variant.Op.Name || got.RejectCircular != variant.RejectCircular {
+			t.Errorf("fnHash %q reversed to %s (armed=%v), want %s (armed=%v)", variant.FnHash, got.Op.Name, got.RejectCircular, variant.Op.Name, variant.RejectCircular)
+		}
+	}
+	if _, ok := operations.VariantForFnHash("zzz"); ok {
+		t.Error("a non-registry hash must not reverse to a variant")
+	}
+}

--- a/ts-go-runtypes/internal/compiler/resolver/dispatch.go
+++ b/ts-go-runtypes/internal/compiler/resolver/dispatch.go
@@ -299,29 +299,70 @@ func (sess *Session) parallelRenderEnabled() bool {
 	return !sess.opts.DisableParallelRender && !sess.opts.SingleThreaded
 }
 
-// familyByPlainHash maps each type-walking family's PLAIN fnHash to its spec —
-// the reverse lookup the cross-family fixpoint needs to route a missing
-// `<fnHash>_<id>` dep to the family that renders it. Cross-family edges always
-// target plain (no-variant) entries, so plain hashes suffice.
-var familyByPlainHash = func() map[string]typefunctions.FamilySpec {
-	out := make(map[string]typefunctions.FamilySpec, len(typefunctions.Families))
+// crossFamilyTarget is what a missing `<fnHash>_<id>` dep routes to: the family
+// that renders the entry, plus the variant that fnHash names.
+type crossFamilyTarget struct {
+	spec          typefunctions.FamilySpec
+	variantSuffix string
+	options       []string
+}
+
+// familyByFnHash maps a type-walking family's fnHash to its spec + variant — the
+// reverse lookup the cross-family fixpoint needs to route a missing
+// `<fnHash>_<id>` dep to the family that renders it.
+//
+// Most cross-family edges target the plain entry, but not all: the
+// validationErrors union arm delegates its verdict to the validate entry
+// compiled with the SAME ValidateOptions as the body referring to it, so an
+// option-carrying hash has to route too. Only the option axes are enumerated —
+// a json op's per-strategy hashes stay out, keeping this map's plain rows
+// byte-identical to what it held before variants were routable.
+var familyByFnHash = func() map[string]crossFamilyTarget {
+	out := make(map[string]crossFamilyTarget, len(typefunctions.Families))
+	allVariants := operations.AllFnVariants()
 	for _, spec := range typefunctions.Families {
 		op, ok := operations.ByFamilyTag(spec.Settings.Tag)
 		if !ok {
 			continue
 		}
-		out[operations.PlainHash(op.Name)] = spec
+		out[operations.PlainHash(op.Name)] = crossFamilyTarget{spec: spec}
+		for _, variant := range allVariants {
+			// The armed (rejectCircularRefs) fork is never named by a
+			// cross-family edge — emitters resolve their delegates under the
+			// plain fork on purpose (see CrossFamilyVariantHash).
+			if variant.Op.Name != op.Name || variant.RejectCircular || len(variant.Options) == 0 {
+				continue
+			}
+			suffix := variantSuffixFor(variant)
+			if suffix == "" {
+				continue
+			}
+			out[variant.FnHash] = crossFamilyTarget{spec: spec, variantSuffix: suffix, options: variant.Options}
+		}
 	}
 	return out
 }()
+
+// variantSuffixFor names the cache-key suffix an option-axis variant renders
+// under. Empty for any op whose axis carries no options (nothing to route).
+func variantSuffixFor(variant operations.FnVariant) string {
+	switch variant.Op.Axis {
+	case operations.AxisValidateOptions:
+		return constants.ValidateVariantSuffix(variant.Options)
+	case operations.AxisHasUnknownKeysOptions:
+		return constants.HasUnknownKeysVariantSuffix(variant.Options)
+	default:
+		return ""
+	}
+}
 
 // resolveCrossFamilyEdges renders, to fixpoint, every foreign-family entry the
 // graph's deps reference but no family demanded directly — the
 // `<valHash>_<member>` lookups union decoders / validationErrors bodies reach at
 // runtime. This replaces the pre-migration CrossFamilyValRoots seeding pass:
 // instead of collecting edges into the validate render, each missing edge is
-// routed to its owning family (via the plain-fnHash reverse map) and collected
-// as a plain root + same-family closure. Sites are stripped from the seed dump
+// routed to its owning family AND variant (via the fnHash reverse map) and
+// collected as a root + same-family closure. Sites are stripped from the seed dump
 // so the sub-collect renders ONLY the requested roots (no demand re-render, no
 // duplicate diagnostics).
 //
@@ -332,7 +373,7 @@ var familyByPlainHash = func() map[string]typefunctions.FamilySpec {
 func (sess *Session) resolveCrossFamilyEdges(graph entrymodules.Graph, dump protocol.Dump, rtOpts typefunctions.RenderOpts) {
 	seedDump := protocol.Dump{RunTypes: dump.RunTypes}
 	for iteration := 0; iteration < 8; iteration++ {
-		missingByFamily := map[string]map[string]bool{}
+		missingByFamily := map[string]map[string]typefunctions.ExtraRoot{}
 		for _, entry := range graph {
 			if entry.Kind != entrymodules.KindTypeFn {
 				continue
@@ -350,14 +391,18 @@ func (sess *Session) resolveCrossFamilyEdges(graph entrymodules.Graph, dump prot
 				if separator < 0 {
 					continue
 				}
-				spec, ok := familyByPlainHash[dep[:separator]]
+				target, ok := familyByFnHash[dep[:separator]]
 				if !ok {
 					continue
 				}
-				if missingByFamily[spec.Key] == nil {
-					missingByFamily[spec.Key] = map[string]bool{}
+				if missingByFamily[target.spec.Key] == nil {
+					missingByFamily[target.spec.Key] = map[string]typefunctions.ExtraRoot{}
 				}
-				missingByFamily[spec.Key][dep[separator+1:]] = true
+				missingByFamily[target.spec.Key][dep] = typefunctions.ExtraRoot{
+					ID:            dep[separator+1:],
+					VariantSuffix: target.variantSuffix,
+					Options:       target.options,
+				}
 			}
 		}
 		if len(missingByFamily) == 0 {
@@ -370,13 +415,18 @@ func (sess *Session) resolveCrossFamilyEdges(graph entrymodules.Graph, dump prot
 		sort.Strings(familyKeys)
 		progressed := false
 		for _, key := range familyKeys {
-			ids := make([]string, 0, len(missingByFamily[key]))
-			for id := range missingByFamily[key] {
-				ids = append(ids, id)
+			roots := make([]typefunctions.ExtraRoot, 0, len(missingByFamily[key]))
+			for _, root := range missingByFamily[key] {
+				roots = append(roots, root)
 			}
-			sort.Strings(ids)
+			sort.Slice(roots, func(i, j int) bool {
+				if roots[i].ID != roots[j].ID {
+					return roots[i].ID < roots[j].ID
+				}
+				return roots[i].VariantSuffix < roots[j].VariantSuffix
+			})
 			before := len(graph)
-			graph.Merge(typefunctions.FamilyByKey(key).Collect(seedDump, rtOpts, ids))
+			graph.Merge(typefunctions.FamilyByKey(key).Collect(seedDump, rtOpts, roots))
 			if len(graph) > before {
 				progressed = true
 			}


### PR DESCRIPTION
Implements `docs/todos/union-errors-ignore-validate-variants.md` (moved to `docs/done/`).

## The bug

`createGetValidationErrorsFn` reported `{path: [], expected: 'union'}` for values the matching `createValidateFn` accepts, whenever a validate option was set and the type was a union. Reproduced on `main`:

```ts
type U = {a: 'x'} | {b: number};

// validate says yes
createValidateFn&lt;U&gt;(undefined, {noLiterals: true})({a: 'zzz'});
// -> true

// the error report says no
createGetValidationErrorsFn&lt;U&gt;(undefined, {noLiterals: true})({a: 'zzz'});
// -> [{path: [], expected: 'union'}]
```

The two functions are meant to be two views of one decision, so a caller that validates, gets `true`, then asks for a report anyway was handed a contradiction. Same for `numberMode`: a `{n: number} | {s: string}` union under `{numberMode: 'typeof'}` accepted `{n: NaN}` and reported a union error for it.

## Cause

`emitUnionValidationErrors` has no union logic of its own: it delegates the verdict to a validator and records one `'union'` error when that validator says no. The hash it resolved was `operations.PlainHash("validate")`, always the plain entry, so under a variant it asked a validator compiled with different options than the one the caller holds.

```go
// before
validateHash := operations.PlainHash("validate") + "_" + rt.ID
// after
validateHash := ctx.CrossFamilyVariantHash("validate") + "_" + rt.ID
```

## The fix, in three pieces

**1. The union arm reads the walker's variant.** A new `EmitContext.CrossFamilyVariantHash` mints the hash from the ValidateOptions names in force on the current walker.

`rejectCircularRefs` is deliberately not folded in. The armed guard is emitted once at the variant root, so at every node the walker inlines the armed fork behaves exactly like the plain one, while the armed *entry* for that node's own type would carry a guard of its own. The armed root still reports a cycle: its own guard fires and returns before the union body runs.

On the spec's "read the variant in force at this node" check: `HasVariantOption` is walker-scoped, and root-scoping is enforced by dep-call dispatch, not by the node. A child the walker inlines sees the option (which is why `noLiterals` bites on a literal nested in a union arm at all); a child it does not inline is dep-called as a plain entry whose own body resolves the plain hash. Validate's walker inlines at the same positions, so the two stay in step at every node.

**2. Demand plumbing, as the spec suspected.** A verr-only variant site never demands the matching validate variant. The plain lane was already carried by the resolver's cross-family fixpoint, but that fixpoint routed edges through a plain-fnHash-only reverse map and collected every missing edge as a plain root.

- `operations.AllFnVariants()` enumerates the closed (operation, args) set once; the collision guard and a new `VariantForFnHash` reverse map both read it, so they cannot drift.
- `familyByFnHash` replaces `familyByPlainHash`, routing an option-carrying hash to its family *and* its variant. Only the option axes are enumerated, so the plain rows are unchanged.
- `typefunctions.ExtraRoot` replaces the bare `[]string` extra roots, so the fixpoint can ask a family for a variant root rather than only a plain one.

**3. Tests.**

- `union_verr_variant_test.go` — the union arm's resolved hash is the variant's validate entry across plain / `noLiterals` / `numberTypeof` / a two-option combo, the edge lands in `CrossFamilyDeps`, and following that edge the way the fixpoint does actually renders the entry. Confirmed to fail on the unfixed emitter.
- `cross_family_variant_route_internal_test.go` — the routing map sends every validate variant to the validate family with the right suffix, and the reverse map covers every minted hash.
- `validateOptionsDispatch.test.ts` — a new block pairing `createValidateFn` and `createGetValidationErrorsFn` over unions under each option, asserting `errors(v).length === 0` exactly when `validate(v)` is true. Both repros from the spec are in it, plus the value-first call shape per the marker coverage rule.

## Checks

| Gate | Result |
| --- | --- |
| `go -C ts-go-runtypes test ./internal/...` | pass |
| `pnpm run test:ci` (all 21 vitest projects) | pass |
| `pnpm run test:bun` | 15 pass, 0 fail |
| `pnpm run lint` (oxlint + eslint + typecheck) | pass |
| `pnpm run format` | clean |

**No fuzz suite added.** Oracle O4 (`test/fuzz/value/fuzzOracle.ts`) already states this property, but its targets are built schema-form with no options, so the variant lane is out of its reach. Widening the fuzz harness to option variants is its own change. The value matrix in the new JS test covers the same property deterministically.

**No docs change.** The guide already states the contract this restores ("Same checks, but instead of a boolean you get an array of what failed") and already documents every option as applying to both factories. Nothing on the site described the broken behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBBF4TuQFkmFZWttsrwpeg