### PR TITLE
fix(setup): the claude-web bootstrap can no longer find the repo

### DIFF
--- a/.claude/skills/fuzzy-testing/framework-fuzzy-testing.md
+++ b/.claude/skills/fuzzy-testing/framework-fuzzy-testing.md
@@ -664,7 +664,7 @@ like a stateful sync pipeline.
 > the enrichment pipeline stays consistent under _any_ sequence of edits to either
 > the source type or the generated file.
 >
-> Grounded in the real pipeline: CLI at [`ts-go-runtypes/cmd/ts-runtypes/enrich_cli.go`](../../../ts-go-runtypes/cmd/ts-runtypes/enrich_cli.go)
+> Grounded in the real pipeline: CLI at [`ts-go-runtypes/cmd/mion/enrich_cli.go`](../../../ts-go-runtypes/cmd/mion/enrich_cli.go)
 > (+ `enrich_reconcile.go`, `enrich_check.go`); the value-preserving merge in
 > [`ts-go-runtypes/internal/enrichment/mirror/reconcile.go`](../../../ts-go-runtypes/internal/enrichment/mirror/reconcile.go);
 > node shapes in [`packages/run-types/src/enrich/friendlyType.ts`](../../../packages/run-types/src/enrich/friendlyType.ts)

--- a/.github/actions/cache-playground-wasm/action.yml
+++ b/.github/actions/cache-playground-wasm/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .cache/rt-wasm
-        key: rt-wasm-${{ hashFiles('ts-go-runtypes/cmd/ts-runtypes-wasm/**', 'ts-go-runtypes/internal/**', 'ts-go-runtypes/go.mod', 'ts-go-runtypes/go.sum', 'container/website/scripts/build-playground.mjs', '.github/actions/bootstrap/**') }}
+        key: rt-wasm-${{ hashFiles('ts-go-runtypes/cmd/mion-wasm/**', 'ts-go-runtypes/internal/**', 'ts-go-runtypes/go.mod', 'ts-go-runtypes/go.sum', 'container/website/scripts/build-playground.mjs', '.github/actions/bootstrap/**') }}
     # A fresh checkout stamps every file with `now`, so build-playground's mtime
     # gate would treat the (older) cached WASM as stale and rebuild it just to
     # byte-compare. Bump the stamp past the checkout so the gate short-circuits

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,7 +4,7 @@ Single setup document for RunTypes. Architecture + workflow rules live in [CLAUD
 
 > **Automated path:** the `mion-setup` skill ([.claude/skills/ts-runtypes-setup/](.claude/skills/ts-runtypes-setup/)) drives this whole document end-to-end — host deps, submodule bootstrap + patches, `pnpm install`, Go + plugin builds, podman engine, and smoke verification. Run `bash .claude/skills/ts-runtypes-setup/setup.sh` and the rest of this doc is reference material.
 
-The repository contains a **Go binary** at [ts-go-runtypes/cmd/ts-runtypes/](ts-go-runtypes/cmd/ts-runtypes/) and a **pnpm workspace** of JS packages under [packages/](packages/). Two **podman-containerized** apps ship alongside: the docs website ([container/website/](container/website/)), one Nuxt install that builds TWO static sites (runtypes.pages.dev and mion.pages.dev, picked by `RT_SITE`), and the validation benchmarks ([container/benchmarks/](container/benchmarks/)).
+The repository contains a **Go binary** at [ts-go-runtypes/cmd/mion/](ts-go-runtypes/cmd/mion/) and a **pnpm workspace** of JS packages under [packages/](packages/). Two **podman-containerized** apps ship alongside: the docs website ([container/website/](container/website/)), one Nuxt install that builds TWO static sites (runtypes.pages.dev and mion.pages.dev, picked by `RT_SITE`), and the validation benchmarks ([container/benchmarks/](container/benchmarks/)).
 
 ---
 
@@ -143,7 +143,7 @@ You can also build the assets directly:
 node container/website/scripts/build-playground.mjs
 ```
 
-It compiles `ts-go-runtypes/cmd/ts-runtypes-wasm` (`GOOS=js GOARCH=wasm`) and emits the mion source overlay, staging `mion.wasm.gz`, `wasm_exec.js`, and `runtypes-sources.json` into `container/website/public/playground-app/` (git-ignored, reproducible). The build is **staleness-gated**: a fast mtime pre-check plus a `go tool buildid` compare over the Go inputs means it is an instant no-op when nothing changed and only recompiles the wasm on a real input change (gzip runs only when the bytes actually change) — so editing the Vue UI never rebuilds the wasm. Because `public/` is bind-mounted into the container, the staged files ride into both the dev server and the production build. The engine tests live at [`packages/run-types/test/playground/`](packages/run-types/test/playground/) and run under `pnpm test` (project `playground`); they need the host-built assets in `.cache/rt-wasm/` and skip without them.
+It compiles `ts-go-runtypes/cmd/mion-wasm` (`GOOS=js GOARCH=wasm`) and emits the mion source overlay, staging `mion.wasm.gz`, `wasm_exec.js`, and `runtypes-sources.json` into `container/website/public/playground-app/` (git-ignored, reproducible). The build is **staleness-gated**: a fast mtime pre-check plus a `go tool buildid` compare over the Go inputs means it is an instant no-op when nothing changed and only recompiles the wasm on a real input change (gzip runs only when the bytes actually change) — so editing the Vue UI never rebuilds the wasm. Because `public/` is bind-mounted into the container, the staged files ride into both the dev server and the production build. The engine tests live at [`packages/run-types/test/playground/`](packages/run-types/test/playground/) and run under `pnpm test` (project `playground`); they need the host-built assets in `.cache/rt-wasm/` and skip without them.
 
 ### Website needs the packages it documents (repo context)
 

--- a/packages/ts-runtypes-devtools/src/go-generated/README.md
+++ b/packages/ts-runtypes-devtools/src/go-generated/README.md
@@ -18,7 +18,7 @@ code in one file. For example the hand-written render helpers in
 | `runtypes-constants.generated.ts`   | `cmd/gen-ts-constants`                                              | `internal/constants/constants.go`                                   |
 | `reflectionKind.generated.ts`       | `cmd/gen-run-type-kind`                                             | `internal/reflection/runtype.go` + `internal/reflection/subkind.go` |
 | `diagnosticCatalog.generated.ts`    | `cmd/gen-diag-catalog` → `scripts/core/gen-diagnostics-catalog.mjs` | `internal/diagnostics/messages.go`                                  |
-| `tsconfig-plugin-keys.generated.ts` | `cmd/gen-plugin-keys`                                               | `cmd/ts-runtypes/config.go` (`tsRuntypesPlugin` json tags)          |
+| `tsconfig-plugin-keys.generated.ts` | `cmd/gen-plugin-keys`                                               | `cmd/mion/config.go` (`tsRuntypesPlugin` json tags)                 |
 
 ## Regenerate
 

--- a/scripts/setup-claude-web.sh
+++ b/scripts/setup-claude-web.sh
@@ -42,15 +42,15 @@ node_major() { command -v node >/dev/null 2>&1 && node -p 'process.versions.node
 # (identified by its unique module path). A fresh clone is fine - we only need
 # committed files, not the (uninitialized) submodules.
 _looks_like_repo() {
-  [ -f "$1/package.json" ] && [ -f "$1/ts-go-runtypes/go.mod" ] && [ -d "$1/ts-go-runtypes/cmd/ts-runtypes" ] \
+  [ -f "$1/package.json" ] && [ -f "$1/ts-go-runtypes/go.mod" ] && [ -d "$1/ts-go-runtypes/cmd/mion" ] \
     && grep -q '^module github.com/mionkit/mion/ts-go-runtypes' "$1/ts-go-runtypes/go.mod" 2>/dev/null
 }
 _resolve_repo_dir() {
   local cand d selfdir root gomod
   selfdir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || true)"
-  # 1) explicit candidates, incl. the web clone convention /home/<user>/ts-run-types
+  # 1) explicit candidates, incl. the web clone convention /home/<user>/mion
   for cand in "${CLAUDE_PROJECT_DIR:-}" "$PWD" "$selfdir/.." "$selfdir" \
-              /home/user/ts-run-types /root/ts-run-types /workspace/ts-run-types; do
+              /home/user/mion /root/mion /workspace/mion; do
     [ -n "$cand" ] || continue
     cand="$(cd "$cand" 2>/dev/null && pwd)" || continue
     _looks_like_repo "$cand" && { printf '%s' "$cand"; return 0; }

--- a/scripts/website/playground-wasm-inputs.mjs
+++ b/scripts/website/playground-wasm-inputs.mjs
@@ -18,7 +18,7 @@ import {existsSync, globSync, readFileSync, statSync} from 'node:fs';
 import {join, sep} from 'node:path';
 
 // Every Go input the wasm links, repo-relative.
-export const WASM_INPUTS = ['ts-go-runtypes/cmd/ts-runtypes-wasm', 'ts-go-runtypes/internal', 'ts-go-runtypes/go.mod', 'ts-go-runtypes/go.sum'];
+export const WASM_INPUTS = ['ts-go-runtypes/cmd/mion-wasm', 'ts-go-runtypes/internal', 'ts-go-runtypes/go.mod', 'ts-go-runtypes/go.sum'];
 
 // Only files that can end up IN the binary count. `go build` never compiles
 // _test.go, and the go tool ignores testdata/ entirely, so hashing them would


### PR DESCRIPTION
This was in PR #194 but landed one commit after the merge, so `main` currently
ships a bootstrap script that cannot find the repo.

## The break

```sh
_looks_like_repo() {
  [ -f "$1/package.json" ] && [ -f "$1/ts-go-runtypes/go.mod" ] \
    && [ -d "$1/ts-go-runtypes/cmd/ts-runtypes" ]   # moved to cmd/mion
```

`cmd/ts-runtypes` no longer exists, so detection fails from every candidate path
and `scripts/setup-claude-web.sh` cannot bootstrap at all. It also searched
`/home/<user>/ts-run-types` for the web clone, which is the OLD repo name; a
clone of `MionKit/mion` lands under `mion`.

## Two more that were silently wrong

| file | what it does |
|---|---|
| `scripts/website/playground-wasm-inputs.mjs` | the wasm staleness gate's input list |
| `.github/actions/cache-playground-wasm` | the CI cache key |

Both listed `ts-go-runtypes/cmd/ts-runtypes-wasm`, which no longer exists.
`hashFiles()` over a missing path does not fail — it just yields a key that no
longer tracks the wasm inputs, so the cache rots quietly instead of erroring.

Plus three dead doc links (`SETUP.md`, the fuzzy-testing skill, the go-generated
README).

## Why the rename missed them

The same blind spot every time: the path is built from a variable or sits inside
a glob, so it is never one token a scanner can see.

```sh
"$1/ts-go-runtypes/cmd/ts-runtypes"        # variable prefix
'ts-go-runtypes/cmd/ts-runtypes-wasm/**'   # glob
```

## Verified

All four detection conditions pass, both setup scripts parse, `WASM_INPUTS[0]`
resolves to `ts-go-runtypes/cmd/mion-wasm`. Lint, format and 78 contract tests
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)