### PR TITLE
fix(run-types): the oversized mock overflows the binary estimate for every seed

### DIFF
--- a/docs/done/size-fuzz-floor-negative-control.md
+++ b/docs/done/size-fuzz-floor-negative-control.md
@@ -1,0 +1,93 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-02
+---
+
+# Size fuzz floor: the oversized negative control does not grow the cold buffer
+
+## Intent
+
+The `fuzz soak · size` job (`release-gate.yml`, `fuzz-soak.yml`) fails before its first
+iteration with
+
+```
+size fuzz floor: the oversized value did not grow the cold buffer — the
+respectBinarySize:false negative control lost its teeth (mock-sizing regression?)
+```
+
+thrown from `runFloor` in
+[packages/run-types/test/fuzz/binary/sizeFuzzRunner.ts](../../packages/run-types/test/fuzz/binary/sizeFuzzRunner.ts)
+(line 239 at the time). The floor generates an oversized mock with `respectBinarySize:false`
+and expects it to overflow the estimated buffer; on CI it did not, so either the mock is no
+longer oversized (a mock-sizing regression, the message's own guess) or the estimate grew
+past what the negative control produces. Both cases mean the size fuzz is no longer proving
+what it claims.
+
+Found on 2026-09-02 by the release gate on PR #201 (run 33579204363, seed `0xd179ff0b`).
+It reproduces locally with that seed (both tests fail in under a second), while an
+unseeded `pnpm rtx core fuzz size --quick` on the same tree passes, so the floor's negative
+control is seed-dependent, which is itself a weakness: the control must overflow for EVERY
+seed. The branch touches no binary or mock code, so this predates it.
+
+## Direction
+
+- Replay with the CI seed: `MION_FUZZ_SEED=0xd179ff0b pnpm rtx core fuzz size --quick`.
+- Read `runFloor` and the `respectBinarySize:false` mock path: what the control generates,
+  how the cold buffer size is estimated, and why the two can end up on the same side for
+  some seeds. Check recent commits to the mock sampler and to the binary size estimate.
+- Fix the root cause (the mock sizing or the estimate), not the assertion: the control has
+  to overflow deterministically, so the floor should not depend on the seed at all.
+- Add a deterministic test for the control (a type whose oversized mock must overflow the
+  estimate) beside the fuzz suite.
+
+## Done when
+
+- `MION_FUZZ_SEED=0xd179ff0b pnpm rtx core fuzz size --quick` and the soak pass.
+- The negative control overflows for every seed (a few dozen seeds in a loop is enough
+  proof), and a deterministic test pins it.
+- `fuzz soak · size` is green on `main`.
+
+## Plan (implemented 2026-09-02)
+
+### Root cause
+
+The floor type `{tag: string; items: string[]}` estimates to 82 bytes under `SIZE_CONFIGS[0]`
+(items 8, stringBytes 8). The oversized generator (`mockOversized.ts`) started from a plain,
+un-sized base mock and inflated ONE string to `2*stringBytes+1 .. 4*stringBytes` chars, past
+that one position's budget only. The estimate is the SUM of every position's budget, so a
+seed whose base value came in under budget elsewhere never reached it: under `0xd179ff0b`
+the base gave `items: []` and a 23-char `tag` (reserve 5 + 3*23 = 74 < 82), so nothing grew.
+Seed 8 did the same with a one-char `tag`. Every other seed "passed" only because the
+un-sized base mock happened to be kilobytes of unicode strings against an 82-byte estimate,
+so the overflow was never attributable to the inflation at all.
+
+### Fix (the mock sizing, not the assertion)
+
+- `binarySize.ts`: `resolveSizing` now also resolves `sizeMaxBytes` (default 64 KiB, the Go
+  `DefaultSizeMaxBytes`), and `overBudgetLength(budgetBytes)` gives the shortest serString
+  payload whose write reserve (`MAX_VARINT + 3*length`) exceeds a budget.
+- `mockOversized.ts`: a string / bigint target is inflated to `overBudgetLength(sizeMaxBytes)`
+  chars / digits (plus a little jitter). The estimator clamps every estimate to `sizeMaxBytes`,
+  so that one position overflows any cold buffer ON ITS OWN, for every seed and every estimate
+  the config can produce. Array-count inflation stays best-effort (documented), and the runner
+  already treats a non-growing array-only type as "not exercised", not a violation.
+- `createMockData.ts`: `respectBinarySize: false` now starts from the same in-bounds base value
+  as `true` (`applyInBoundsSizing`), so the overflow is the inflated position's alone and the
+  oversized values stay small.
+- The `runFloor` assertion is untouched: it still throws when the control loses its teeth.
+
+### Tests
+
+- `test/suites/mocking/respectBinarySize.test.ts`: the `false` cases now pin, for 64 seeds each,
+  that the inflated string / bigint reserve exceeds `sizeMaxBytes` while the rest stays in-bounds,
+  the array fallback, the untouched `maxLength` field, and the default 64 KiB cap.
+- `test/fuzz/binary/binaryOversizedControl.test.ts` (resolver-backed): compiles the floor type
+  under every `SIZE_CONFIGS` entry and checks, for the CI seed, seed 8, the default seed and
+  48 more, that the in-bounds value never grows and the oversized value always grows.
+
+### Docs
+
+No website change: the mocking page's option row ("steer a value to fit, or deliberately
+exceed, the estimate") stays true. The fuzz README and the option's JSDoc describe the cap.

--- a/packages/run-types/src/mocking/binarySize.ts
+++ b/packages/run-types/src/mocking/binarySize.ts
@@ -10,6 +10,7 @@ import type {MockRandom} from './mockRandom.ts';
 const DEFAULT_SIZE_BIAS = 0.8;
 const DEFAULT_SIZE_ITEMS = 100;
 const DEFAULT_SIZE_STRING_BYTES = 32;
+const DEFAULT_SIZE_MAX_BYTES = 64 * 1024;
 
 // dataView.ts MAX_VARINT — every serString write reserves MAX_VARINT + charLength*3
 // (worst-case UTF-8), the high-water the bounds below keep under the estimate.
@@ -19,6 +20,8 @@ export interface ResolvedSizing {
   bias: number;
   items: number;
   stringBytes: number;
+  /** The cap the estimator clamps every estimate to, so no estimate exceeds it. **/
+  maxBytes: number;
 }
 
 function posInt(value: number | undefined, fallback: number): number {
@@ -31,7 +34,16 @@ export function resolveSizing(opts?: BinarySizingOptions): ResolvedSizing {
     bias,
     items: posInt(opts?.sizeItems, DEFAULT_SIZE_ITEMS),
     stringBytes: posInt(opts?.sizeStringBytes, DEFAULT_SIZE_STRING_BYTES),
+    maxBytes: posInt(opts?.sizeMaxBytes, DEFAULT_SIZE_MAX_BYTES),
   };
+}
+
+/** The shortest serString payload (ASCII chars, or a bigint's decimal digits)
+ *  whose write reserve `MAX_VARINT + 3*length` exceeds `budgetBytes`. A value of
+ *  that length forces a cold buffer seeded at (or under) the budget to grow on
+ *  its own, whatever else the value holds. **/
+export function overBudgetLength(budgetBytes: number): number {
+  return Math.max(1, Math.floor((budgetBytes - MAX_VARINT) / 3) + 1);
 }
 
 // ASCII only — one UTF-8 byte per char, so a string's char length IS its byte

--- a/packages/run-types/src/mocking/createMockData.ts
+++ b/packages/run-types/src/mocking/createMockData.ts
@@ -76,10 +76,10 @@ export function createMockDataFn<T>(
     // reproduces the same value; no seed reuses the stateless native instance.
     mockOpts.random = mockOpts.seed === undefined ? nativeMockRandom : new MockRandom(mockOpts.seed);
     // Steer generation to FIT the binary cold-start estimate — only when
-    // explicitly requested (`=== true`). `undefined` leaves the random generator
-    // untouched; `false` (oversized) inflates a position past the budget and
-    // reads `binarySizingOptions` directly, so it needs no in-bounds pass.
-    if (mockOpts.respectBinarySize === true) applyInBoundsSizing(mockOpts);
+    // explicitly requested. `undefined` leaves the random generator untouched.
+    // `false` (oversized) starts from the same in-bounds value and inflates ONE
+    // position past the estimate's cap, so the overflow is that position's alone.
+    if (mockOpts.respectBinarySize !== undefined) applyInBoundsSizing(mockOpts);
     if (mockOpts.invalid) return mockRunTypeInvalid(runType, merged, []) as T;
     if (mockOpts.respectBinarySize === false) return mockRunTypeOversized(runType, merged, []) as T;
     return mockRunType(runType, merged, []) as T;

--- a/packages/run-types/src/mocking/mockOversized.ts
+++ b/packages/run-types/src/mocking/mockOversized.ts
@@ -1,14 +1,23 @@
 // The `respectBinarySize: false` generator — make a value that EXCEEDS the
 // binary cold-start estimate so a `dynamic` buffer must grow. The size
-// counterpart of mockInvalid.ts: generate an in-bounds mock, co-walk the RunType
-// alongside it, and inflate ONE unbounded position past its budget.
+// counterpart of mockInvalid.ts: generate an in-bounds mock (the caller already
+// applied applyInBoundsSizing), co-walk the RunType alongside it, and inflate ONE
+// unbounded position past the WHOLE estimate.
 //
 // Only an UNBOUNDED position can grow while staying valid — a `string` / `array`
 // / `bigint` with no length-bounding format. A formatted node (maxLength /
 // maxItems / fixed bigint width / uuid …) can't exceed its bound without becoming
-// invalid, so it is never a target. `string` / `bigint` overshoots are guaranteed
-// past the budget; an array-count overshoot is best-effort (an array of zero-byte
-// elements may not), which the caller's size oracle confirms.
+// invalid, so it is never a target.
+//
+// The inflated position must overflow the estimate ON ITS OWN: the estimate sums
+// every position's budget, and the rest of the value can land anywhere under
+// theirs (an empty array, a one-char string), so overshooting one position's
+// budget proves nothing. The generator never sees the estimate, but it knows the
+// cap the estimator clamps every estimate to (`sizeMaxBytes`), so a `string` /
+// `bigint` is inflated until its write reserve exceeds that cap — guaranteed
+// growth for every seed and every estimate the config can produce. An
+// array-count overshoot stays best-effort (an array of zero-byte elements may
+// not grow), which the caller's size oracle confirms.
 
 import {RunTypeKind} from '../go-generated/runTypeKind.generated.ts';
 import type {RunType} from '../runtypes/types.ts';
@@ -16,7 +25,7 @@ import type {MockOptions, RunTypeMockOptions} from './mockTypes.ts';
 import {nativeMockRandom} from './mockRandom.ts';
 import type {MockRandom} from './mockRandom.ts';
 import {mockRunType} from './mockType.ts';
-import {randomAscii, resolveSizing} from './binarySize.ts';
+import {overBudgetLength, randomAscii, resolveSizing} from './binarySize.ts';
 
 const K = RunTypeKind;
 const kindOf = (node: RunType): number => node.kind as number;
@@ -32,7 +41,8 @@ interface Target {
 function inflatableKind(node: RunType | undefined): TargetKind | null {
   if (!node || node.formatAnnotation) return null; // formatted -> possibly bounded/fixed, skip
   const kind = kindOf(node);
-  if (kind === K.string || kind === K.templateLiteral) return 'string';
+  // A template literal is a pattern, so a longer random string would be invalid.
+  if (kind === K.string) return 'string';
   if (kind === K.array) return 'array';
   if (kind === K.bigint) return 'bigint';
   return null;
@@ -76,19 +86,23 @@ function collect(node: RunType | undefined, value: unknown, set: (v: unknown) =>
   }
 }
 
-function bigOverBudget(random: MockRandom): bigint {
-  const digits = 28 + Math.floor(random.float() * 12); // well past the 20-digit budget
-  let mag = 9n; // leading non-zero
-  for (let i = 1; i < digits; i++) mag = mag * 10n + BigInt(Math.floor(random.float() * 10));
+// A bigint serialises its decimal string (serString(v.toString(), true)), so its
+// reserve is the same MAX_VARINT + 3*digits — `digits` past the cap grows.
+function bigOverBudget(digits: number, random: MockRandom): bigint {
+  let text = '9'; // leading non-zero
+  for (let i = 1; i < digits; i++) text += random.int(0, 9);
+  const mag = BigInt(text);
   return random.float() < 0.5 ? mag : -mag;
 }
 
 function inflate(target: Target, mock: MockOptions, options: RunTypeMockOptions, random: MockRandom): void {
-  const {items, stringBytes} = resolveSizing(mock.binarySizingOptions);
+  const {items, stringBytes, maxBytes} = resolveSizing(mock.binarySizingOptions);
+  // Past the cap on its own, plus a little jitter so oversized values still vary.
+  const length = overBudgetLength(maxBytes) + random.int(0, stringBytes);
   if (target.kind === 'string') {
-    target.set(randomAscii(stringBytes * 2 + 1 + Math.floor(random.float() * stringBytes * 2), random));
+    target.set(randomAscii(length, random));
   } else if (target.kind === 'bigint') {
-    target.set(bigOverBudget(random));
+    target.set(bigOverBudget(length, random));
   } else {
     const count = items + 1 + Math.floor(random.float() * Math.max(1, items));
     const child = target.node.child;
@@ -99,8 +113,8 @@ function inflate(target: Target, mock: MockOptions, options: RunTypeMockOptions,
 }
 
 /** Generate an in-bounds mock (options already steered by applyInBoundsSizing),
- *  then inflate ONE unbounded position past the estimate. Returns the plain
- *  in-bounds value when the type has no inflatable position. **/
+ *  then inflate ONE unbounded position past the estimate's cap. Returns the
+ *  plain in-bounds value when the type has no inflatable position. **/
 export function mockRunTypeOversized(runType: RunType, options: RunTypeMockOptions, stack: RunType[] = []): unknown {
   const mock = options.mock as MockOptions;
   const random = mock.random ?? nativeMockRandom;

--- a/packages/run-types/src/mocking/mockTypes.ts
+++ b/packages/run-types/src/mocking/mockTypes.ts
@@ -84,14 +84,16 @@ export interface MockOptions {
    *      not the wire size: collections capped at `sizeItems`, strings short
    *      enough that their reserve fits `sizeStringBytes`, bigints small, optionals
    *      omitted below bias 1, ASCII charset.
-   *    - `false` — the value EXCEEDS the estimate: one unbounded position
-   *      (array / string / bigint) is inflated past its budget, forcing a grow.
+   *    - `false` — the value EXCEEDS the estimate: an in-bounds value with one
+   *      unbounded position (string / bigint, else array) inflated past
+   *      `sizeMaxBytes`, the cap every estimate stays under, forcing a grow.
    *    - `undefined` (default) — no size-specific behaviour.
    *  Bounds are read from `binarySizingOptions`. **/
   respectBinarySize?: boolean;
   /** The size-estimate config `respectBinarySize` bounds against — mirrors the
    *  resolver's `--size-*` options / the Go `SizeEstimateConfig`. Omitted fields
-   *  fall back to the binary defaults (bias 0.8, items 100, stringBytes 32). **/
+   *  fall back to the binary defaults (bias 0.8, items 100, stringBytes 32,
+   *  maxBytes 65536). **/
   binarySizingOptions?: BinarySizingOptions;
   /** Draw credit-card mocks from the well-known sandbox numbers every payment
    *  gateway publishes (`4111111111111111`, `378282246310005`, ...) instead of

--- a/packages/run-types/test/fuzz/README.md
+++ b/packages/run-types/test/fuzz/README.md
@@ -219,7 +219,8 @@ resolver's own diagnostics, not guessed at generation time.
 Targets the binary encoder's cold-start size estimate and its dynamic buffer.
 Two lanes per generated type: an **in-bounds** value (`respectBinarySize: true`)
 must fit the pre-sized buffer with no resize; an **oversized** negative control
-(`respectBinarySize: false`) must trigger growth and still round-trip.
+(`respectBinarySize: false`, one position inflated past `sizeMaxBytes`, the cap
+every estimate stays under) must trigger growth and still round-trip.
 
 - `sizeOracle.ts` — **O-SIZE-NOGROW** (an in-bounds value never resizes the cold
   buffer), **O-SIZE-ROUNDTRIP** (decode/re-encode is byte-stable), **O-SIZE-GREW**
@@ -230,6 +231,8 @@ must fit the pre-sized buffer with no resize; an **oversized** negative control
   deterministic floor so a run can't silently go vacuous.
 - Tests: `binarySizeEstimate.integration` (the soak, `MION_FUZZ_SIZE_SOAK_MS`),
   `binarySizeFloors` (per-kind reserve floors at an adversarial tiny config),
+  `binaryOversizedControl` (the floor's oversized control grows for every seed
+  under every config),
   `binaryDynamicGrow` + `binaryEncoderResize` (the grow-in-place path — the
   buffer-overflow / adaptive-history regressions), `binaryIndexSig.smoke` (F1).
 

--- a/packages/run-types/test/fuzz/binary/binaryOversizedControl.test.ts
+++ b/packages/run-types/test/fuzz/binary/binaryOversizedControl.test.ts
@@ -1,0 +1,55 @@
+// Deterministic pin for the size lane's NEGATIVE CONTROL: the floor type's
+// `respectBinarySize:false` mock must grow the cold buffer for EVERY seed, under
+// EVERY size config. Before this pin the oversized generator inflated one string
+// past its own per-position budget only, so a seed whose base value came in
+// under budget elsewhere (an empty `items` array) never reached the estimate
+// and the fuzz threw "the negative control lost its teeth" (CI seed 0xd179ff0b).
+// Now the inflated position's reserve exceeds sizeMaxBytes, the cap every
+// estimate stays under, so the overflow no longer depends on the seed.
+
+import {describe, it, expect} from 'vitest';
+import {createMockDataFn} from '@mionjs/run-types';
+import type {BinarySizingOptions} from '../../../src/mocking/mockTypes.ts';
+import {mixSeed, withSeededRandom} from '../core/seededRng.ts';
+import {openClient, compileType, hasBinary, type CompiledType} from '../type/typeFuzzHarness.ts';
+import {checkInBounds, checkOversized} from './sizeOracle.ts';
+import {FLOOR_TYPE, SIZE_CONFIGS} from './sizeFuzzRunner.ts';
+
+// The CI seed that first tripped the floor, a second under-budget seed found
+// while replaying it, the lane's default seed, and a sweep of small ones.
+const SEEDS = [0xd179ff0b, 8, 0xc0ffee, ...Array.from({length: 48}, (_, i) => i + 1)];
+
+function mock(compiled: CompiledType, respectBinarySize: boolean, cfg: BinarySizingOptions): unknown {
+  const fn = createMockDataFn(
+    undefined,
+    {mock: {respectBinarySize, binarySizingOptions: cfg}},
+    compiled.reflectionTuple as never
+  );
+  return (fn as () => unknown)();
+}
+
+describe('binary size — the oversized negative control grows the cold buffer for every seed', () => {
+  const register = hasBinary() ? it : it.skip;
+
+  register.each(SIZE_CONFIGS.map((cfg, i) => [i, cfg] as const))('config %i', async (_i, cfg) => {
+    const client = openClient(cfg);
+    try {
+      const compiled = await compileType(client, FLOOR_TYPE);
+      expect(compiled.resolverError, 'resolver').toBeUndefined();
+      expect(compiled.errorDiagnostics).toEqual([]);
+      expect(compiled.seed, 'estimate').toBeDefined();
+      expect(compiled.seed! < cfg.sizeMaxBytes, 'the floor estimate stays under the cap').toBe(true);
+      for (const seed of SEEDS) {
+        const ctx = {seed};
+        const inBounds = withSeededRandom(mixSeed(seed, 'floor-value', 0), () => mock(compiled, true, cfg));
+        expect(checkInBounds(compiled, inBounds, ctx), `seed ${seed.toString(16)}: in-bounds`).toEqual([]);
+        const oversized = withSeededRandom(mixSeed(seed, 'floor-over', 0), () => mock(compiled, false, cfg));
+        const neg = checkOversized(compiled, oversized, ctx);
+        expect(neg.violation, `seed ${seed.toString(16)}: oversized round-trip`).toBeNull();
+        expect(neg.exercised, `seed ${seed.toString(16)}: the oversized value must grow the cold buffer`).toBe(true);
+      }
+    } finally {
+      client.close();
+    }
+  });
+});

--- a/packages/run-types/test/fuzz/binary/sizeFuzzRunner.ts
+++ b/packages/run-types/test/fuzz/binary/sizeFuzzRunner.ts
@@ -47,7 +47,7 @@ export const SIZE_CONFIGS: ReadonlyArray<Required<BinarySizingOptions>> = [
  *  otherwise go vacuous when every fuzz iteration skips — which is what a
  *  resolver dying under full-suite load does (one crash closes the client, so
  *  every later request on it throws and cascades to `skipped`). **/
-const FLOOR_TYPE: GeneratedType = {
+export const FLOOR_TYPE: GeneratedType = {
   decls: [],
   root: {
     kind: 'object',

--- a/packages/run-types/test/suites/mocking/respectBinarySize.test.ts
+++ b/packages/run-types/test/suites/mocking/respectBinarySize.test.ts
@@ -1,8 +1,9 @@
 // The `respectBinarySize` mock option — steer createMockDataFn against the binary
 // cold-start size estimate. `true` keeps a value within the estimate's per-kind
 // budget (so a `dynamic` buffer encodes it without growing); `false` overshoots
-// one unbounded position so it must grow. Driven value-first (the schema carries
-// its own runtype, no plugin needed) so the assertions exercise the real factory.
+// one unbounded position past sizeMaxBytes (the cap every estimate stays under)
+// so it must grow, for every seed. Driven value-first (the schema carries its
+// own runtype, no plugin needed) so the assertions exercise the real factory.
 
 import {describe, it, expect} from 'vitest';
 import {createMockDataFn, createValidateFn} from '@mionjs/run-types';
@@ -75,37 +76,75 @@ describe('respectBinarySize: true — values fit the estimate', () => {
 });
 
 describe('respectBinarySize: false — values exceed the estimate', () => {
-  it('overshoots an unbounded position while staying valid', () => {
+  // dataView.ts MAX_VARINT — a serString write reserves MAX_VARINT + 3*length.
+  const MAX_VARINT = 5;
+  const reserve = (text: string): number => MAX_VARINT + 3 * text.length;
+  // A tiny cap keeps the inflated values small; the estimator clamps every
+  // estimate to sizeMaxBytes, so a reserve past it grows any cold buffer.
+  const TINY = {...SZ, sizeMaxBytes: 64};
+  const SEEDS = Array.from({length: 64}, (_, i) => i + 1);
+
+  it('inflates the one unbounded string past sizeMaxBytes for EVERY seed, the rest in-bounds', () => {
     const schema = RT.object({s: TF.string(), arr: RT.array(TF.number())});
     const validate = createValidateFn(schema);
-    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: SZ}});
-    let exceeded = 0;
-    for (let i = 0; i < 200; i++) {
-      const v = mock() as {s: string; arr: number[]};
+    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: TINY}});
+    for (const seed of SEEDS) {
+      const v = mock({mock: {seed}}) as {s: string; arr: number[]};
       expect(validate(v)).toBe(true);
-      if (utf8(v.s) > SZ.sizeStringBytes || v.arr.length > SZ.sizeItems) exceeded++;
+      expect(reserve(v.s), `seed ${seed}: string reserve`).toBeGreaterThan(TINY.sizeMaxBytes);
+      expect(v.arr.length, `seed ${seed}: array stays in-bounds`).toBeLessThanOrEqual(TINY.sizeItems);
     }
-    expect(exceeded).toBeGreaterThan(100);
   });
 
-  it('inflates an unbounded bigint past the decimal budget', () => {
-    const schema = RT.array(TF.bigInt());
-    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: SZ}});
-    let big = 0;
-    for (let i = 0; i < 100; i++) {
-      for (const v of mock() as bigint[]) if (v.toString().replace('-', '').length > 20) big++;
+  it('inflates an unbounded bigint past sizeMaxBytes for EVERY seed', () => {
+    const schema = RT.object({big: TF.bigInt()});
+    const validate = createValidateFn(schema);
+    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: TINY}});
+    for (const seed of SEEDS) {
+      const v = mock({mock: {seed}}) as {big: bigint};
+      expect(validate(v)).toBe(true);
+      expect(reserve(v.big.toString()), `seed ${seed}: bigint reserve`).toBeGreaterThan(TINY.sizeMaxBytes);
     }
-    expect(big).toBeGreaterThan(0);
+  });
+
+  it('overshoots the default 64 KiB cap when sizeMaxBytes is omitted', () => {
+    const schema = TF.string();
+    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: {sizeBias: 1}}});
+    expect(reserve(mock() as string)).toBeGreaterThan(64 * 1024);
+  });
+
+  it('falls back to an array-count overshoot when no string / bigint is unbounded', () => {
+    const schema = RT.object({arr: RT.array(TF.number())});
+    const validate = createValidateFn(schema);
+    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: TINY}});
+    for (const seed of SEEDS) {
+      const v = mock({mock: {seed}}) as {arr: number[]};
+      expect(validate(v)).toBe(true);
+      expect(v.arr.length, `seed ${seed}`).toBeGreaterThan(TINY.sizeItems);
+    }
+  });
+
+  it('does not inflate a template literal (a pattern, so a longer string would be invalid)', () => {
+    const schema = RT.object({id: RT.templateLiteral(['user-', TF.number()]), free: TF.string()});
+    const validate = createValidateFn(schema);
+    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: TINY}});
+    for (const seed of SEEDS) {
+      const v = mock({mock: {seed}}) as {id: string; free: string};
+      expect(validate(v)).toBe(true);
+      expect(v.id).toMatch(/^user-/);
+      expect(reserve(v.free)).toBeGreaterThan(TINY.sizeMaxBytes);
+    }
   });
 
   it('does not inflate a maxLength-bounded string (stays valid)', () => {
     const schema = RT.object({fixed: TF.string({maxLength: 4}), free: TF.string()});
     const validate = createValidateFn(schema);
-    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: SZ}});
-    for (let i = 0; i < 100; i++) {
-      const v = mock() as {fixed: string; free: string};
+    const mock = createMockDataFn(schema, {mock: {respectBinarySize: false, binarySizingOptions: TINY}});
+    for (const seed of SEEDS) {
+      const v = mock({mock: {seed}}) as {fixed: string; free: string};
       expect(validate(v)).toBe(true);
       expect(v.fixed.length).toBeLessThanOrEqual(4); // the bounded field is never the inflated one
+      expect(reserve(v.free)).toBeGreaterThan(TINY.sizeMaxBytes);
     }
   });
 });


