### PR TITLE
fix(release): converted-suites expects 22 refusals, each matched to a documented row

### DIFF
--- a/container/website/sites/runtypes/content/02.guide/13.source-conversion.md
+++ b/container/website/sites/runtypes/content/02.guide/13.source-conversion.md
@@ -78,7 +78,10 @@ What is left is the short list below, where even the escape cannot help because 
 | ----- | --- |
 | A cycle that never passes through a named type | The self reference has nothing to point at. Give the inner type a name and it converts. |
 | A symbol-keyed property | The property name is a symbol, and an escape can only carry a type it can write down. |
-| A recursive type written inline at a call site | The call has no name for the loop to close on. Declare the type with a name and it converts. |
+| A unique symbol literal type (`typeof sym`) | No builder can spell a symbol value. |
+| A property tagged `@nonEnumerable` | The tag shapes the wire format but has no builder spelling, so dropping it would change the type's identity. |
+| A recursive type reaching a call site through a mapped type such as `DataOnly<T>` | The mapping hands the call an unnamed copy of the loop, so there is no name to close it on. Pass the named type itself and it converts. |
+| A recursive tuple reaching a call site through a mapped type | Same cause, and a tuple slot cannot tie the knot either. Put the recursion behind an object, array, Map, Set or function slot. |
 | A reference to a type whose file is not in the same run | Add that file to the same command. |
 | A Temporal type that resolves to `any` | The Temporal declarations are missing from your project. Add the `ESNext.Temporal` lib or a polyfill's types. Converting would bake the `any` in permanently. |
 

--- a/docs/done/converted-suites-refusal-count-drift.md
+++ b/docs/done/converted-suites-refusal-count-drift.md
@@ -1,0 +1,78 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-02
+---
+
+# The converted-suites refusal count no longer matches the tree (23 expected, 22 seen)
+
+## Intent
+
+The release gate's "suite tree in the value forms" job (`pnpm rtx core converted-suites`)
+fails on `main`: the builders conversion now refuses 22 declarations, and
+[scripts/core/converted-suites.mjs](../../scripts/core/converted-suites.mjs) still expects 23.
+The script's own message says what happened: a conversion limitation was fixed and the count
+was not lowered with the commit that fixed it. Until it is, `release-gate.yml` cannot go green,
+so no release can ship.
+
+Found on 2026-09-02 while running the release gate on the merge-plan close-out branch
+(PR #201); reproduces locally on that branch and predates it (the branch touches no
+conversion code).
+
+## Direction
+
+- Reproduce: `pnpm rtx core converted-suites`. The log lists the 22 remaining refusals.
+- Find which of the 23 documented limitations now converts: diff the listed refusals against
+  the rows in
+  [packages/run-types/test/features/unsupported-conversion.test.ts](../../packages/run-types/test/features/unsupported-conversion.test.ts)
+  (that test is the documented list; when a row starts converting it fails too, so it may
+  already be red, or its row may already have been removed without the count following).
+  `git log` on `ts-go-runtypes/internal/convert` (or the equivalent package) shows the fixing
+  commit.
+- Lower `expectedRefusals` to 22 and, if the unsupported-conversion table still carries the
+  fixed row, drop it. Keep the count and the table in the same commit, as the script asks.
+- Consider deriving the expected count from the unsupported-conversion rows instead of a
+  literal, so the two can never drift again; the implementer decides whether that is worth it.
+
+## Done when
+
+- `pnpm rtx core converted-suites` passes.
+- `packages/run-types/test/features/unsupported-conversion.test.ts` passes and lists exactly
+  the refusals the script prints.
+- `release-gate.yml`'s "suite tree in the value forms" job is green on `main`.
+
+## Plan (approved 2026-09-02, implemented the same day)
+
+Findings that shaped it:
+
+- No fixing commit exists. Rebuilding the resolver at the root commit of the current history
+  (`ece3e26`, the one that also set `expectedRefusals: 23`) and converting that commit's own
+  suite tree already yields 22 refusals. The number was stale from the start; nothing in the
+  converter changed the count since.
+- The suite tree refuses five KINDS: a `unique symbol` literal at a call site (12), a nested
+  recursive type reached through `DataOnly<T>` at a call site (4), a recursive tuple reached
+  through `DataOnly<T>` at a call site (2), a symbol-keyed member (2), and an `@nonEnumerable`
+  member (2). Only the last two kinds had a row in `unsupported-conversion.test.ts`; the docs
+  table carried a third row ("a recursive type written inline at a call site") that described
+  no real refusal: a call naming a local recursive type is skipped silently, not refused.
+- The count cannot be derived from the table: the table lists kinds, the count is instances.
+  What CAN be derived is whether every printed refusal belongs to a documented kind.
+
+What shipped:
+
+1. `scripts/core/converted-suites.mjs`: `expectedRefusals` is 22, and every refusal line must
+   now contain the `says` fragment of a row in `unsupported-conversion.test.ts` (read off the
+   test file itself). An undocumented refusal fails the run with the offending lines, so a new
+   limitation cannot land without its row, and a fixed one still trips the count.
+2. `packages/run-types/test/features/unsupported-conversion.test.ts`: four new rows, each a
+   real declaration handed to the real binary: the unique symbol literal, the `@nonEnumerable`
+   member, the nested recursive type through `DataOnly` at a call site, and the recursive tuple
+   through `DataOnly` at a call site. The comment on recursion explains why a call site refuses
+   where a declaration converts.
+3. `container/website/sites/runtypes/content/02.guide/13.source-conversion.md`: the "what does
+   not convert" table mirrors the test rows again (four rows added, the inaccurate inline-call
+   row reworded to the mapped-type shape that actually refuses).
+
+Verified: the unsupported-conversion test passes (8 rows), and `pnpm rtx core converted-suites`
+generates the builders tree with 22 documented refusals and runs it green.

