### PR TITLE
fix(runtypes): keep the compact union envelope when a member positionalizes a nested object

### DIFF
--- a/docs/done/roundtrip-compact-quoted-object-key.md
+++ b/docs/done/roundtrip-compact-quoted-object-key.md
@@ -1,0 +1,114 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-02
+---
+
+# Compact codec loses an object whose key contains a double quote
+
+## Intent
+
+The roundtrip fuzz soak (`fuzz soak · roundtrip` in `release-gate.yml` and `fuzz-soak.yml`)
+found 4 violations, all on one generated type, all in the COMPACT format. A value like
+
+```json
+{"kind":"t1","f0":[{"with\"quote":true}]}
+```
+
+comes back from the compact round-trip as
+
+```json
+{"kind":"t1","f0":[[true]]}
+```
+
+The object with the quoted key turns into a bare array, `validate` rejects the decoded value,
+compact disagrees with clone and with the native JSON projection, and the wire is not stable.
+The other codecs (json, binary, clone) agree with each other, so this is a compact encoder or
+decoder bug around escaping a `"` inside an object key, most likely in the key table or the
+object/array discrimination.
+
+Found on 2026-09-02 by the release gate on PR #201 (run 33579204363, seed `0xd179ff0b`).
+Predates that branch, which touches no codec code.
+
+## Direction
+
+- Replay: `MION_FUZZ_SEED=0xd179ff0b pnpm rtx core fuzz roundtrip --soak`. The violating
+  type is logged as `({1}|{2}|{1}|{1}) (seed=2792797093)` with the four `RT-*/compact`
+  oracle names; the fuzz harness under `packages/run-types/test/fuzz/roundtrip/` can
+  regenerate that one type from its per-type seed.
+- Reduce it to a hand-written feature test first (a union arm whose object has a key with a
+  `"` in it, nested in an array), so the fix is pinned by a deterministic test and not only
+  by the fuzzer. Follow the Marker test coverage rule in `ts-go-runtypes/CLAUDE.md` if the
+  test goes through the marker API.
+- Then fix the compact codec (the Go emitter and its JS twin, whichever side owns key
+  escaping) and confirm the seeded soak passes.
+
+## Done when
+
+- The reduced feature test passes and the compact round-trip of a quoted-key object equals
+  the clone / json results.
+- `MION_FUZZ_SEED=0xd179ff0b pnpm rtx core fuzz roundtrip --soak` reports 0 violations.
+- `fuzz soak · roundtrip` is green on `main`.
+
+## Plan, compact union envelope (implemented 2026-09-02)
+
+Planned and built by the delegated background session; no interactive plan approval was
+available, so the plan below is the one that shipped.
+
+### What was actually wrong
+
+The quote was incidental. The compact strategy reuses the flat-union encode / decode of the
+keyed strategies, and those drop the `[idx, value]` / `[-1, merged]` envelope on a union
+whose members are all plain JSON data (`roundTripsRaw`), leaving the decoder as the
+identity. Compact still turns every NESTED object into a positional array, so for
+
+```ts
+type T = {kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'} | {kind: 't3'};
+```
+
+the encoder wrote `{"kind":"t1","f0":[[true]]}` and the identity decoder handed the array
+straight back. Every union of plain objects with a nested object (array, tuple, record or
+direct) failed the same way, quoted key or not. There is no JS twin of this codec; the fix
+is Go only.
+
+### Fix
+
+- `union_flat_compact.go` (new): `compactUnionNeedsEnvelope` answers "does any surviving
+  member positionalize something?", asking each keyed member's property / index-signature
+  values and each atomic member whole through the existing cjr noop predicate. It mirrors
+  `unionJsonNoop`'s member walk instead of `buildFlatLayout` so the predicate never emits
+  duplicate drop diagnostics, and threads the caller's cycle set.
+- `buildCompactFlatLayout` widens `AtomicNeedsTuple` with that verdict; both compact union
+  arms build their layout through it, so encode and decode agree on the wire.
+- `emitUnionPrepareForJsonSafe` / `emitUnionRestoreFromJsonFlat` gained layout-taking
+  variants; the keyed strategies keep the raw round-trip and the record-union optimisation.
+- `compactFromJsonNoopRecursive`'s union arm now also requires "no compact envelope", so
+  the noop gate cannot elide the decode it just started emitting.
+
+Unions where nothing positionalizes (`Record<string, number> | {kind: 'x'}`) stay a bare
+object on compact exactly as before.
+
+### Tests
+
+- Go, `union_flat_compact_test.go`: rendered compactForJson / compactFromJson modules for
+  the nested-object union (envelope + positional `[v.b.c]` + unwrap), the record-of-numbers
+  union (still bare, noop entry), the atomic-only `{c: string}[] | string` (arms wrapped),
+  each contrasted with the keyed family staying raw; plus the helper's verdicts.
+- Go, `noop_types_test.go`: three new predicate fixtures pinning cjr false / rj true.
+- Go, `noop_predicate_test.go` corpus: four union shapes so the mechanical
+  predicate-vs-emitter soundness pin covers the rule across every family.
+- JS, `suites/serialization/CompactUnionEncoding.test.ts`: the soak shape and the
+  reduced shapes, asserting the compact wire and the round-trip, with the marker
+  coverage pair (value-first `createJsonEncoderFn(value, …)` versus static
+  `createJsonEncoderFn<T>(undefined, …)`, and both `getRunTypeId` shapes on one id).
+- JS, `suites/serialization/Unions.ts`: a `union_nested_object_member` case run through
+  every encoder x decoder pairing, binary and the value-first schema variants.
+- JS, `fuzz/type/compactUnionNestedObject.smoke.test.ts`: seven shapes through all five
+  lanes of the roundtrip harness, checking round-trip, validate and cross-lane agreement.
+- Seeded soak: `MION_FUZZ_SEED=0xd179ff0b pnpm rtx core fuzz roundtrip --soak`.
+
+### Docs
+
+None. The site does not describe the compact union wire, and the user-visible promise
+(compact round-trips like the other strategies) is unchanged; this restores it.