### PR DESCRIPTION
## What

`MION_FUZZ_SEED=0xd179ff0b pnpm rtx core fuzz size --quick` failed in under a second with "size fuzz floor: the oversized value did not grow the cold buffer" (the release gate on PR #201), while an unseeded run passed. The negative control was seed-dependent.

## Root cause

The floor type `{tag: string; items: string[]}` estimates to 82 bytes. The `respectBinarySize: false` generator started from a plain, un-sized base value and inflated ONE string past that position's own budget (2x to 4x `sizeStringBytes`). The estimate is the SUM of every position's budget, so a seed whose base value came in under budget elsewhere never reached it: under `0xd179ff0b` the base gave `items: []` and a 23-char `tag` (reserve 5 + 3*23 = 74 < 82), so nothing grew. Other seeds "passed" only because the un-sized base happened to be kilobytes of unicode strings.

## Fix (the mock sizing, not the assertion)

- The inflated string / bigint now exceeds `sizeMaxBytes`, the cap the estimator clamps every estimate to, so that one position overflows any cold buffer on its own, for every seed and every config. `resolveSizing` resolves `sizeMaxBytes` (default 64 KiB) and `overBudgetLength` gives the shortest payload whose write reserve exceeds a budget.
- The oversized value now starts from the same in-bounds base as `respectBinarySize: true`, so the overflow is the inflated position's alone and values stay small.
- Template literals are no longer inflation targets (a longer random string would not match the pattern, so the value would be invalid).
- The `runFloor` assertion is untouched.

## Tests

- `respectBinarySize.test.ts`: for 64 seeds each, the inflated string / bigint reserve exceeds `sizeMaxBytes` while the rest stays in-bounds; the array fallback, the untouched `maxLength` and template literal fields, and the default 64 KiB cap.
- New `test/fuzz/binary/binaryOversizedControl.test.ts` (resolver-backed): the floor type under every `SIZE_CONFIGS` entry, for the CI seed, seed 8, the default seed and 48 more: the in-bounds value never grows, the oversized value always grows.
- Verified: the seeded `--quick` run and the `--soak` run pass, `pnpm run test:ci` (all 7 batches) and `pnpm run lint` are green.

Spec moved to `docs/done/size-fuzz-floor-negative-control.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Efs8EfuE6YMo6L51Vz4Mg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Efs8EfuE6YMo6L51Vz4Mg2)_