--- a/packages/run-types/test/features/unsupported-conversion.test.ts
+++ b/packages/run-types/test/features/unsupported-conversion.test.ts
@@ -89,12 +89,67 @@ const UNSUPPORTED: readonly UnsupportedCase[] = [
     says: 'symbol-keyed member',
     keeps: 'export type Tagged = {[tag]: number};',
   },
+  {
+    title: 'a unique symbol literal (typeof sym), which no builder can spell',
+    files: {'main.ts': 'declare const sym: unique symbol;\nexport type Tag = typeof sym;\n'},
+    target: 'builders',
+    code: 'CNV001',
+    says: 'a literal is not convertible',
+    keeps: 'export type Tag = typeof sym;',
+  },
+  {
+    title: 'a member tagged @nonEnumerable, a descriptor no builder form carries',
+    files: {'main.ts': 'export type Hidden = {\n  /** @nonEnumerable */\n  secret?: string;\n  name: string;\n};\n'},
+    target: 'builders',
+    code: 'CNV001',
+    says: 'marked @nonEnumerable',
+    keeps: '/** @nonEnumerable */\n  secret?: string;',
+  },
 
   // NOT listed: recursive declarations. Every named recursive declaration now
   // converts — plain data shapes through RT.circular/RT.self(), and the
   // shapes RT.circular cannot carry (a getRunType escape on the cycle, a
   // cycle closing on a tuple slot) through the LAZY PAIR: the type stays a
   // real declaration and gains a `getRunType<Name>()` handle const.