--- a/docs/todos/regex-sample-timeout-poisons-disk-cache.md
+++ b/docs/todos/regex-sample-timeout-poisons-disk-cache.md
@@ -1,0 +1,67 @@
+---
+type: fix
+spec: guidelines
+status: ready
+created: 2026-09-02
+---
+
+# A transient regex-sample timeout is cached as a build-halting FMT002 error
+
+## Intent
+
+While fixing the compact codec (`docs/done/roundtrip-compact-quoted-object-key.md`) a
+vitest run started on a loaded machine (a Go test run and a fuzz soak in parallel) and
+every later vitest run in the tree halted at startup with
+
+```
+@mionjs/devtools: 3 unsupported-type errors — build halted.
+packages/test-server/src/test-server.ts(287,4): error FMT002: Invalid type-format params:
+pattern /^[^\s@]{1,64}@(?:[a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,63}$/ does not compile as a JS
+RegExp: pattern evaluation timed out on a 16-character sample; the pattern may backtrack
+catastrophically
+```
+
+The pattern is the stock email format and matches a 16-character sample in about a
+millisecond. The verdict came from the regex sidecar's per-sample budget (250 ms, see
+`MATCH_BUDGET_MS` in `packages/go-be-sidecar/src/index.ts`), which was blown only because
+the machine was saturated. That transient verdict was then written into the resolver's
+disk cache with the entry it belongs to (`node_modules/.cache/mion/<fingerprint>/<typeID>/
+val.json`, the `diagnostics` field of `RTEntry` in
+`ts-go-runtypes/internal/cachegen/diskcache/format.go`) and replayed as an Error on every
+following run, on an idle machine, until the cache was deleted by hand. Two entries under
+`packages/client/node_modules/.cache/mion` and the ones under `packages/test-server`
+carried the text `backtrack catastrophically`.
+
+Predates the compact fix: the same tree without that change halts the same way as long as
+the poisoned entries exist, and passes with `MION_CACHE_DIR=""` (cache off) or after
+`rm -rf packages/*/node_modules/.cache/mion`.
+
+## Direction
+
+The implementer plans the details. Verified pointers:
+
+- The sidecar reports a timed-out sample as `compileError` via `runawayMessage`
+  (`ts-go-runtypes/internal/jsengine/sidecar.bundle.mjs`, built from
+  `packages/go-be-sidecar/src/index.ts`), and the resolver turns that into the Error
+  severity diagnostic `FMT002` (`CodeFMTInvalidParams` in
+  `ts-go-runtypes/internal/diagnostics/codes_runtype.go`).
+- The disk cache stores an entry's diagnostics alongside its code
+  (`ts-go-runtypes/internal/cachegen/diskcache/format.go`, `Diagnostics []CachedDiagnostic`),
+  so a verdict that depends on wall-clock load becomes permanent.
+- Two reasonable fixes, to be weighed: never cache an entry whose diagnostics include a
+  timeout verdict (a timeout is not a property of the type), and/or make the sidecar
+  retry a timed-out sample once on a quiet budget before declaring the pattern runaway.
+  The budget itself may also deserve a look: 250 ms per sample is tight under CI load.
+- Doc drift found on the way: the comments in
+  `ts-go-runtypes/internal/cachegen/diskcache/disk.go`, `format.go` and `fingerprint.go`
+  still name the cache dir `node_modules/.cache/ts-runtypes`; the resolver writes
+  `node_modules/.cache/mion` (`ts-go-runtypes/internal/compiler/resolver/resolver.go`).
+  Fix those comments in the same change.
+
+## Done when
+
+- A regex-sample timeout can no longer be replayed from the disk cache: a fresh run after
+  a loaded run does not halt on `FMT002` for a pattern that matches its sample quickly.
+- A test pins it (Go, around the disk cache write or the sidecar verdict, whichever side
+  owns the fix).
+- The diskcache comments name the real cache directory.

--- a/packages/run-types/test/fuzz/type/compactUnionNestedObject.smoke.test.ts
+++ b/packages/run-types/test/fuzz/type/compactUnionNestedObject.smoke.test.ts
@@ -1,0 +1,110 @@
+// Regression (roundtrip soak, seed 0xd179ff0b / per-type seed 2792797093): a
+// union of JSON-compatible object members round-trips raw on the keyed JSON
+// strategies (no envelope, identity decode). The compact strategy reused that
+// rule while positionalizing every NESTED object, so
+// `{kind: 't1', f0: [{"with\"quote": true}]}` came back as `{kind: 't1', f0: [[true]]}`
+// on the compact lane only. The quote is incidental: any nested object inside a
+// member of such a union broke the same way. Compact now keeps the union
+// envelope whenever a member positionalizes something, so all five lanes agree.
+import {describe, it, expect} from 'vitest';
+import {compileCodecs, openClient, hasBinary, ALL_LANES} from '../roundtrip/roundtripHarness.ts';
+import {typecheckGeneratedType} from './tsValidate.ts';
+import type {GeneratedType, TypeShape, PropShape} from '../core/typeGen.ts';
+
+function lit(value: string): TypeShape {
+  return {kind: 'literal', value};
+}
+function prop(name: string, shape: TypeShape): PropShape {
+  return {name, optional: false, readonly: false, method: false, shape};
+}
+function obj(...props: PropShape[]): TypeShape {
+  return {kind: 'object', props};
+}
+const bool: TypeShape = {kind: 'boolean'};
+const tagged = (tag: string, ...props: PropShape[]): TypeShape => obj(prop('kind', lit(tag)), ...props);
+
+const cases: {title: string; root: TypeShape; values: unknown[]}[] = [
+  {
+    title: 'the soak shape: tuple of a quoted-key object inside a tagged union',
+    root: {
+      kind: 'union',
+      members: [
+        tagged('t0'),
+        tagged('t1', prop('f0', {kind: 'tuple', elems: [obj(prop('with"quote', bool))]})),
+        tagged('t2'),
+        tagged('t3'),
+      ],
+    },
+    values: [{kind: 't1', f0: [{'with"quote': true}]}, {kind: 't0'}, {kind: 't3'}],
+  },
+  {
+    title: 'array of objects inside a tagged union',
+    root: {kind: 'union', members: [tagged('t0'), tagged('t1', prop('f0', {kind: 'array', elem: obj(prop('a', bool))}))]},
+    values: [
+      {kind: 't1', f0: [{a: true}, {a: false}]},
+      {kind: 't1', f0: []},
+    ],
+  },
+  {
+    title: 'nested object inside a tagged union',
+    root: {kind: 'union', members: [tagged('t0'), tagged('t1', prop('f0', obj(prop('a', bool))))]},
+    values: [{kind: 't1', f0: {a: true}}, {kind: 't0'}],
+  },
+  {
+    title: 'string | object with a nested object',
+    root: {kind: 'union', members: [{kind: 'string'}, tagged('t1', prop('f0', obj(prop('a', bool))))]},
+    values: [{kind: 't1', f0: {a: true}}, 'plain'],
+  },
+  {
+    title: 'record of objects | tagged object',
+    root: {kind: 'union', members: [{kind: 'record', value: obj(prop('a', bool))}, tagged('t1')]},
+    values: [{x: {a: true}}, {kind: 't1'}],
+  },
+  {
+    title: 'array of objects | string (no object member at all)',
+    root: {kind: 'union', members: [{kind: 'array', elem: obj(prop('a', bool))}, {kind: 'string'}]},
+    values: [[{a: true}], 'plain'],
+  },
+  {
+    title: 'same-named prop with two different object types',
+    root: {
+      kind: 'union',
+      members: [tagged('t0', prop('f', obj(prop('a', bool)))), tagged('t1', prop('f', obj(prop('b', {kind: 'number'}))))],
+    },
+    values: [
+      {kind: 't1', f: {b: 2}},
+      {kind: 't0', f: {a: false}},
+    ],
+  },
+];
+
+describe('compact strategy: union members holding nested objects', () => {
+  for (const {title, root, values} of cases) {
+    (hasBinary() ? it : it.skip)(`every lane round-trips and agrees with clone: ${title}`, async () => {
+      const gen: GeneratedType = {decls: [], root};
+      expect(typecheckGeneratedType(gen), `${title} must be valid TypeScript`).toEqual([]);
+      const client = openClient();
+      try {
+        const compiled = await compileCodecs(client, gen);
+        expect(compiled.resolverError, compiled.resolverError).toBeUndefined();
+        expect(compiled.evalError, compiled.evalError).toBeUndefined();
+        expect(compiled.errorDiagnostics).toEqual([]);
+        for (const value of values) {
+          const cloneWire = compiled.codecs.clone!.encode(value);
+          for (const lane of ALL_LANES) {
+            const codec = compiled.codecs[lane];
+            expect(codec, `${lane} codec wired`).toBeDefined();
+            const back = codec!.decode(codec!.encode(value));
+            expect(back, `${lane} round-trip`).toEqual(value);
+            expect(compiled.validate!(back), `${lane} decoded value validates`).toBe(true);
+            // Cross-lane agreement: re-encoding the decoded value on the clone
+            // lane yields the clone wire of the original.
+            expect(compiled.codecs.clone!.encode(back), `${lane} agrees with clone`).toBe(cloneWire);
+          }
+        }
+      } finally {
+        client.close();
+      }
+    });
+  }
+});

--- a/packages/run-types/test/suites/serialization/CompactUnionEncoding.test.ts
+++ b/packages/run-types/test/suites/serialization/CompactUnionEncoding.test.ts
@@ -1,0 +1,82 @@
+// Regression (roundtrip fuzz soak, seed 0xd179ff0b): a union of JSON-compatible
+// object members round-trips raw on the keyed strategies (no `[-1, …]` envelope,
+// identity decode). The compact strategy reused that rule, but it turns every
+// NESTED object into a positional array, so `{kind: 't1', f0: [{"with\"quote":
+// true}]}` came back as `{kind: 't1', f0: [[true]]}`. Compact now keeps the
+// envelope whenever a member positionalizes something, and drops it only when
+// nothing inside the union changes shape (the record-union optimisation).
+import {describe, expect, it} from 'vitest';
+import {createJsonDecoderFn, createJsonEncoderFn, getRunTypeId} from '@mionjs/run-types';
+
+// A top-level union enveloped on the wire starts with `[-1,` / `[<digit>,`.
+const TOP_ENVELOPE = /^\[-?\d/;
+
+type Tagged = {kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'} | {kind: 't3'};
+type NestedObject = {kind: 'a'} | {kind: 'b'; f: {x: number}};
+type ArrayOrString = {a: number}[] | string;
+type RecordOfObjects = Record<string, {a: number}> | {kind: 'x'};
+type RecordOfNumbers = Record<string, number> | {kind: 'x'};
+
+describe('serialization / compact union with nested objects (regression)', () => {
+  it('the soak shape: tuple of a quoted-key object inside a tagged union round-trips', () => {
+    const enc = createJsonEncoderFn<Tagged>(undefined, {strategy: 'compact'});
+    const dec = createJsonDecoderFn<Tagged>(undefined, {strategy: 'compact'});
+    const value: Tagged = {kind: 't1', f0: [{'with"quote': true}]};
+    const wire = enc(value)!;
+    expect(wire).toMatch(TOP_ENVELOPE);
+    expect(dec(wire)).toEqual(value);
+    expect(dec(enc({kind: 't0'})!)).toEqual({kind: 't0'});
+  });
+
+  it('nested object member keeps the envelope and rebuilds the keyed object', () => {
+    const enc = createJsonEncoderFn<NestedObject>(undefined, {strategy: 'compact'});
+    const dec = createJsonDecoderFn<NestedObject>(undefined, {strategy: 'compact'});
+    expect(enc({kind: 'b', f: {x: 1}})).toBe('[-1,{"kind":"b","f":[1]}]');
+    expect(dec(enc({kind: 'b', f: {x: 1}})!)).toEqual({kind: 'b', f: {x: 1}});
+    expect(dec(enc({kind: 'a'})!)).toEqual({kind: 'a'});
+  });
+
+  it('keyed strategies still round-trip the same union raw, without an envelope', () => {
+    const clone = createJsonEncoderFn<NestedObject>();
+    const dec = createJsonDecoderFn<NestedObject>();
+    expect(clone({kind: 'b', f: {x: 1}})).toBe('{"kind":"b","f":{"x":1}}');
+    expect(dec(clone({kind: 'b', f: {x: 1}})!)).toEqual({kind: 'b', f: {x: 1}});
+  });
+
+  it('atomic-only union whose array arm holds objects wraps its arms', () => {
+    const enc = createJsonEncoderFn<ArrayOrString>(undefined, {strategy: 'compact'});
+    const dec = createJsonDecoderFn<ArrayOrString>(undefined, {strategy: 'compact'});
+    expect(enc([{a: 1}])).toMatch(TOP_ENVELOPE);
+    expect(dec(enc([{a: 1}])!)).toEqual([{a: 1}]);
+    expect(dec(enc('hi')!)).toBe('hi');
+  });
+
+  it('record member with object values wraps, record member with atomic values stays bare', () => {
+    const objects = createJsonEncoderFn<RecordOfObjects>(undefined, {strategy: 'compact'});
+    const objectsDec = createJsonDecoderFn<RecordOfObjects>(undefined, {strategy: 'compact'});
+    expect(objects({x: {a: 1}})).toMatch(TOP_ENVELOPE);
+    expect(objectsDec(objects({x: {a: 1}})!)).toEqual({x: {a: 1}});
+    expect(objectsDec(objects({kind: 'x'})!)).toEqual({kind: 'x'});
+
+    const numbers = createJsonEncoderFn<RecordOfNumbers>(undefined, {strategy: 'compact'});
+    const numbersDec = createJsonDecoderFn<RecordOfNumbers>(undefined, {strategy: 'compact'});
+    expect(numbers({x: 1})).toBe('{"x":1}');
+    expect(numbersDec(numbers({x: 1})!)).toEqual({x: 1});
+  });
+
+  // Marker coverage rule: the value-first factory shape `createJsonEncoderFn(value,
+  // …)` infers T from the value and must land on the same compact codec as the
+  // static `createJsonEncoderFn<T>(undefined, …)` shape; both getRunTypeId shapes
+  // must resolve the union to ONE id.
+  it('value-first and static shapes produce the same compact wire (reflect + static)', () => {
+    const value: NestedObject = {kind: 'b', f: {x: 1}};
+    const reflectEnc = createJsonEncoderFn(value, {strategy: 'compact'});
+    const staticEnc = createJsonEncoderFn<NestedObject>(undefined, {strategy: 'compact'});
+    expect(reflectEnc(value)).toBe(staticEnc(value));
+
+    const reflectDec = createJsonDecoderFn(value, {strategy: 'compact'});
+    expect(reflectDec(staticEnc(value)!)).toEqual(value);
+
+    expect(getRunTypeId(value)).toBe(getRunTypeId<NestedObject>());
+  });
+});

--- a/packages/run-types/test/suites/serialization/Unions.ts
+++ b/packages/run-types/test/suites/serialization/Unions.ts
@@ -160,6 +160,75 @@ export const UNIONS = {
       ),
     getTestData: () => ({values: [{a: 'world', aa: true}, {b: 7}, {c: 1n}, {d: 'hello'}, {}]}),
   },
+  union_nested_object_member: {
+    title: 'Tagged union with a nested object member',
+    description:
+      'Tagged union ({kind: "t0"} | {kind: "t1"; f0: [{"with\"quote": boolean}]} | {kind: "t2"}) where every member is plain JSON data, but one member holds a tuple with a nested object. The keyed strategies round-trip it raw; compact must keep its union envelope because it turns the nested object into a positional array.',
+    serializeNotes:
+      'Regression from the roundtrip fuzz soak: compact used to skip the union envelope for JSON-compatible unions and handed the nested object back as a bare array. The quoted key is the shape the soak found; any nested object triggered it.',
+    mutateEncoder: () =>
+      createJsonEncoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(undefined, {
+        strategy: 'mutate',
+      }),
+    cloneEncoder: () =>
+      createJsonEncoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(undefined, {
+        strategy: 'clone',
+      }),
+    directEncoder: () =>
+      createJsonEncoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(undefined, {
+        strategy: 'direct',
+      }),
+    compactEncoder: () =>
+      createJsonEncoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(undefined, {
+        strategy: 'compact',
+      }),
+    stripDecoder: () => createJsonDecoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(),
+    preserveDecoder: () =>
+      createJsonDecoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(undefined, {
+        strategy: 'preserve',
+      }),
+    compactDecoder: () =>
+      createJsonDecoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(undefined, {
+        strategy: 'compact',
+      }),
+    binaryEncoder: () => createBinaryEncoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(),
+    binaryDecoder: () => createBinaryDecoderFn<{kind: 't0'} | {kind: 't1'; f0: [{'with"quote': boolean}]} | {kind: 't2'}>(),
+    schemaEncoder: () =>
+      createJsonEncoderFn(
+        RT.union([
+          RT.object({kind: RT.literal('t0')}),
+          RT.object({kind: RT.literal('t1'), f0: RT.tuple({required: [RT.object({'with"quote': RT.boolean()})]})}),
+          RT.object({kind: RT.literal('t2')}),
+        ])
+      ),
+    schemaDecoder: () =>
+      createJsonDecoderFn(
+        RT.union([
+          RT.object({kind: RT.literal('t0')}),
+          RT.object({kind: RT.literal('t1'), f0: RT.tuple({required: [RT.object({'with"quote': RT.boolean()})]})}),
+          RT.object({kind: RT.literal('t2')}),
+        ])
+      ),
+    schemaBinaryEncoder: () =>
+      createBinaryEncoderFn(
+        RT.union([
+          RT.object({kind: RT.literal('t0')}),
+          RT.object({kind: RT.literal('t1'), f0: RT.tuple({required: [RT.object({'with"quote': RT.boolean()})]})}),
+          RT.object({kind: RT.literal('t2')}),
+        ])
+      ),
+    schemaBinaryDecoder: () =>
+      createBinaryDecoderFn(
+        RT.union([
+          RT.object({kind: RT.literal('t0')}),
+          RT.object({kind: RT.literal('t1'), f0: RT.tuple({required: [RT.object({'with"quote': RT.boolean()})]})}),
+          RT.object({kind: RT.literal('t2')}),
+        ])
+      ),
+    getTestData: () => ({
+      values: [{kind: 't0'}, {kind: 't1', f0: [{'with"quote': true}]}, {kind: 't1', f0: [{'with"quote': false}]}, {kind: 't2'}],
+    }),
+  },
   union_with_discriminator_property: {
     title: 'Discriminated union',
     description:

--- a/ts-go-runtypes/internal/cachegen/typefunctions/json_compact.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/json_compact.go
@@ -161,7 +161,11 @@ func (CompactForJsonEmitter) Emit(rt *reflection.RunType, ctx *EmitContext, _ Co
 		// `[memberIndex, value]`, object members merge into `[-1, keyedObject]`.
 		// The merged object stays keyed (a union has no single positional shape);
 		// nested objects inside members still become positional via CompileChild.
-		return emitUnionPrepareForJsonSafe(rt, ctx, v)
+		// The layout is compact-widened: a union the keyed strategies pass
+		// through raw keeps the envelope when a member positionalizes, or the
+		// identity decoder would hand those nested arrays back as-is
+		// (union_flat_compact.go).
+		return emitUnionPrepareForJsonSafeLayout(rt, ctx, v, buildCompactFlatLayout(rt, ctx))
 
 	case reflection.KindIntersection:
 		return RTCode{Code: "", Type: CodeS}

--- a/ts-go-runtypes/internal/cachegen/typefunctions/json_compact_restore.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/json_compact_restore.go
@@ -145,8 +145,10 @@ func (CompactFromJsonEmitter) Emit(rt *reflection.RunType, ctx *EmitContext, _ C
 	case reflection.KindUnion:
 		// Reuse the keyed flat-union decode — symmetric with the compact encode,
 		// which reuses the keyed flat-union encode (object members merge into a
-		// keyed `[-1, object]` envelope; only nested objects go positional).
-		return emitUnionRestoreFromJsonFlat(rt, ctx, v)
+		// keyed `[-1, object]` envelope; only nested objects go positional). Same
+		// compact-widened layout as the encode, so both sides agree on whether
+		// the envelope is on the wire (union_flat_compact.go).
+		return emitUnionRestoreFromJsonFlatLayout(rt, ctx, v, buildCompactFlatLayout(rt, ctx))
 
 	case reflection.KindIntersection:
 		return RTCode{Code: "", Type: CodeS}

--- a/ts-go-runtypes/internal/cachegen/typefunctions/json_prepare_safe.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/json_prepare_safe.go
@@ -823,7 +823,12 @@ func emitIndexSignaturePrepareForJsonSafe(rt *reflection.RunType, ctx *EmitConte
 // restoreFromJson. Each clause returns a NEW value built from
 // safeChildExpr / buildSafeObjectClone; the input is never touched.
 func emitUnionPrepareForJsonSafe(rt *reflection.RunType, ctx *EmitContext, v string) RTCode {
-	layout := buildFlatLayout(rt, ctx)
+	return emitUnionPrepareForJsonSafeLayout(rt, ctx, v, buildFlatLayout(rt, ctx))
+}
+
+// emitUnionPrepareForJsonSafeLayout is the encode body over a caller-built
+// layout — compact widens the envelope rule first (buildCompactFlatLayout).
+func emitUnionPrepareForJsonSafeLayout(rt *reflection.RunType, ctx *EmitContext, v string, layout FlatLayout) RTCode {
 	if len(layout.AtomicMembers) == 0 && len(layout.ObjectMembers) == 0 {
 		return RTCode{Code: "", Type: CodeS}
 	}

--- a/ts-go-runtypes/internal/cachegen/typefunctions/noop_types.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/noop_types.go
@@ -705,9 +705,10 @@ func compactFromJsonNoopRecursive(rt *reflection.RunType, ctx *EmitContext, visi
 		return compactFromJsonNoopRecursive(rt.Child, ctx, visited)
 
 	case reflection.KindUnion:
-		// The compact union arm IS emitUnionRestoreFromJsonFlat — delegate
-		// to the shared flat-union rule (roundTripsRaw ⇒ identity).
-		return unionJsonNoop(rt, ctx)
+		// The compact union arm IS emitUnionRestoreFromJsonFlat over the
+		// compact-widened layout: the shared flat-union rule (roundTripsRaw ⇒
+		// identity) AND no member positionalizes (union_flat_compact.go).
+		return unionJsonNoop(rt, ctx) && !compactUnionNeedsEnvelope(rt, ctx, visited)
 	}
 	// undefined/void (force-rebind), bigint/symbol/regexp (value
 	// transforms), never/promise/function kinds (unsupported), and any

--- a/ts-go-runtypes/internal/cachegen/typefunctions/noop_types_test.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/noop_types_test.go
@@ -46,6 +46,17 @@ func noopPredicateTypes(t *testing.T) (*EmitContext, map[string]*reflection.RunT
 	unionDate := &reflection.RunType{ID: "uDat", Kind: reflection.KindUnion, Children: []*reflection.RunType{makeRef("str"), makeRef("dat")}}
 	unionObjects := &reflection.RunType{ID: "uObj", Kind: reflection.KindUnion, Children: []*reflection.RunType{makeRef("objCompat"), makeRef("objBig")}}
 
+	// The compact envelope rule (union_flat_compact.go): unions the keyed
+	// strategies round-trip raw, where a member positionalizes under compact —
+	// a merged object member holding a NESTED object, and an atomic array-of-
+	// objects member — versus one whose members hold only atomics (a numeric
+	// record beside a flat object), which stays raw on every strategy.
+	propInner := &reflection.RunType{ID: "pinner", Kind: reflection.KindProperty, Name: "inner", IsSafeName: true, Child: makeRef("objCompat")}
+	objNest := &reflection.RunType{ID: "objNest", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("pinner")}}
+	unionObjNest := &reflection.RunType{ID: "uObjNest", Kind: reflection.KindUnion, Children: []*reflection.RunType{makeRef("objCompat"), makeRef("objNest")}}
+	unionArrObjStr := &reflection.RunType{ID: "uArrObjStr", Kind: reflection.KindUnion, Children: []*reflection.RunType{makeRef("arrCO"), makeRef("str")}}
+	unionRecObj := &reflection.RunType{ID: "uRecObj", Kind: reflection.KindUnion, Children: []*reflection.RunType{makeRef("recA"), makeRef("objCompat")}}
+
 	// The user-reported shape: circular JSON-compatible object —
 	// `{a: string; d?: Self[]}` reached through an optional array prop.
 	circArr := &reflection.RunType{ID: "circArr", Kind: reflection.KindArray, Child: makeRef("circ")}
@@ -97,6 +108,7 @@ func noopPredicateTypes(t *testing.T) (*EmitContext, map[string]*reflection.RunT
 		arrCompatObj, arrStr, arrDate,
 		namedClass, anonClass,
 		unionAtomic, unionDate, unionObjects,
+		propInner, objNest, unionObjNest, unionArrObjStr, unionRecObj,
 		circArr, circProp, circ,
 		circDArr, circDProp, circDat,
 		anyT, unkT, lit, nev, propNever, objNever,
@@ -424,9 +436,12 @@ func TestNoopType_CompactFromJson(t *testing.T) {
 	}{
 		{"str", true},
 		{"arrStr", true},
-		{"uAt", true},        // raw-round-trip union (shared restore rule)
-		{"objCompat", false}, // rj says true — the delegation trap
-		{"arrCO", false},     // array of objects — positional elements
+		{"uAt", true},         // raw-round-trip union (shared restore rule)
+		{"uObjNest", false},   // rj says true — a merged member positionalizes its nested object
+		{"uArrObjStr", false}, // rj says true — the array arm positionalizes its elements
+		{"uRecObj", true},     // numeric record | flat object: nothing positionalizes, stays raw
+		{"objCompat", false},  // rj says true — the delegation trap
+		{"arrCO", false},      // array of objects — positional elements
 		{"dat", false},
 		{"und", false},
 		{"lit", true},
@@ -437,6 +452,13 @@ func TestNoopType_CompactFromJson(t *testing.T) {
 				t.Errorf("isNoopForCompactFromJson(%s) = %v, want %v", c.id, got, c.want)
 			}
 		})
+	}
+	// The divergence pin for the compact envelope rule: the keyed decoder
+	// round-trips these unions raw (identity), compact must not.
+	for _, id := range []string{"uObjNest", "uArrObjStr", "uRecObj"} {
+		if !isNoopForRestoreJson(types[id], ctx) {
+			t.Errorf("isNoopForRestoreJson(%s) = false, want true (the keyed strategies round-trip it raw)", id)
+		}
 	}
 }
 

--- a/ts-go-runtypes/internal/cachegen/typefunctions/union_flat.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/union_flat.go
@@ -310,7 +310,12 @@ func mergedPropPrepareBody(mp FlatMergedProp, accessor, discAccessor string, ctx
 // the compile-time decision tells the decoder exactly which shape to
 // expect.
 func emitUnionRestoreFromJsonFlat(rt *reflection.RunType, ctx *EmitContext, v string) RTCode {
-	layout := buildFlatLayout(rt, ctx)
+	return emitUnionRestoreFromJsonFlatLayout(rt, ctx, v, buildFlatLayout(rt, ctx))
+}
+
+// emitUnionRestoreFromJsonFlatLayout is the decode body over a caller-built
+// layout — compact widens the envelope rule first (buildCompactFlatLayout).
+func emitUnionRestoreFromJsonFlatLayout(rt *reflection.RunType, ctx *EmitContext, v string, layout FlatLayout) RTCode {
 	if len(layout.AtomicMembers) == 0 && len(layout.ObjectMembers) == 0 {
 		return RTCode{Code: "", Type: CodeS}
 	}

--- a/ts-go-runtypes/internal/cachegen/typefunctions/union_flat_compact.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/union_flat_compact.go
@@ -1,0 +1,98 @@
+package typefunctions
+
+import (
+	"github.com/mionkit/mion/ts-go-runtypes/internal/reflection"
+)
+
+// The compact strategy's union envelope rule.
+//
+// The keyed JSON strategies drop the `[idx, value]` / `[-1, merged]` envelope
+// on a union that round-trips raw (FlatLayout.roundTripsRaw: every member is
+// isJsonCompatible), and the decoder is identity: native JSON preserves every
+// member's shape, so nothing needs undoing. Compact reuses the flat-union
+// encode / decode (json_compact.go / json_compact_restore.go) but positionalizes
+// every nested object literal / plain class, a transform isJsonCompatible
+// cannot see. Under the shared rule `{kind: 'a'} | {kind: 'b'; f: {x: number}}`
+// encoded `f` as `[1]` and the identity decoder handed it back as an array.
+//
+// compactUnionNeedsEnvelope closes that gap: when any surviving member carries
+// a compact-only transform the compact pair keeps the envelope, so the encoder
+// writes `[-1, merged]` / `[idx, value]` and the decoder unwraps and walks the
+// arm — the same mixed-union path a `Date` member takes. Read by BOTH compact
+// emitters and by the cjr noop predicate (compactFromJsonNoopRecursive), so the
+// three cannot drift.
+
+// compactUnionNeedsEnvelope reports whether the compact pair must keep the
+// flat-union envelope on rt because a member positionalizes something. Mirrors
+// unionJsonNoop's member walk (stripped members skipped) rather than calling
+// buildFlatLayout, which emits drop diagnostics the predicate must not
+// duplicate. visited threads the caller's cycle set: a self-referential member
+// re-enters as identity (greatest fixpoint, the isJsonCompatible rule).
+func compactUnionNeedsEnvelope(rt *reflection.RunType, ctx *EmitContext, visited map[string]struct{}) bool {
+	children := rt.SafeUnionChildren
+	if len(children) == 0 {
+		children = rt.Children
+	}
+	for _, ref := range children {
+		resolved := ctx.ResolveRef(ref)
+		if resolved == nil || isStrippedUnionMember(resolved) {
+			continue
+		}
+		if compactUnionMemberTransforms(resolved, ctx, visited) {
+			return true
+		}
+	}
+	return false
+}
+
+// compactUnionEnvelope is the emitter entry: a fresh cycle set seeded with the
+// union itself, so a member that points back at rt reads as identity exactly
+// like the predicate's in-walk re-entry.
+func compactUnionEnvelope(rt *reflection.RunType, ctx *EmitContext) bool {
+	visited := make(map[string]struct{})
+	if rt.ID != "" {
+		visited[rt.ID] = struct{}{}
+	}
+	return compactUnionNeedsEnvelope(rt, ctx, visited)
+}
+
+// compactUnionMemberTransforms is one member's verdict. An object literal or
+// anonymous plain class stays KEYED on the union wire whichever bucket it lands
+// in (the merged branch has no single positional shape; an index-signature
+// shape in the atomic bucket routes to the keyed clone in
+// emitObjectCompactForJson), so only its member VALUES can positionalize and
+// the walk asks each property / index signature. Every other member compiles
+// whole through the compact arms, so its own cjr verdict decides — a named user
+// class, an array of objects, a Map with object values are all transforms.
+func compactUnionMemberTransforms(resolved *reflection.RunType, ctx *EmitContext, visited map[string]struct{}) bool {
+	keyed := resolved.Kind == reflection.KindObjectLiteral ||
+		(resolved.Kind == reflection.KindClass && resolved.SubKind == reflection.SubKindNone && userClassName(resolved) == "")
+	if !keyed {
+		return !compactFromJsonNoopRecursive(resolved, ctx, visited)
+	}
+	for _, childRef := range resolved.Children {
+		member := ctx.ResolveRef(childRef)
+		if member == nil || member.IsStatic || isFunctionLikeKind(member.Kind) {
+			continue
+		}
+		switch member.Kind {
+		case reflection.KindProperty, reflection.KindPropertySignature, reflection.KindIndexSignature:
+			if !compactFromJsonNoopRecursive(member, ctx, visited) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// buildCompactFlatLayout is buildFlatLayout plus the compact envelope rule: a
+// union the keyed strategies pass through raw still wraps when a member
+// positionalizes. Both compact emitters build their layout here so encode and
+// decode read the same AtomicNeedsTuple.
+func buildCompactFlatLayout(rt *reflection.RunType, ctx *EmitContext) FlatLayout {
+	layout := buildFlatLayout(rt, ctx)
+	if !layout.AtomicNeedsTuple && compactUnionEnvelope(rt, ctx) {
+		layout.AtomicNeedsTuple = true
+	}
+	return layout
+}

--- a/ts-go-runtypes/internal/cachegen/typefunctions/union_flat_compact_test.go
+++ b/ts-go-runtypes/internal/cachegen/typefunctions/union_flat_compact_test.go
@@ -1,0 +1,178 @@
+package typefunctions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mionkit/mion/ts-go-runtypes/internal/protocol"
+	"github.com/mionkit/mion/ts-go-runtypes/internal/reflection"
+)
+
+// buildNestedObjectUnionFixture builds the roundtrip-soak shape reduced to its
+// essence: a union of two JSON-compatible object members, one of which holds a
+// NESTED object literal —
+//
+//	{ a: string }  |  { b: { c: string } }
+//
+// Every member is isJsonCompatible, so the keyed strategies round-trip it raw
+// (no envelope, identity decode). Compact positionalizes `b` into `[v.b.c]`,
+// so it MUST keep the envelope or the identity decoder hands the array back.
+func buildNestedObjectUnionFixture() []*reflection.RunType {
+	str := &reflection.RunType{ID: "str", Kind: reflection.KindString}
+	propC := &reflection.RunType{ID: "pc", Kind: reflection.KindProperty, Name: "c", IsSafeName: true, Child: makeRef("str")}
+	inner := &reflection.RunType{ID: "inner", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("pc")}}
+	propA := &reflection.RunType{ID: "pa", Kind: reflection.KindProperty, Name: "a", IsSafeName: true, Child: makeRef("str")}
+	propB := &reflection.RunType{ID: "pb", Kind: reflection.KindProperty, Name: "b", IsSafeName: true, Child: makeRef("inner")}
+	obj1 := &reflection.RunType{ID: "ob1", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("pa")}}
+	obj2 := &reflection.RunType{ID: "ob2", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("pb")}}
+	union := &reflection.RunType{
+		ID: "uni", Kind: reflection.KindUnion,
+		Children:          []*reflection.RunType{makeRef("ob1"), makeRef("ob2")},
+		SafeUnionChildren: []*reflection.RunType{makeRef("ob1"), makeRef("ob2")},
+	}
+	return []*reflection.RunType{str, propC, inner, propA, propB, obj1, obj2, union}
+}
+
+// buildRecordNumberUnionFixture is the record-union optimisation's shape,
+// `{[key: string]: number} | {a: string}`: nothing positionalizes inside either
+// member, so compact must stay envelope-free exactly like the keyed strategies.
+func buildRecordNumberUnionFixture() []*reflection.RunType {
+	str := &reflection.RunType{ID: "str", Kind: reflection.KindString}
+	num := &reflection.RunType{ID: "num", Kind: reflection.KindNumber}
+	idx := &reflection.RunType{ID: "idx", Kind: reflection.KindIndexSignature, Child: makeRef("num"), Index: makeRef("str")}
+	rec := &reflection.RunType{ID: "rec", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("idx")}}
+	propA := &reflection.RunType{ID: "pa", Kind: reflection.KindProperty, Name: "a", IsSafeName: true, Child: makeRef("str")}
+	obj := &reflection.RunType{ID: "ob1", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("pa")}}
+	union := &reflection.RunType{
+		ID: "uni", Kind: reflection.KindUnion,
+		Children:          []*reflection.RunType{makeRef("rec"), makeRef("ob1")},
+		SafeUnionChildren: []*reflection.RunType{makeRef("rec"), makeRef("ob1")},
+	}
+	return []*reflection.RunType{str, num, idx, rec, propA, obj, union}
+}
+
+// buildArrayOfObjectsOrStringFixture is the atomic-only shape `{c: string}[] |
+// string`: no merged branch at all, but the array member positionalizes its
+// elements, so compact needs the `[idx, value]` arms where the keyed strategies
+// collapse to identity (atomicOnlyJsonIdentity).
+func buildArrayOfObjectsOrStringFixture() []*reflection.RunType {
+	str := &reflection.RunType{ID: "str", Kind: reflection.KindString}
+	propC := &reflection.RunType{ID: "pc", Kind: reflection.KindProperty, Name: "c", IsSafeName: true, Child: makeRef("str")}
+	inner := &reflection.RunType{ID: "inner", Kind: reflection.KindObjectLiteral, Children: []*reflection.RunType{makeRef("pc")}}
+	arr := &reflection.RunType{ID: "arr", Kind: reflection.KindArray, Child: makeRef("inner")}
+	union := &reflection.RunType{
+		ID: "uni", Kind: reflection.KindUnion,
+		Children:          []*reflection.RunType{makeRef("arr"), makeRef("str")},
+		SafeUnionChildren: []*reflection.RunType{makeRef("arr"), makeRef("str")},
+	}
+	return []*reflection.RunType{str, propC, inner, arr, union}
+}
+
+// TestCompactForJsonModule_NestedObjectUnionKeepsEnvelope — the compact encode
+// of `{a: string} | {b: {c: string}}` wraps the merged object in `[-1, …]` and
+// positionalizes the nested member (`[v.b.c]`), while the keyed clone encode
+// of the SAME fixture emits no envelope (the raw round-trip it is entitled to).
+func TestCompactForJsonModule_NestedObjectUnionKeepsEnvelope(t *testing.T) {
+	dump := protocol.Dump{RunTypes: buildNestedObjectUnionFixture()}
+
+	compact := renderModule(t, dump, "compactForJson")
+	if !strings.Contains(compact, "[-1, ") {
+		t.Errorf("compact encode must keep the `[-1, …]` envelope when a member positionalizes; got:\n%s", compact)
+	}
+	if !strings.Contains(compact, "[v.b.c]") {
+		t.Errorf("compact encode must positionalize the nested object `[v.b.c]`; got:\n%s", compact)
+	}
+
+	clone := renderModule(t, dump, "prepareForJsonSafe")
+	if strings.Contains(clone, "[-1, ") {
+		t.Errorf("clone encode of a JSON-compatible object union must stay envelope-free; got:\n%s", clone)
+	}
+}
+
+// TestCompactFromJsonModule_NestedObjectUnionUnwraps — the compact decode of
+// the same fixture unwraps the envelope and rebuilds the nested object, while
+// restoreFromJson stays identity (`return v`).
+func TestCompactFromJsonModule_NestedObjectUnionUnwraps(t *testing.T) {
+	dump := protocol.Dump{RunTypes: buildNestedObjectUnionFixture()}
+
+	compact := renderModuleDefault(t, dump, "compactFromJson")
+	if !strings.Contains(compact, "= v[0]") {
+		t.Errorf("compact decode must unwrap the envelope (`const dec = v[0]`); got:\n%s", compact)
+	}
+	if !strings.Contains(compact, "=== -1") {
+		t.Errorf("compact decode must dispatch the merged-object arm (`=== -1`); got:\n%s", compact)
+	}
+	if !strings.Contains(compact, "v.b = ") {
+		t.Errorf("compact decode must rebuild the nested object into `v.b`; got:\n%s", compact)
+	}
+
+	restore := renderModuleDefault(t, dump, "restoreFromJson")
+	if strings.Contains(restore, "= v[0]") {
+		t.Errorf("restoreFromJson of a JSON-compatible object union must stay identity; got:\n%s", restore)
+	}
+}
+
+// TestCompactForJsonModule_RecordNumberUnionStaysBare — nothing positionalizes
+// inside `{[key: string]: number} | {a: string}`, so compact keeps the
+// record-union optimisation: no envelope on either half.
+func TestCompactForJsonModule_RecordNumberUnionStaysBare(t *testing.T) {
+	dump := protocol.Dump{RunTypes: buildRecordNumberUnionFixture()}
+
+	compact := renderModule(t, dump, "compactForJson")
+	if strings.Contains(compact, "[-1, ") || strings.Contains(compact, "[0, ") {
+		t.Errorf("compact encode of a record/atomic-value union must stay envelope-free; got:\n%s", compact)
+	}
+	restore := renderModuleDefault(t, dump, "compactFromJson")
+	if !strings.Contains(restore, "_uni','union',,true)") {
+		t.Errorf("compact decode of a record/atomic-value union must stay identity (noop entry); got:\n%s", restore)
+	}
+}
+
+// TestCompactForJsonModule_ArrayOfObjectsOrStringWrapsArms — with no merged
+// branch the keyed strategies pass `{c: string}[] | string` through untouched;
+// compact positionalizes the array elements, so it emits the `[idx, value]` arms
+// and the decoder dispatches on the index.
+func TestCompactForJsonModule_ArrayOfObjectsOrStringWrapsArms(t *testing.T) {
+	dump := protocol.Dump{RunTypes: buildArrayOfObjectsOrStringFixture()}
+
+	compact := renderModule(t, dump, "compactForJson")
+	if !strings.Contains(compact, "[0,") {
+		t.Errorf("compact encode must wrap the array arm as `[0, …]`; got:\n%s", compact)
+	}
+	clone := renderModule(t, dump, "prepareForJsonSafe")
+	if strings.Contains(clone, "[0,") {
+		t.Errorf("clone encode of an atomic-only JSON-compatible union must stay identity; got:\n%s", clone)
+	}
+
+	restore := renderModuleDefault(t, dump, "compactFromJson")
+	if !strings.Contains(restore, "= v[0]") || !strings.Contains(restore, "=== 0") {
+		t.Errorf("compact decode must unwrap and dispatch the array arm; got:\n%s", restore)
+	}
+}
+
+// TestCompactUnionNeedsEnvelope pins the helper the emitters and the cjr
+// predicate share, over the three fixtures above.
+func TestCompactUnionNeedsEnvelope(t *testing.T) {
+	cases := []struct {
+		name  string
+		types []*reflection.RunType
+		want  bool
+	}{
+		{"nested object member", buildNestedObjectUnionFixture(), true},
+		{"record of numbers | object", buildRecordNumberUnionFixture(), false},
+		{"array of objects | string", buildArrayOfObjectsOrStringFixture(), true},
+		{"bigint/Date members (transforms the keyed rule already envelopes)", buildBigIntDateUnionFixture(), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			refTable := make(map[string]*reflection.RunType, len(c.types))
+			for _, rt := range c.types {
+				refTable[rt.ID] = rt
+			}
+			ctx := &EmitContext{walker: &Walker{RefTable: refTable}}
+			if got := compactUnionEnvelope(refTable["uni"], ctx); got != c.want {
+				t.Errorf("compactUnionEnvelope = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/ts-go-runtypes/internal/compiler/resolver/noop_predicate_test.go
+++ b/ts-go-runtypes/internal/compiler/resolver/noop_predicate_test.go
@@ -63,6 +63,14 @@ type WithLeakPromise = {p: Promise<number>; b: number};
 type AllStrippedUnion = ArrayBuffer | SharedArrayBuffer;
 type WithNonEnum = {a: string; /** @nonEnumerable */ hidden?: string};
 class ErrSub extends Error {code: number = 0}
+type UObjNested = {kind: 'a'} | {kind: 'b'; f: Compat};
+type UArrObj = Compat[] | string;
+type URecObj = {[key: string]: Compat} | {kind: 'x'};
+type URecAtomic = {[key: string]: number} | {kind: 'x'};
+getRunTypeId<UObjNested>();
+getRunTypeId<UArrObj>();
+getRunTypeId<URecObj>();
+getRunTypeId<URecAtomic>();
 getRunTypeId<WithNonEnum>();
 getRunTypeId<ErrSub>();
 getRunTypeId<WithLeakNative>();


### PR DESCRIPTION
## What

The compact JSON strategy lost any object nested inside a member of a union of plain objects. The roundtrip fuzz soak (`MION_FUZZ_SEED=0xd179ff0b`, PR #201's release gate) caught it as

```
{"kind":"t1","f0":[{"with\"quote":true}]}  →  compact  →  {"kind":"t1","f0":[[true]]}
```

The quote in the key is incidental. Any nested object (array, tuple, record or direct) inside such a union broke the same way; json, binary and clone were fine.

## Why

Compact reuses the flat-union encode/decode of the keyed strategies. Those drop the `[idx, value]` / `[-1, merged]` envelope when every member is plain JSON data and decode as identity. Compact still turns every nested object into a positional array, so the encoder changed the shape and the identity decoder handed the array back.

## Fix (Go only, there is no JS twin of this codec)

- `union_flat_compact.go` (new): `compactUnionNeedsEnvelope` answers "does any member positionalize something?", asking each keyed member's property / index-signature values and each atomic member whole through the existing `compactFromJson` noop predicate. Mirrors `unionJsonNoop`'s member walk (no duplicate drop diagnostics) and threads the cycle set.
- `buildCompactFlatLayout` widens `AtomicNeedsTuple` with that verdict; both compact union arms build their layout through it, so encode and decode agree on the wire.
- The two shared union emitters gained layout-taking variants; the keyed strategies are unchanged and the record-union optimisation still applies to compact when nothing positionalizes (`Record<string, number> | {kind: 'x'}` stays a bare object).
- The `compactFromJson` noop predicate's union arm requires "no compact envelope" too, so the noop gate cannot elide the decode.

## Tests

- Go: rendered-module tests for the nested-object union, the record-of-numbers union and the atomic-only `{c: string}[] | string` (each contrasted with the keyed family), the helper's verdicts, three new noop-predicate fixtures (cjr false / rj true), and four corpus types for the mechanical predicate-vs-emitter soundness pin.
- JS: `suites/serialization/CompactUnionEncoding.test.ts` (compact wire + round-trip, with the marker coverage pair: value-first `createJsonEncoderFn(value, …)` versus static `createJsonEncoderFn<T>(undefined, …)`, both `getRunTypeId` shapes on one id), a `union_nested_object_member` case in `suites/serialization/Unions.ts` through every pairing, and `fuzz/type/compactUnionNestedObject.smoke.test.ts` over all five roundtrip lanes.
- `MION_FUZZ_SEED=0xd179ff0b pnpm rtx core fuzz roundtrip --soak` reports 0 violations. Full `go test ./internal/...`, `pnpm run test:ci` (all 21 projects), lint and typecheck are green.

## Docs

None: the site does not describe the compact union wire and the user-visible promise is unchanged. Spec moved to `docs/done/roundtrip-compact-quoted-object-key.md` with the shipped plan appended.

## Delegated finding (merge order)

While gating this, a loaded host made the regex sidecar's 250 ms sample budget expire on the stock email format, and that transient `FMT002` verdict was written into the resolver disk cache and replayed as a build-halting error on every later run until the cache was deleted. Filed as `docs/todos/regex-sample-timeout-poisons-disk-cache.md` on this branch and delegated to a parallel session; per the findings rule, that fix's PR merges BEFORE this one, after which this branch is rebased and its `docs/todos/` copy dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4jUWAgeCfcgM7B5j7Vb24

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4jUWAgeCfcgM7B5j7Vb24)_