+  //
+  // A CALL SITE has no declaration to pair with, so the same cycles refuse
+  // there when the recursive type is local to the enclosing function and a
+  // mapped type (DataOnly<T>, Partial<T>) stands between the call and the
+  // name: the mapping hands the printer an anonymous copy of the loop. A call
+  // that names the local recursive type directly is left as written instead (a
+  // skip, not a refusal), since the name still works in type form; a top-level
+  // recursive type converts as a declaration and its calls ride the escape.
+  {
+    title: 'a recursive type below the root, reaching a call site through a mapped type (DataOnly)',
+    files: {
+      'main.ts':
+        "import {createValidateFn, type DataOnly} from '@mionjs/run-types';\n" +
+        'export const validate = () => {\n' +
+        '  interface Leaf {\n    name: string;\n    child?: Leaf;\n  }\n' +
+        '  interface Root {\n    isRoot: true;\n    leaf: Leaf;\n  }\n' +
+        '  return createValidateFn<DataOnly<Root>>();\n' +
+        '};\n',
+    },
+    target: 'builders',
+    code: 'CNV001',
+    says: 'cycle through an unnamed type',
+    keeps: 'createValidateFn<DataOnly<Root>>()',
+  },
+  {
+    title: 'a recursive tuple reaching a call site through a mapped type (the cycle closes on a tuple slot)',
+    files: {
+      'main.ts':
+        "import {createValidateFn, type DataOnly} from '@mionjs/run-types';\n" +
+        'export const validate = () => {\n' +
+        '  type Pair = [number, Pair?];\n' +
+        '  return createValidateFn<DataOnly<Pair>>();\n' +
+        '};\n',
+    },
+    target: 'builders',
+    code: 'CNV001',
+    says: 'closes on a tuple slot',
+    keeps: 'createValidateFn<DataOnly<Pair>>()',
+  },
 
   // ── Cross-file references the run cannot see ──────────────────────────
   {

--- a/scripts/core/converted-suites.mjs
+++ b/scripts/core/converted-suites.mjs
@@ -18,9 +18,12 @@
 // spell is left byte-identical and keeps working in type form, so the suite
 // still runs. The counts below are the contract — if a target starts refusing
 // MORE, something regressed; if it refuses FEWER, a limitation was fixed and the
-// number should come down with the commit that fixed it.
+// number should come down with the commit that fixed it. The count alone cannot
+// tell a new limitation from an old one, so every refusal is ALSO matched
+// against the documented list: its message must carry the `says` fragment of a
+// row in unsupported-conversion.test.ts, or the run fails as undocumented.
 import {execFileSync, spawnSync} from 'node:child_process';
-import {existsSync, rmSync} from 'node:fs';
+import {existsSync, readFileSync, rmSync} from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -30,6 +33,7 @@ const SUITES = path.join(PACKAGE_ROOT, 'test/suites');
 const BINARY = path.join(REPO_ROOT, 'bin/mion');
 const TSCONFIG = path.join(PACKAGE_ROOT, 'tsconfig.test.json');
 const VITEST_CONFIG = path.join(PACKAGE_ROOT, 'vitest.converted.config.ts');
+const UNSUPPORTED_LIST = path.join(PACKAGE_ROOT, 'test/features/unsupported-conversion.test.ts');
 
 // Per target: the tree it generates, and the number of declarations convert is
 // expected to refuse. Every refusal is a documented limitation with a row in
@@ -37,8 +41,18 @@ const VITEST_CONFIG = path.join(PACKAGE_ROOT, 'vitest.converted.config.ts');
 // BUILDER has to come out as a TypeScript expression, so a shape with no
 // factory spelling has nowhere to go.
 const TARGETS = [
-  {name: 'builders', dir: path.join(PACKAGE_ROOT, 'test/converted-builders'), expectedRefusals: 23},
+  {name: 'builders', dir: path.join(PACKAGE_ROOT, 'test/converted-builders'), expectedRefusals: 22},
 ];
+
+// The `says` fragments of the documented list, read off the test file itself so
+// the two can never drift: a refusal whose message matches none of them is a
+// limitation nobody wrote down.
+function documentedFragments() {
+  const source = readFileSync(UNSUPPORTED_LIST, 'utf8');
+  const fragments = [...source.matchAll(/^\s*says:\s*(['"])(.+?)\1,?\s*$/gm)].map((match) => match[2]);
+  if (fragments.length === 0) throw new Error(`converted-suites: no \`says\` rows found in ${UNSUPPORTED_LIST}`);
+  return fragments;
+}
 
 const args = process.argv.slice(2);
 const keep = args.includes('--keep');
@@ -71,6 +85,18 @@ function generate(target) {
   const refusals = (result.stderr ?? '').split('\n').filter((line) => /CNV\d{3} error/.test(line));
   const rewritten = (result.stdout ?? '').split('\n').filter((line) => line.startsWith('rewrote ')).length;
   console.log(`-> ${target.name}: rewrote ${rewritten} file(s), ${refusals.length} refusal(s)`);
+  const fragments = documentedFragments();
+  const undocumented = refusals.filter((line) => !fragments.some((fragment) => line.includes(fragment)));
+  if (undocumented.length > 0) {
+    console.error(
+      `converted-suites: ${target.name} produced ${undocumented.length} refusal(s) no row in ` +
+        `${path.relative(REPO_ROOT, UNSUPPORTED_LIST)} documents. Add the row (its \`says\` fragment must ` +
+        'appear in the message) with the commit that introduced the limitation.\n' +
+        undocumented.join('\n')
+    );
+    process.exitCode = 1;
+    return false;
+  }
   if (refusals.length !== target.expectedRefusals) {
     console.error(
       `converted-suites: ${target.name} produced ${refusals.length} refusals, expected ${target.expectedRefusals}.\n` +


### PR DESCRIPTION
## Why

The release gate's "suite tree in the value forms" job (`pnpm rtx core converted-suites`) fails on `main`: the builders conversion refuses 22 declarations while the script expected 23. Implements `docs/todos/converted-suites-refusal-count-drift.md` (moved to `docs/done/`).

There is no fixing commit to point at. Rebuilding the resolver at the root commit of the current history (the same commit that set `expectedRefusals: 23`) and converting that commit's own suite tree already yields 22 refusals. The number was stale from the start.

## What changed

- **`scripts/core/converted-suites.mjs`**: `expectedRefusals` is 22. Every refusal line must now also contain the `says` fragment of a row in `unsupported-conversion.test.ts` (read off the test file). A refusal nobody documented fails the run with the offending lines, so the count and the table can no longer drift apart in either direction.
- **`packages/run-types/test/features/unsupported-conversion.test.ts`**: four new rows for kinds the suite tree refuses but the table did not list: a `unique symbol` literal, an `@nonEnumerable` member, a nested recursive type reaching a call site through `DataOnly<T>`, and a recursive tuple reaching a call site through `DataOnly<T>`. Each row is a real declaration handed to the real binary.
- **Website** (`02.guide/13.source-conversion.md`): the "what does not convert" table mirrors the test rows again. The old "recursive type written inline at a call site" row described no real refusal (such a call is skipped, not refused) and is reworded to the mapped-type shape that does refuse.

## Verified

- `pnpm exec vitest run packages/run-types/test/features/unsupported-conversion.test.ts`: 8 passed.
- `pnpm rtx core converted-suites`: 80 files rewritten, 22 refusals all matched to documented rows, converted tree 87 files / 7349 tests green.
- `pnpm run lint`, `pnpm run format`, `pnpm run typecheck:test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AupUXgmn3kYvvEK2MN79s

---
_Generated by [Claude Code](https://claude.ai/code/session_017AupUXgmn3kYvvEK2MN79s)_