### PR TITLE
fix(bench): repair the typia lane and zod's all-optional cases so the release-gate benchmarks pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,8 @@ name: ci
 # instead of tailing them. It NEVER builds the shared image: it PULLS the
 # prebuilt one (competitor node_modules baked in) and mounts our freshly built
 # binary; if the image can't be pulled the job fails (rebuild + push it from
-# local — it is not a CI artifact). typia is skipped (MION_VALIDATION_BENCH_NO_TYPIA) for now
-# because its native plugin compiles ~200s at run time and is not yet baked into
-# the image; the prod gate's `benchmarks` job exercises typia.
+# local — it is not a CI artifact). typia builds like every other lane: the image
+# bakes its compiled ttsc plugin, so the smoke costs seconds, not a ~200s compile.
 #
 # A FIFTH job, `commitlint`, gates PR commit messages against Conventional
 # Commits. It is PR-only and light (no submodules/Go): the auto-changelog
@@ -355,10 +354,7 @@ jobs:
       # type-check, only to build, so MION_VALIDATION_BENCH_NO_TYPIA is deliberately NOT set here.
       - name: Benchmark competitor-map typecheck
         run: pnpm rtx bench typecheck
-      # MION_VALIDATION_BENCH_NO_TYPIA stays until the prebuilt image BAKES typia's .ttsc plugin (a
-      # local image change + republish); a no-.ttsc image would otherwise recompile
-      # it ~200s here. Drop this once that image is live.
+      # typia included: the prebuilt image bakes its compiled ttsc plugin, so its
+      # build is an esbuild pass like the others.
       - name: Benchmark competitor-build smoke
-        env:
-          MION_VALIDATION_BENCH_NO_TYPIA: '1'
         run: pnpm rtx bench smoke

--- a/.github/workflows/pr-heavy.yml
+++ b/.github/workflows/pr-heavy.yml
@@ -94,11 +94,7 @@ jobs:
       # publishable numbers. Every lane still has to answer correctly AND reject
       # an invalid payload before it is measured, which is the part that catches
       # a broken competitor after a rename.
+      # typia runs here too: the prebuilt image bakes its compiled ttsc plugin, so
+      # its lane builds in seconds like the others.
       - name: Run the benchmarks
         run: pnpm rtx bench --quick
-        # typia is skipped for the same reason ci.yml skips it: its native .ttsc
-        # plugin is not baked into the image and compiles for ~200s at run time,
-        # and without it esbuild cannot resolve typia's internal entry points.
-        # The prod gate's own benchmarks job is what exercises typia.
-        env:
-          MION_VALIDATION_BENCH_NO_TYPIA: '1'

--- a/SETUP.md
+++ b/SETUP.md
@@ -190,7 +190,7 @@ GHCR env (see [scripts/lib/engine.mjs](scripts/lib/engine.mjs)): `GHCR_OWNER` (d
 Notes:
 
 - **PAT scope:** push needs `write:packages` (pull of a private image needs `read:packages`). For pushing to the **org** namespace (`ghcr.io/mionkit/…`) use a **classic** PAT authorized for the MionKit org via SSO — fine-grained tokens need the org to opt in to package writes. If an org push is denied, publish under your personal namespace with `GHCR_OWNER=<you>`.
-- **Multi-arch on an arm64 Mac:** the `linux/amd64` half builds under QEMU emulation (slower); a local `build-image` is always pinned to the host arch so it runs native. The image does not pre-warm typia at build time, so the first benchmark run that includes typia compiles its native plugin (~200s) into a persisted named volume (`pnpm rtx bench clean` drops it); later runs reuse it.
+- **Multi-arch on an arm64 Mac:** the `linux/amd64` half builds under QEMU emulation (slower); a local `build-image` is always pinned to the host arch so it runs native. The image pre-compiles typia's native ttsc plugin at build time and bakes it under `node_modules/.cache/ttsc`, so no benchmark run pays that compile.
 - **Visibility:** the GHCR package is **private by default**. Make it public (or grant the repo read access) so CI / other hosts can pull without authenticating. The image carries an `org.opencontainers.image.source` label so the package links to this repo.
 
 ---

--- a/container/benchmarks/README.md
+++ b/container/benchmarks/README.md
@@ -101,11 +101,18 @@ same transform through `@ttsc/unplugin`'s esbuild adapter and bundles to one
 (it also documents the one esbuild quirk it works around: stripping typia's
 `: input is T =>` return-predicate annotations before esbuild parses).
 
-The first build compiles typia's native plugin once (~200s, "once per cache key")
-via ttsc's own embedded Go toolchain. Since the image is deps-only (no source at
-build time), this compile happens on the **first run that includes typia** rather
-than at image build, writing into a persisted named volume (`competitors/typia/node_modules/.ttsc`)
-so every later run reuses it; `pnpm rtx bench clean` drops the volume.
+typia's native plugin is compiled ONCE, at image build: the Containerfile warms it
+with a trivial probe (the plugin's cache key is the typia + ttsc + Go toolchain
+versions, not the caller's types) and bakes the result under
+`competitors/typia/node_modules/.cache/ttsc/plugins`, so a bench build reuses it and
+never pays the multi-minute compile. The warm is fatal: an image whose typia lane
+cannot build is not published. The lane's four pins (`typia`, `ttsc`,
+`@ttsc/unplugin`, `typescript`) move together (typia declares the ttsc range it
+works with, `@ttsc/unplugin` peers its exact ttsc line, ttsc resolves the
+`typescript` package for the native compiler), and the bench workspace refuses
+releases younger than 30 days (`minimumReleaseAge` in
+[`_deps/pnpm-workspace.yaml`](_deps/pnpm-workspace.yaml)), so bump all four to a
+set at least that old.
 
 typia entries copy the per-case literal `T` verbatim from the ts-go competitor
 (the type must be written at the `createIs<T>()` call site, like ts-go's
@@ -128,7 +135,7 @@ invalidated only when a dependency manifest changes.
 | ------------------------------------------------------ | ---------------------------------------------------------- |
 | zod · @sinclair/typebox · ajv · typia · vite · esbuild | every competitor's source files + `shared/` + `typecost/` source |
 | each competitor's `node_modules` + `package.json`      | `bin/mion` + `packages/*` (ts-go competitor only) |
-| typia's `.ttsc` compile cache → a persisted named volume | writable `results/` (so each `<name>.json` survives `--rm`) |
+| typia's compiled ttsc plugin (`node_modules/.cache/ttsc`, warmed at image build) | writable `results/` (so each `<name>.json` survives `--rm`) |
 
 ## Usage
 
@@ -197,8 +204,8 @@ The run commands **pull the latest published `ghcr.io/mionkit/tsrt-website:lates
 (the shared image) by default** (cheap no-op when current), falling back to a local
 build when the registry is unreachable. Set `MION_VALIDATION_BENCH_USE_LOCAL=1` to build/use a local image
 (offline, or to test a dep bump before pushing). typia's native plugin is
-pre-compiled into `node_modules/.ttsc` at image build time (baked into the image),
-so the bench build reuses it with no ~200s runtime compile.
+pre-compiled into `node_modules/.cache/ttsc` at image build time (baked into the
+image), so the bench build reuses it with no runtime compile.
 
 `bench` runs each competitor in its **own `--rm` container** (strongest
 isolation), then `aggregate.mjs` prints the table + coverage. It exits non-zero if
@@ -206,10 +213,9 @@ any competitor has a `fail`/`errored` case, so the run doubles as a cross-librar
 conformance test. Each run also **publishes** the per-competitor JSON into the
 canonical `<repo>/.docdata/container/benchmarks/` dir, which the docs website mounts
 read-only (`MION_DOCDATA`) to build benchmark docs from. Env knobs: `MION_VALIDATION_BENCH_NO_TIMING=1` (correctness only, fast),
-`MION_VALIDATION_BENCH_TIME_MS=100` (per-cell window). typia runs **by default** now that each
-competitor installs in isolation; a failed typia build degrades gracefully (its
-column is left blank that run). Set `MION_VALIDATION_BENCH_NO_TYPIA=1` to skip it on a host where
-its native plugin won't build.
+`MION_VALIDATION_BENCH_TIME_MS=100` (per-cell window). typia runs **by default**, in
+every lane including `--quick`; a typia build that fails FAILS the run like any other
+lane. Set `MION_VALIDATION_BENCH_NO_TYPIA=1` to skip it for a shorter local loop.
 
 ## Type-checking cost (`bench:typecost`)
 

--- a/container/benchmarks/_audit/host-collect.mjs
+++ b/container/benchmarks/_audit/host-collect.mjs
@@ -17,7 +17,7 @@
 //
 // Requirements: a node_modules resolvable from competitors/<name>/ that provides
 // the competitor libraries (zod / @sinclair/typebox / ajv / ajv-formats, and for
-// typia: typia / ttsc / @ttsc/unplugin / @typescript/native-preview / esbuild),
+// typia: typia / ttsc / @ttsc/unplugin / typescript / esbuild),
 // plus a `tsx` runner. Point at tsx with MION_AUDIT_TSX; the deps must be installed
 // somewhere node's upward node_modules walk finds (e.g. container/benchmarks/node_modules).
 //

--- a/container/benchmarks/_deps/competitors/typia/package.json
+++ b/container/benchmarks/_deps/competitors/typia/package.json
@@ -1,10 +1,10 @@
 {"name":"bench-typia","private":true,"type":"module",
  "scripts":{"build":"node esbuild.config.mjs","bench":"node dist/run.mjs"},
- "dependencies":{"typia":"13.0.0-dev.20260511"},
+ "dependencies":{"typia":"13.2.0"},
  "devDependencies":{
-   "ttsc":"0.10.2",
-   "@ttsc/unplugin":"0.10.2",
-   "@typescript/native-preview":"7.0.0-dev.20260511.1",
+   "ttsc":"0.23.0",
+   "@ttsc/unplugin":"0.23.0",
+   "typescript":"7.0.2",
    "esbuild":"0.25.12",
    "@types/node":"22.10.0"
  }}

--- a/container/benchmarks/competitors/typia/esbuild.config.mjs
+++ b/container/benchmarks/competitors/typia/esbuild.config.mjs
@@ -1,20 +1,33 @@
 // typia's MODERN tsgo build (replaces the legacy Vite + @ryoppippi/unplugin-typia
 // path, which is archived and has no tsgo support).
 //
-// The project runs on tsgo (typescript-go / @typescript/native-preview), and
-// typia's tsgo path is the `samchon/ttsc` toolchain: typia@next ships a Go-native
-// transform that plugs into ttsc. Bundlers bypass the `ttsc` CLI, so we drive the
-// same transform through `@ttsc/unplugin` — its esbuild adapter applies typia's
-// tsgo transform during the esbuild pass, then esbuild bundles everything to ONE
-// runnable `dist/run.mjs` (ESM, node22) that the bench runner executes directly.
+// The project runs on tsgo (typescript-go, published as `typescript` 7), and typia's
+// tsgo path is the `samchon/ttsc` toolchain: typia ships a Go-native transform that
+// plugs into ttsc. Bundlers bypass the `ttsc` CLI, so we drive the same transform
+// through `@ttsc/unplugin` — its esbuild adapter applies typia's tsgo transform
+// during the esbuild pass, then esbuild bundles everything to ONE runnable
+// `dist/run.mjs` (ESM, node22) that the bench runner executes directly.
 //
-// Plugin discovery: `@ttsc/unplugin` reads `compilerOptions.plugins` from the
-// nearest tsconfig.json (here: `[{ transform: "typia/lib/transform" }]`), so the
-// transform is wired through tsconfig.json — no extra config needed there.
+// Plugin discovery: `@ttsc/unplugin` compiles the project its `project` option names
+// (this dir's tsconfig.json, whose `compilerOptions.plugins` is
+// `[{ transform: "typia/lib/transform" }]`) and hands back the transformed source of
+// that project's OWN files, i.e. the files under this dir. The shared harness it
+// reaches through `../../shared` is part of the program (type-checked, in the
+// `include`) but is never emitted, so the wrapper below leaves those files to
+// esbuild's own TypeScript loader: they hold no typia call, nothing there needs the
+// transform. Without `project`, the adapter picks the nearest tsconfig.json of each
+// FILE, and the shared files have none.
 //
-// First build compiles typia's native plugin once via ttsc's OWN embedded Go
-// toolchain (no system Go required) and caches it under node_modules/.ttsc/; every
-// later build reuses that cache and is ~instant.
+// ttsc resolves the `typescript` package from this dir (TypeScript 7 ships the native
+// compiler as `@typescript/typescript-<platform>`); the `@typescript/native-preview`
+// package is no longer part of this lane. The first build compiles typia's native
+// plugin once with the Go toolchain bundled in `@ttsc/<platform>` (no system Go, no
+// download) and caches it under node_modules/.cache/ttsc/plugins/; the image bakes
+// that cache at build time (container/website/Containerfile), so a bench build never
+// pays the compile. The four pins in _deps/competitors/typia/package.json (typia,
+// ttsc, @ttsc/unplugin, typescript) move TOGETHER: typia declares the ttsc range it
+// works with, @ttsc/unplugin peers its exact ttsc line, and a typia dev build once
+// mapped `./lib/internal/*` exports to files it did not ship.
 //
 // ── Why the predicate-strip wrapper below ────────────────────────────────────
 // typia's tsgo transform replaces `createIs<T>()` with an IIFE whose returned
@@ -93,12 +106,16 @@ export const typiaTsgo = (tsconfig) => {
   // pointing it at a probe-including config puts the probe in the program so the
   // transform emits output for it (otherwise: "ttsc transform did not return output").
   const inner = ttscEsbuild(tsconfig ? {project: tsconfig} : undefined);
+  // ttsc emits only the project's own files; anything outside (../../shared) is
+  // handed back to esbuild untouched (see the header).
+  const projectDir = tsconfig ? path.dirname(path.resolve(tsconfig)) : here;
   return {
     name: 'typia-tsgo',
     setup(esbuildApi) {
       const registerOnLoad = esbuildApi.onLoad.bind(esbuildApi);
       esbuildApi.onLoad = (options, callback) =>
         registerOnLoad(options, async (args) => {
+          if (!args.path.startsWith(projectDir + path.sep)) return undefined;
           const result = await callback(args);
           if (result && typeof result.contents === 'string' && result.contents.includes(': input is ')) {
             return {...result, contents: stripReturnPredicates(result.contents)};
@@ -141,6 +158,6 @@ if (isMain) {
     platform: 'node',
     target: 'node22',
     minify: false,
-    plugins: [typiaTsgo()],
+    plugins: [typiaTsgo(path.join(here, 'tsconfig.json'))],
   });
 }

--- a/container/benchmarks/competitors/zod/cases.ts
+++ b/container/benchmarks/competitors/zod/cases.ts
@@ -1,6 +1,17 @@
 import {z} from 'zod';
 import {NOT_SUPPORTED, type CompetitorCases} from '../../shared/harness/types.ts';
 
+// RunTypes' plain-object guard: an all-optional object type accepts only an ordinary
+// object, never an array, a Date / Map / Set / RegExp or any other builtin instance,
+// even though every property is optional. z.object alone only excludes arrays and null,
+// and a `.refine` on it sees the PARSED copy (a fresh plain object), so the guard has to
+// run on the input, ahead of the object schema. This is zod's deliberate, documented
+// choice here (docs/cross-library-validation-alignment-report.md, "Plain-object guard"):
+// zod agrees with mion on every sample of these cases, and the release gate counts a
+// `fail` on them as a broken run.
+const plainObject = <Output, Input>(schema: z.ZodType<Output, Input>) =>
+  z.custom<Input>((value) => Object.prototype.toString.call(value) === '[object Object]').pipe(schema);
+
 // Every supported case builds its zod schema inside its own `buildErrors` thunk —
 // self-contained and copy-paste runnable, with any shared sub-schema inlined. zod
 // has NO cheap boolean validator (safeParse always builds the full ZodError), so
@@ -440,13 +451,12 @@ export const cases: CompetitorCases = {
       return (value: unknown) => schema.safeParse(value).success;
     },
   },
-  // interface_all_optional: {a?:string, b?:number} — declared as the same interface as mion.
-  // NB zod's z.object accepts Date/Map/Set instances (its isObject only excludes arrays/null), so this
-  // accepts those where mion rejects them; that pass/reject discrepancy is the correctness
-  // benchmark's job to surface, not a hand guard's.
+  // interface_all_optional: {a?:string, b?:number} — the same interface as mion, behind the
+  // plain-object guard (plainObject above): z.object alone accepts Date/Map/Set/RegExp
+  // instances, since its isObject only excludes arrays and null.
   'OBJECT.interface_all_optional': {
     buildErrors: () => {
-      const schema = z.object({a: z.string().optional(), b: z.number().optional()});
+      const schema = plainObject(z.object({a: z.string().optional(), b: z.number().optional()}));
       return (value: unknown) => schema.safeParse(value).success;
     },
   },
@@ -1029,17 +1039,17 @@ export const cases: CompetitorCases = {
   'CIRCULAR_REFS.object_self_cycle': NOT_SUPPORTED, // a reference cycle would stack-overflow
 
   // ── UTILITY ──
-  // partial: {name?:string, age?:number, createdAt?:Date} with plain-object guard (rejects arrays/Date/Map/Set)
-  // partial: {name?:string, age?:number, createdAt?:Date} — the Partial<> of UTILITY.required, declared
-  // as the same interface as mion (idiomatic z.object). See the interface_all_optional note + the
-  // correctness todo: zod accepts Date/Map/Set instances where mion rejects them.
+  // partial: {name?:string, age?:number, createdAt?:Date} — the Partial<> of UTILITY.required, the
+  // same interface as mion behind the plain-object guard (rejects arrays/Date/Map/Set).
   'UTILITY.partial': {
     buildErrors: () => {
-      const schema = z.object({
-        name: z.string().optional(),
-        age: z.number().optional(),
-        createdAt: z.date().optional(),
-      });
+      const schema = plainObject(
+        z.object({
+          name: z.string().optional(),
+          age: z.number().optional(),
+          createdAt: z.date().optional(),
+        })
+      );
       return (value: unknown) => schema.safeParse(value).success;
     },
   },
@@ -1177,17 +1187,18 @@ export const cases: CompetitorCases = {
     },
   },
   // deep_partial_recursive_mapped: {display?:{theme?:'light'|'dark', brightness?:number}, audio?:{volume?:number, muted?:boolean}}
-  // declared as the same nested interface as mion (idiomatic nested z.object). See the
-  // interface_all_optional note + the correctness todo: zod accepts Date/Map/Set instances where
-  // mion rejects them (the outer/nested plain-object discrepancy).
+  // the same nested interface as mion; every level is all-optional, so every level sits
+  // behind the plain-object guard, exactly where mion applies it.
   'UTILITY.deep_partial_recursive_mapped': {
     buildErrors: () => {
-      const schema = z.object({
-        display: z
-          .object({theme: z.enum(['light', 'dark']).optional(), brightness: z.number().optional()})
-          .optional(),
-        audio: z.object({volume: z.number().optional(), muted: z.boolean().optional()}).optional(),
-      });
+      const schema = plainObject(
+        z.object({
+          display: plainObject(
+            z.object({theme: z.enum(['light', 'dark']).optional(), brightness: z.number().optional()})
+          ).optional(),
+          audio: plainObject(z.object({volume: z.number().optional(), muted: z.boolean().optional()})).optional(),
+        })
+      );
       return (value: unknown) => schema.safeParse(value).success;
     },
   },

--- a/container/benchmarks/compiletime/compiletime.mjs
+++ b/container/benchmarks/compiletime/compiletime.mjs
@@ -18,8 +18,8 @@
 //
 // Run with cwd = competitors/<name>; tsgo/ttsc/vite + the bind-mounted plugin all live
 // in that competitor's node_modules. Each number is the median of N (default 5); a
-// warm-up build runs first so the cold process-start (and typia's one-time ~200s ttsc
-// plugin compile, cached in the .ttsc volume) never lands in a tier.
+// warm-up build runs first so the cold process-start (and typia's ttsc plugin
+// compile, if the image did not bake it) never lands in a tier.
 
 import fs from 'node:fs';
 import os from 'node:os';
@@ -53,7 +53,12 @@ const OUT_DIR = path.join(COMPETITOR_DIR, '.compiletime-out');
 const MION_CACHE = path.join(COMPETITOR_DIR, '.compiletime-rt-cache');
 const VITE_CACHE = path.join(COMPETITOR_DIR, '.compiletime-vite-cache');
 const MION_BINARY = process.env.MION_BINARY ?? path.join(COMPETITOR_DIR, 'bin', 'mion');
-const TSGO = path.join(COMPETITOR_DIR, 'node_modules', '.bin', 'tsgo');
+// The native compiler: `@typescript/native-preview` exposes it as `tsgo`, TypeScript 7
+// (what the typia lane installs, since ttsc resolves the `typescript` package) exposes
+// the same binary as `tsc`. Prefer the explicit preview bin, fall back to typescript's.
+const TSGO =
+  ['tsgo', 'tsc'].map((bin) => path.join(COMPETITOR_DIR, 'node_modules', '.bin', bin)).find((bin) => fs.existsSync(bin)) ??
+  path.join(COMPETITOR_DIR, 'node_modules', '.bin', 'tsgo');
 const TTSC = path.join(COMPETITOR_DIR, 'node_modules', '.bin', 'ttsc');
 
 const req = createRequire(path.join(COMPETITOR_DIR, '__compiletime_resolve.cjs'));
@@ -178,8 +183,8 @@ async function main() {
   );
   await setupFull();
 
-  // Warm up each tier once (discarded): Node JIT, tsgo/vite init, and typia's one-time
-  // ttsc plugin compile (~200s, cached in .ttsc) — none of it lands in a measured cell.
+  // Warm up each tier once (discarded): Node JIT, tsgo/vite init, and typia's ttsc
+  // plugin compile (if the image did not bake it under node_modules/.cache/ttsc) — none of it lands in a measured cell.
   console.error(`compiletime[${COMPETITOR}]: warming up (${keys.length} types)...`);
   try {
     stripMs();

--- a/container/website/Containerfile
+++ b/container/website/Containerfile
@@ -112,8 +112,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
 # /bench as the root, find "no projects", and install nothing). Each gets a copy
 # of the supply-chain policy (pnpm-workspace.yaml + .npmrc) plus its package.json.
 # Manifests are sourced from .bench-deps/ (a build-time copy of container/benchmarks/_deps/,
-# staged by scripts/website/site.sh). typia's install is non-fatal so its opt-in
-# fragile deps can't abort the build. node_modules is cached on each package.json.
+# staged by scripts/website/site.sh). Every install is fatal, typia's included: the
+# release gate runs the typia lane, so an image without it is not one worth
+# publishing. node_modules is cached on each package.json.
 COPY .bench-deps/pnpm-workspace.yaml .bench-deps/.npmrc /bench/competitors/zod/
 COPY .bench-deps/competitors/zod/package.json /bench/competitors/zod/package.json
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
@@ -137,31 +138,33 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
 COPY .bench-deps/pnpm-workspace.yaml .bench-deps/.npmrc /bench/competitors/typia/
 COPY .bench-deps/competitors/typia/package.json /bench/competitors/typia/package.json
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-    cd /bench/competitors/typia && pnpm install --no-frozen-lockfile \
-    || echo ">> typia install failed; its column degrades gracefully (left blank that run; MION_VALIDATION_BENCH_NO_TYPIA=1 skips it)"
+    cd /bench/competitors/typia && pnpm install --no-frozen-lockfile
 
-# Pre-compile typia's native ttsc plugin so node_modules/.ttsc is BAKED into the
-# image. Otherwise it compiles (~90-200s) at the first runtime build. The plugin is
-# keyed on typia's version (not the caller's types), so a trivial probe warms it and
-# the real bench build reuses it. Needs network (downloads ttsc's embedded Go
-# toolchain) - available during build. Non-fatal: on failure typia just recompiles
-# the plugin at runtime, exactly as before.
+# Pre-compile typia's native ttsc plugin so node_modules/.cache/ttsc/plugins is BAKED
+# into the image. Otherwise it compiles (~2-4 min) at the first runtime build. The
+# plugin is keyed on the typia + ttsc + Go toolchain versions (not the caller's
+# types), so a trivial probe warms it and the real bench build reuses it. ttsc
+# compiles it with the Go toolchain bundled in @ttsc/<platform>: no download, no
+# system Go. The probe's compiler options mirror /bench/tsconfig.base.json (the
+# bind-mounted competitor projects extend it) so the same typescript + plugin
+# generation is exercised.
 #
-# The final `rm -rf` drops the Go build + module caches ttsc created while compiling
-# the plugin (~3 GB in /root/.cache/go-build + /root/go) - runtime only needs the
-# compiled plugin under node_modules/.ttsc (~28 MB), so baking the caches was dead
-# weight (they were HALF the image). Runs unconditionally (`;` after the `|| echo`)
-# so the caches never survive, warm success or not, and in the SAME layer so the
-# image actually shrinks. If the warm ever fell back to a runtime recompile, ttsc
-# re-fetches its toolchain then, exactly as it did before any baking.
+# FATAL on purpose. This step used to fall back to "typia recompiles at runtime",
+# which is how a broken typia lane shipped unnoticed: the release gate then paid the
+# compile on every run and failed anyway. `test -f` proves the compiled binary sits
+# where the bench build will look for it.
+#
+# The trailing `rm -rf` drops the Go build + module caches ttsc created while
+# compiling (~4 GB under node_modules/.cache/ttsc/go-build, plus anything under
+# /root): runtime only needs the compiled plugin (~60 MB under plugins/), so baking
+# the caches was dead weight. Same layer, so the image actually shrinks.
 RUN cd /bench/competitors/typia \
  && printf 'import typia from "typia";\nexport const _ttscWarm = typia.createIs<{ a: number; b: string }>();\n' > .ttsc-warm.ts \
- && printf '{"compilerOptions":{"strict":true,"plugins":[{"transform":"typia/lib/transform"}]},"include":[".ttsc-warm.ts"]}' > tsconfig.ttsc-warm.json \
+ && printf '{"compilerOptions":{"target":"ESNext","module":"ESNext","moduleResolution":"Bundler","strict":true,"skipLibCheck":true,"types":["node"],"plugins":[{"transform":"typia/lib/transform"}]},"include":[".ttsc-warm.ts"]}' > tsconfig.ttsc-warm.json \
  && node --input-type=module -e 'import {build} from "esbuild"; import ttsc from "@ttsc/unplugin/esbuild"; await build({entryPoints:[".ttsc-warm.ts"],bundle:true,write:false,format:"esm",platform:"node",target:"node22",logLevel:"info",tsconfig:"tsconfig.ttsc-warm.json",plugins:[ttsc({project:"tsconfig.ttsc-warm.json"})]});' \
  && rm -f .ttsc-warm.ts tsconfig.ttsc-warm.json \
- && test -d node_modules/.ttsc \
- || echo ">> ttsc warm skipped/failed; typia recompiles its plugin at the first runtime build"; \
- rm -rf /root/.cache/go-build /root/go
+ && test -f "$(find node_modules/.cache/ttsc/plugins -type f -name plugin | head -n 1)" \
+ && rm -rf node_modules/.cache/ttsc/go-build /root/.cache/go-build /root/go
 
 # typecost runner: its own TypeScript install (it drives the compiler API). The
 # marker package it type-resolves against is bind-mounted into the mion
@@ -183,5 +186,5 @@ LABEL org.mionkit.deps-hash="${DEPS_HASH}"
 
 # No CMD: scripts/website/site.sh (WORKDIR /app) and scripts/website/bench-data/bench.sh (WORKDIR
 # /bench) each bind-mount their first-party source and supply the command. typia's
-# native ttsc plugin is pre-compiled into /bench/competitors/typia/node_modules/.ttsc
+# native ttsc plugin is pre-compiled into /bench/competitors/typia/node_modules/.cache/ttsc
 # above (baked into the image), so the bench build reuses it with no runtime compile.

--- a/docs/done/bench-image-stale-typia-lane-broken.md
+++ b/docs/done/bench-image-stale-typia-lane-broken.md
@@ -1,7 +1,7 @@
 ---
 type: fix
 spec: guidelines
-status: ready
+status: done
 created: 2026-09-02
 ---
 
@@ -61,6 +61,29 @@ edit changes the hash too, but `main` was already stale without it).
   fail/errored metric-cases.
 - The pulled `tsrt-website` image is accepted by the staleness guard (no local rebuild in
   CI).
+
+## What shipped (2026-09-02)
+
+- typia lane: `typia@13.2.0` + `ttsc@0.23.0` + `@ttsc/unplugin@0.23.0` + `typescript@7.0.2`
+  (the newest set the bench workspace's 30-day `minimumReleaseAge` allowed on the day;
+  typia 14 / ttsc 0.28 were a week old). `@typescript/native-preview` left the lane.
+- `esbuild.config.mjs` names its tsconfig as the ttsc `project` and hands files outside
+  the competitor dir back to esbuild. The Containerfile installs typia fatally, warms the
+  plugin fatally, proves `node_modules/.cache/ttsc/plugins/*/plugin` and drops the 4 GB Go
+  build cache in the same layer. `compiletime.mjs` accepts typescript 7's `tsc` bin.
+- `MION_VALIDATION_BENCH_NO_TYPIA=1` is gone from `ci.yml`, `pr-heavy.yml` and the
+  `--quick` defaults: with the plugin baked, the typia build is a one-second esbuild pass.
+- zod: the three all-optional cases carry the plain-object guard on the input side
+  (`z.custom(...).pipe(schema)`), so zod agrees with RunTypes on every sample again, as the
+  Correctness page and the alignment report state.
+- Verified in-container on an image built from these manifests: typia 206 ok / 0 fail /
+  0 errored (73 not-supported), zod 239 ok / 0 fail on validationErrors, no plugin
+  recompile at run time, `bench typecheck` and `bench smoke` green.
+- NOT done here: the republish. The fixing session had the GHCR credentials but no arm64
+  emulation and no route to Docker Hub for the base image, so `pnpm rtx container push
+  website` and `pnpm rtx container push e2e` (its Containerfile label changed in PR #201)
+  run from a maintainer host after merge. Until then CI rebuilds the website image
+  locally (the staleness guard doing its job), which is slow but green.
 
 ## Plan (approved 2026-09-02, implemented on branch fix/bench-typia-lane)
 

--- a/docs/maybe/upgrade-bench-competitors-to-typescript-7.md
+++ b/docs/maybe/upgrade-bench-competitors-to-typescript-7.md
@@ -1,19 +1,19 @@
 # Upgrade benchmark competitors to TypeScript 7 (deferred — too early)
 
-**Status:** todo — deliberately deferred. Do NOT do this yet: it is too early, and it is not yet clear the competitor toolchains work on stable `typescript@7` at all.
+**Status:** todo — deferred. The typia lane already runs on stable `typescript@7` (moved there when the lane was repaired in September 2026); what is left is the mion competitor's compile-time-tier pin, which is low value.
 **Created:** 2026-07-08
 **Related:** our own resolver's tsgo pin is kept current separately via `pnpm rtx core bump-tsgolint` (see [`SETUP.md`](../../SETUP.md#bumping-the-tsgolint-pin)). This todo is the competitor-side analogue.
 
 ## What
 
-The benchmark harness ([`container/benchmarks/`](../../container/benchmarks/)) pins the pre-release `@typescript/native-preview@7.0.0-dev.20260511.1` in its competitor deps. TypeScript 7.0 has since shipped stable under the plain `typescript` npm tag. When the competitor toolchains support it, move those pins from `@typescript/native-preview` to stable `typescript@7` so the comparison uses the same compiler a real user would run.
+The benchmark harness ([`container/benchmarks/`](../../container/benchmarks/)) still pins the pre-release `@typescript/native-preview@7.0.0-dev.20260511.1` in the mion competitor's deps. TypeScript 7.0 has since shipped stable under the plain `typescript` npm tag. Move that pin to stable `typescript@7` so the compile-time tiers use the same compiler a real user would run.
 
 ## Where native-preview is actually used (evidence)
 
-Two competitor `_deps` packages pin it — not one:
+One competitor `_deps` package still pins it:
 
-- **typia** — [`_deps/competitors/typia/package.json`](../../container/benchmarks/_deps/competitors/typia/package.json): `@typescript/native-preview@7.0.0-dev.20260511.1` alongside `typia@13.0.0-dev.20260511`, `ttsc@0.10.2`, `@ttsc/unplugin@0.10.2`. typia **produces its validators through it**: its tsgo path is the `samchon/ttsc` toolchain (typia ships a Go-native transform that plugs into ttsc), driven here via `@ttsc/unplugin`'s esbuild adapter ([`esbuild.config.mjs`](../../container/benchmarks/competitors/typia/esbuild.config.mjs)). Per that file, "the first build compiles typia's native plugin once via ttsc's OWN embedded Go toolchain (no system Go required) and caches it under `node_modules/.ttsc/`" — i.e. typia builds a native Go plugin per environment/image, then reuses the cache.
-- **mion** (our own competitor entry) — [`_deps/competitors/ts-runtypes/package.json`](../../container/benchmarks/_deps/competitors/ts-runtypes/package.json): pins it too, but only for the **compile-time-phase tiers** of the `compiletime` bench (the README notes "mion needs `@typescript/native-preview` (tsgo) in its competitor deps for the strip/typecheck tiers; typia already ships it"). Our *runtime* validators come from the Go resolver binary (`@ts-runtypes/bin`), never native-preview.
+- **typia** — no longer. [`_deps/competitors/typia/package.json`](../../container/benchmarks/_deps/competitors/typia/package.json) installs stable `typescript@7.0.2` next to `typia@13.2.0`, `ttsc@0.23.0` and `@ttsc/unplugin@0.23.0`: ttsc resolves the `typescript` package for its native compiler, compiles typia's Go plugin with the toolchain bundled in `@ttsc/<platform>`, and the image bakes that plugin under `node_modules/.cache/ttsc` at build time ([`esbuild.config.mjs`](../../container/benchmarks/competitors/typia/esbuild.config.mjs) documents the wiring).
+- **mion** (our own competitor entry) — [`_deps/competitors/mion/package.json`](../../container/benchmarks/_deps/competitors/mion/package.json): pins it only for the **compile-time-phase tiers** of the `compiletime` bench (the strip / typecheck tiers spawn `node_modules/.bin/tsgo`, falling back to typescript 7's `tsc`). Our *runtime* validators come from the Go resolver binary (`@mionjs/bin`), never native-preview.
 
 `zod`, `typebox`, and `ajv` never touch it.
 
@@ -31,20 +31,18 @@ Note the refinement of the original intuition ("maybe type-instantiation count c
 
 ## Why it's too early / risky
 
-- typia pins `typia@13.0.0-dev.20260511` and `@typescript/native-preview@7.0.0-dev.20260511.1` at the **same dev date** — its Go-native ttsc transform is matched to a specific tsgo *dev* build. Stable `typescript@7` is very likely not wired into typia's ttsc toolchain yet, and typia@13 itself is still a dev build. Bumping native-preview alone would probably break typia's transform outright.
-- The whole typia path is fragile: `ttsc` + `@ttsc/unplugin` (both pinned 0.10.2) build a native Go plugin through ttsc's embedded Go toolchain, re-derived per image. A tsgo generation change forces that native plugin to rebuild and can hit ttsc/tsgo compatibility gaps.
-- The compiler's npm identity changed: the tsgo binary now ships under `typescript@7`, not `@typescript/native-preview`. ttsc / @ttsc/unplugin discover the `tsgo` bin from the native-preview package layout; stable `typescript@7`'s bin layout must be verified to still be found.
+- The only consumer left is the mion competitor's compile-time tiers, and `compiletime.mjs` already accepts typescript 7's `tsc` bin where no `tsgo` bin exists, so the swap is a one-line manifest change plus an image republish.
+- The bench workspace refuses releases younger than 30 days (`minimumReleaseAge`), so pick a `typescript` 7.x at least that old.
 
 ## Trigger to revisit
 
-Do it once typia ships a **stable (non-dev) release whose ttsc toolchain targets stable `typescript@7`**, and confirm `ttsc` / `@ttsc/unplugin` support that tsgo generation. Until then this is blocked on upstream, not on us.
+Whenever the compile-time tiers should run on the same stable compiler as the typia lane. Nothing upstream blocks it any more.
 
 ## Concrete steps (when unblocked)
 
 1. Edit the **checked-in `_deps` sources** (never the git-ignored `.bench-deps/` staging copies):
-   - `_deps/competitors/typia/package.json` — replace `@typescript/native-preview` with `typescript@7.x`; bump `typia`, `ttsc`, `@ttsc/unplugin` to versions that target stable tsgo.
-   - `_deps/competitors/ts-runtypes/package.json` — replace `@typescript/native-preview` with `typescript@7.x` (compile-time tiers only).
-2. Verify ttsc's tsgo discovery: native-preview exposed a `tsgo` bin; confirm the ttsc toolchain finds the compiler under stable `typescript@7` (the `node_modules/.ttsc/` native-plugin cache may need clearing so it rebuilds against the new tsgo).
+   - `_deps/competitors/mion/package.json` — replace `@typescript/native-preview` with `typescript@7.x` (compile-time tiers only).
+2. Confirm `compiletime.mjs` picks `node_modules/.bin/tsc` for the strip / typecheck tiers once no `tsgo` bin is installed, and that the mion lane's vite build is unaffected (it never used the pin).
 3. Rebuild + push the GHCR bench image (`pnpm rtx container build-image` then `pnpm rtx container push`) — `_deps` changes are inert until the image is republished (the known stale-bench-image gotcha).
 4. Re-run the suite (`pnpm rtx bench --full`); confirm typia still emits validators (its validation column is present, not `err`) and the compiletime tiers still run. typecost should come back byte-identical (shared 6.0.3).
 5. Do NOT hand-edit `.bench-deps/` — it regenerates from `_deps/` at image build.

--- a/docs/todos/bench-image-stale-typia-lane-broken.md
+++ b/docs/todos/bench-image-stale-typia-lane-broken.md
@@ -1,0 +1,104 @@
+---
+type: fix
+spec: guidelines
+status: ready
+created: 2026-09-02
+---
+
+# Validation benchmark job: published image is stale and the typia lane cannot be rebuilt
+
+## Intent
+
+The release gate's "validation + type-cost benchmarks (podman)" job fails on `main`. Two
+things stack up:
+
+1. The published `ghcr.io/mionkit/tsrt-website:latest` image was built from OLDER website
+   manifests than the tree (its deps stamp is `47e25ea5650707c1`; `main` hashes to
+   `3c554e1472e5fd86`, see `depsHash` in
+   [scripts/container/image.mjs](../../scripts/container/image.mjs)). The staleness guard
+   therefore refuses the pulled image and every CI lane rebuilds it from scratch, which is
+   slow and, worse, means the job runs an image nobody published.
+2. In that from-scratch rebuild the typia competitor lane does not build. Its
+   `pnpm install --no-frozen-lockfile` warns "typia install failed; its column degrades
+   gracefully", the ttsc warm step is skipped, and at bench time esbuild fails with
+   `Could not resolve "typia/lib/internal/_isMultipleOf"` and `_stringLength`: the installed
+   `typia@13.0.0-dev.20260511` maps `./lib/internal/*.mjs` in its exports but ships no such
+   files, while the ttsc transform (`ttsc@0.10.2`, `@ttsc/unplugin@0.10.2`) still emits those
+   imports. `bench: 1 competitor lane(s) failed: typia` then fails the job. `ci.yml` and
+   `pr-heavy.yml` hide this by setting `MION_VALIDATION_BENCH_NO_TYPIA=1`; the release gate
+   does not, and should not.
+3. The same run reports three zod correctness failures the job also counts:
+   `zod / OBJECT.interface_all_optional`, `zod / UTILITY.partial` and
+   `zod / UTILITY.deep_partial_recursive_mapped` `[validationErrors]: fail — invalid[1]
+   accepted` (zod 4.4.3). Either the case's invalid sample is wrong for zod's semantics or
+   zod's validationErrors path accepts it; decide per case and fix the case or mark the
+   override, the way the other competitor overrides are recorded.
+
+Found on 2026-09-02 by the first release-gate run in this repo
+(https://github.com/MionKit/mion/actions/runs/33579204363, job "validation + type-cost
+benchmarks"). Predates PR #201, which touches no benchmark code (its Containerfile label
+edit changes the hash too, but `main` was already stale without it).
+
+## Direction
+
+- Reproduce the typia lane in the container: `pnpm rtx container build-image website`
+  then `pnpm rtx bench --one typia` (or the equivalent `rtx bench` invocation the job
+  runs; read `release-gate.yml`). Pin a typia + ttsc pair that agree on the internal
+  module layout (a matching dev build of both, or the latest stable typia with its own
+  transform), and make the warm step fail loudly instead of "skipped/failed".
+- Fix or override the three zod cases with a reason each.
+- Then republish the images so the stamp matches the tree:
+  `pnpm rtx container push website` (and `e2e`, whose Containerfile label changed in
+  PR #201). That needs `GHCR_PAT`; if the session has no credentials, say so in the PR and
+  leave the republish to the maintainer as the last step.
+- Drop `MION_VALIDATION_BENCH_NO_TYPIA=1` from `ci.yml` / `pr-heavy.yml` only if the
+  rebuilt image bakes the plugin so the smoke stays fast (the comment in `ci.yml` explains
+  the 200 s cost otherwise).
+
+## Done when
+
+- The release gate's benchmark job passes on `main` with typia enabled and zero
+  fail/errored metric-cases.
+- The pulled `tsrt-website` image is accepted by the staleness guard (no local rebuild in
+  CI).
+
+## Plan (approved 2026-09-02, implemented on branch fix/bench-typia-lane)
+
+Findings that shaped it:
+
+- `minimumReleaseAge` (30 days) in `_deps/pnpm-workspace.yaml` applies to exact pins
+  too, so typia 14 / ttsc 0.28 (Aug 2026) were not installable on the day of the fix.
+  The newest pair old enough: `typia@13.2.0` + `ttsc@0.23.0` + `@ttsc/unplugin@0.23.0`
+  (unplugin peers its exact ttsc line; typia 13.x wants `ttsc >= 0.19.2`).
+- ttsc >= 0.19 resolves the `typescript` package for its native compiler (TypeScript 7
+  ships it as `@typescript/typescript-<platform>`), so the lane installs
+  `typescript@7.0.2` and drops `@typescript/native-preview`. ttsc bundles its own Go
+  toolchain in `@ttsc/<platform>` (no download, no system Go) and caches the compiled
+  plugin under `<workspace>/node_modules/.cache/ttsc/plugins/<key>/plugin`, not `.ttsc`.
+- `@ttsc/unplugin` now emits only the project's OWN files: the shared harness under
+  `../../shared` is in the program but never emitted, so the esbuild wrapper names its
+  tsconfig as the `project` and hands files outside the competitor dir back to esbuild.
+- zod 4.4.3's `z.object` accepts Date / Map / Set / RegExp for an all-optional shape and a
+  `.refine` sees the parsed copy. The Correctness page and the alignment report both
+  record zod as agreeing with RunTypes here, so the three cases get the plain-object
+  guard back on the input side (`z.custom(...).pipe(schema)`) rather than an override.
+
+Steps:
+
+1. `_deps/competitors/typia/package.json`: the four pins above (+ esbuild, @types/node).
+2. `competitors/typia/esbuild.config.mjs`: explicit `project`, project-dir filter, header.
+3. `container/website/Containerfile`: typia install fatal; warm step fatal, proves
+   `node_modules/.cache/ttsc/plugins/*/plugin`, drops the 4 GB Go build cache in-layer.
+4. `compiletime.mjs`: the native compiler bin is `tsgo` (preview) or `tsc` (typescript 7).
+5. Drop `MION_VALIDATION_BENCH_NO_TYPIA=1` from `ci.yml`, `pr-heavy.yml` and the
+   `--quick` defaults; the baked plugin makes the typia build an esbuild pass.
+6. zod: `plainObject()` helper on the three all-optional cases.
+7. Tests: `packages/devtools/test/bench-lane-contracts.test.ts` pins the manifest
+   agreement, the fatal warm + cache path, the wrapper filter and the zod guard.
+8. Docs: benchmarks README, SETUP.md, the audit collector comment, the parked TS 7 note.
+9. Validate in-container (build the image on top of the published one, since Docker Hub
+   is unreachable from the session), run `bench-one typia`, `bench-one zod`,
+   `typecheck`, `smoke`; then the PR-readiness gate; then move this spec to docs/done.
+10. Republish: `pnpm rtx container push website` and `push e2e`. The session has the
+    GHCR credentials but no arm64 emulation and no Docker Hub route, so the multi-arch
+    push has to run from a maintainer host; the PR says so.

--- a/packages/devtools/test/bench-lane-contracts.test.ts
+++ b/packages/devtools/test/bench-lane-contracts.test.ts
@@ -50,7 +50,7 @@ describe('the typecost artifact fixture tracks the real writer', () => {
 });
 
 describe('typia competitor map calls real typia exports', () => {
-  // typia 13.0.0-dev.20260511 (the version pinned in
+  // typia 13.2.0 (the version pinned in
   // container/benchmarks/_deps/competitors/typia/package.json), read off its own
   // lib/module.d.ts. `createValidateFn` is NOT among them: it is a RunTypes name
   // that leaked in through one of our own createX -> createXFn renames.
@@ -471,4 +471,107 @@ describe('rtx bench sub-verbs reach bench.mjs', () => {
       expect(include).toContain('../../shared');
     }
   });
+});
+
+describe('the typia lane pins a toolchain that agrees with itself', () => {
+  // How the release gate's benchmark job broke: the lane pinned a typia DEV build whose
+  // package exports mapped `./lib/internal/*.mjs` to files the tarball did not ship,
+  // next to a ttsc line whose transform still emitted those imports, so esbuild died on
+  // `Could not resolve "typia/lib/internal/_isMultipleOf"`. The image's install and
+  // warm steps were both non-fatal, so the broken lane still produced an image.
+  const manifest = JSON.parse(read('container/benchmarks/_deps/competitors/typia/package.json')) as {
+    dependencies: Record<string, string>;
+    devDependencies: Record<string, string>;
+  };
+  const exact = /^\d+\.\d+\.\d+$/;
+
+  it('pins a stable typia release, never a dev build', () => {
+    expect(manifest.dependencies.typia).toMatch(exact);
+  });
+
+  it('pins ttsc and @ttsc/unplugin to the same release (the unplugin peers its exact ttsc line)', () => {
+    expect(manifest.devDependencies.ttsc).toMatch(exact);
+    expect(manifest.devDependencies['@ttsc/unplugin']).toBe(manifest.devDependencies.ttsc);
+  });
+
+  it('installs the typescript package ttsc resolves for the native compiler, not the preview package', () => {
+    // ttsc >= 0.19 resolves `typescript` (7 ships the native tsgo binary as
+    // @typescript/typescript-<platform>) and refuses to run without it.
+    expect(manifest.devDependencies.typescript).toMatch(exact);
+    expect(Number(manifest.devDependencies.typescript.split('.')[0])).toBeGreaterThanOrEqual(7);
+    expect(manifest.devDependencies).not.toHaveProperty('@typescript/native-preview');
+  });
+});
+
+describe('the image bakes the compiled typia plugin, or fails to build', () => {
+  const containerfile = read('container/website/Containerfile');
+
+  it('installs typia fatally, like every other lane', () => {
+    expect(containerfile).not.toContain('typia install failed');
+    expect(containerfile).toMatch(/cd \/bench\/competitors\/typia && pnpm install --no-frozen-lockfile\n/);
+  });
+
+  it('proves the compiled plugin sits under node_modules/.cache/ttsc before the layer ends', () => {
+    // ttsc >= 0.19 caches plugins under <workspace>/node_modules/.cache/ttsc/plugins/<key>/plugin;
+    // the old `.ttsc` dir is never created, so a `test -d node_modules/.ttsc` proved nothing.
+    expect(containerfile).toContain('find node_modules/.cache/ttsc/plugins -type f -name plugin');
+    expect(containerfile).not.toContain('node_modules/.ttsc');
+    expect(containerfile).not.toContain('ttsc warm skipped');
+  });
+
+  it('drops the Go build cache the warm leaves behind, in the same layer', () => {
+    expect(containerfile).toContain('rm -rf node_modules/.cache/ttsc/go-build');
+  });
+
+  it('lets every CI lane run typia now that the plugin is baked', () => {
+    for (const workflow of ['.github/workflows/ci.yml', '.github/workflows/pr-heavy.yml']) {
+      expect(read(workflow), workflow).not.toContain("MION_VALIDATION_BENCH_NO_TYPIA: '1'");
+    }
+    // --quick used to skip typia by default ("its native build dominates"); it no longer does.
+    expect(read('scripts/website/bench-data/bench.mjs')).not.toContain("setIfUnset('MION_VALIDATION_BENCH_NO_TYPIA'");
+  });
+});
+
+describe("typia's esbuild wrapper leaves the shared harness to esbuild", () => {
+  // @ttsc/unplugin compiles the project its `project` option names and emits only that
+  // project's OWN files. The shared harness under ../../shared is in the program (it is in
+  // the tsconfig `include`) but never emitted: asking the adapter for it fails the build
+  // with "ttsc transform did not return output for .../shared/harness/audit.ts".
+  const source = read('container/benchmarks/competitors/typia/esbuild.config.mjs');
+
+  it('names its own tsconfig as the ttsc project for the bench bundle', () => {
+    expect(source).toContain("plugins: [typiaTsgo(path.join(here, 'tsconfig.json'))]");
+  });
+
+  it('hands files outside the project dir back to esbuild instead of the adapter', () => {
+    expect(source).toContain('if (!args.path.startsWith(projectDir + path.sep)) return undefined;');
+  });
+});
+
+describe('the all-optional zod cases keep the plain-object guard', () => {
+  // The Correctness page states zod agrees with RunTypes on every sample, the alignment
+  // report records zod's plain-object guard as deliberate, and aggregate.mjs fails the
+  // release gate on any `fail`. z.object alone accepts a Date / Map / Set / RegExp for an
+  // all-optional shape, and a `.refine` sees the parsed copy, so the guard has to wrap
+  // the schema from the input side (z.custom(...).pipe(schema)).
+  const source = read('container/benchmarks/competitors/zod/cases.ts');
+  const entry = (key: string): string => {
+    const start = source.indexOf(`'${key}': {`);
+    expect(start, `${key} not found`).toBeGreaterThan(-1);
+    return source.slice(start, source.indexOf('\n  },', start));
+  };
+
+  it('defines the guard on the input side of the object schema', () => {
+    expect(source).toMatch(
+      /const plainObject = [\s\S]*?z\s*\.custom<Input>\([\s\S]*?'\[object Object\]'\)[\s\S]*?\.pipe\(schema\)/
+    );
+  });
+
+  it.each(['OBJECT.interface_all_optional', 'UTILITY.partial', 'UTILITY.deep_partial_recursive_mapped'])(
+    '%s wraps its schema in it',
+    (key) => {
+      expect(entry(key)).toContain('plainObject(');
+      expect(entry(key)).not.toContain('samples:');
+    }
+  );
 });

--- a/scripts/lib/env.mjs
+++ b/scripts/lib/env.mjs
@@ -98,7 +98,7 @@ export const REGISTRY = [
   {name: 'MION_VALIDATION_BENCH_ENGINE', scope: 'dev', task: '-', desc: 'Container engine (default podman)'},
   {name: 'MION_VALIDATION_BENCH_IMAGE', scope: 'dev', task: '-', desc: 'Local image tag (default tsrt-website:dev)'},
   {name: 'MION_VALIDATION_BENCH_CONTAINER', scope: 'dev', task: '-', desc: 'Container name prefix (default tsrt-bench)'},
-  {name: 'MION_VALIDATION_BENCH_NO_TYPIA', scope: 'dev', task: '-', desc: 'Skip the typia competitor (its native plugin build)'},
+  {name: 'MION_VALIDATION_BENCH_NO_TYPIA', scope: 'dev', task: '-', desc: 'Skip the typia competitor lane'},
   {name: 'MION_VALIDATION_BENCH_QUICK', scope: 'dev', task: '-', desc: 'Fast/preview benchmark numbers (noisy)'},
   {name: 'MION_VALIDATION_BENCH_NO_TIMING', scope: 'dev', task: '-', desc: 'Correctness-only run (no timing)'},
   {name: 'MION_VALIDATION_BENCH_TIME_MS', scope: 'dev', task: '-', desc: 'Per-cell timing window in ms (default 100)'},

--- a/scripts/website/bench-data/bench.mjs
+++ b/scripts/website/bench-data/bench.mjs
@@ -47,7 +47,8 @@ function config(env = process.env) {
     runNetwork: env.MION_VALIDATION_BENCH_RUN_NETWORK || '',
     docdataDir: env.MION_VALIDATION_BENCH_DOCDATA || join(REPO_ROOT, '.docdata'),
     remoteImage: env.MION_VALIDATION_BENCH_REMOTE_IMAGE || `${registry}/${owner}/tsrt-website:latest`,
-    // typia's one-time native-plugin compile (.ttsc) persisted across --rm runs.
+    // typia's LEGACY plugin volume, from before the image baked the compiled plugin:
+    // only ever removed (`clean`), never mounted.
     volTtsc: `${containerBase}-typia-ttsc`,
   };
 }
@@ -151,8 +152,9 @@ function mountArgs(cfg) {
   args.push('-v', `${PLUGIN_PKG}:${tsgo}/node_modules/@mionjs/devtools:ro${mo}`);
   if (existsSync(join(BIN_PKG, 'lib/index.js'))) args.push('-v', `${BIN_PKG}:${tsgo}/node_modules/@mionjs/bin:ro${mo}`);
 
-  // typia's native ttsc plugin is BAKED into the image; do NOT mount a volume (an
-  // empty named volume would shadow it and force a ~90-200s recompile).
+  // typia's native ttsc plugin is BAKED into the image (node_modules/.cache/ttsc);
+  // do NOT mount a volume there (an empty named volume would shadow it and force a
+  // multi-minute recompile).
   args.push('-v', `${RESULTS_DIR}:/bench/results${mo}`);
   return args;
 }
@@ -575,7 +577,7 @@ function cmdShell(cfg) {
 }
 
 function cmdClean(cfg) {
-  note("removing the typia .ttsc volume (the shared image is managed by 'pnpm rtx container clean')");
+  note("removing typia's legacy .ttsc volume, if any (the plugin is baked into the shared image now, which 'pnpm rtx container clean' manages)");
   capture(cfg.engine, ['volume', 'rm', '-f', cfg.volTtsc]);
 }
 
@@ -589,9 +591,8 @@ function applyQuick() {
   setIfUnset('MION_VALIDATION_BENCH_TIME_MS', '20'); // runtime: short per-cell window (vs 100ms)
   setIfUnset('MION_COMPILETIME_N', '1'); // compile-time: single repeat (vs 5)
   setIfUnset('MION_TRANSFORM_WIRE_N', '1'); // transform-wire: single repeat (vs 5)
-  setIfUnset('MION_VALIDATION_BENCH_NO_TYPIA', '1'); // skip typia (its native build dominates)
   setIfUnset('MION_COMPILETIME_COMPETITORS', 'mion');
-  console.error(`==> MION_VALIDATION_BENCH_QUICK on: fast/preview mode (MION_VALIDATION_BENCH_TIME_MS=${process.env.MION_VALIDATION_BENCH_TIME_MS}, MION_COMPILETIME_N=${process.env.MION_COMPILETIME_N}, typia skipped, serialization iters reduced). Numbers are noisy.`);
+  console.error(`==> MION_VALIDATION_BENCH_QUICK on: fast/preview mode (MION_VALIDATION_BENCH_TIME_MS=${process.env.MION_VALIDATION_BENCH_TIME_MS}, MION_COMPILETIME_N=${process.env.MION_COMPILETIME_N}, serialization iters reduced). Numbers are noisy.`);
 }
 
 function dispatch(cfg, args) {


### PR DESCRIPTION
## Why

The release gate's "validation + type-cost benchmarks (podman)" job fails on `main` (run 33579204363). The published `tsrt-website` image is stale against the tree, so CI rebuilds it, and in that rebuild the typia lane cannot build: the pinned `typia@13.0.0-dev.20260511` maps `./lib/internal/*.mjs` exports to files it does not ship while `ttsc@0.10.2`'s transform still emits those imports. The image's typia install and plugin warm were both non-fatal, so the broken lane produced an image anyway. The same run scored three zod 4.4.3 cases as `invalid[1] accepted`.

Implements `docs/todos/bench-image-stale-typia-lane-broken.md` (moved to `docs/done/`).

## What changed

**typia lane**
- `_deps/competitors/typia/package.json` pins `typia@13.2.0` + `ttsc@0.23.0` + `@ttsc/unplugin@0.23.0` + `typescript@7.0.2`, dropping `@typescript/native-preview`. This is the newest set the bench workspace's 30-day `minimumReleaseAge` accepts today (typia 14 / ttsc 0.28 are a week old, and that policy applies to exact pins too). ttsc >= 0.19 resolves the `typescript` package for its native compiler, compiles the plugin with the Go toolchain bundled in `@ttsc/<platform>`, and caches it under `node_modules/.cache/ttsc/plugins`, not `.ttsc`.
- `esbuild.config.mjs` names its tsconfig as the ttsc `project` and hands files outside the competitor dir back to esbuild: the unplugin now emits only the project's own files, and the shared harness (which has no typia calls) was failing with "ttsc transform did not return output".
- `Containerfile`: typia's install is fatal, the warm step is fatal, proves `node_modules/.cache/ttsc/plugins/*/plugin`, and drops the 4 GB Go build cache in the same layer.
- `compiletime.mjs` falls back to typescript 7's `tsc` bin when no `tsgo` bin is installed.
- `MION_VALIDATION_BENCH_NO_TYPIA=1` is removed from `ci.yml`, `pr-heavy.yml` and the `--quick` defaults: with the plugin baked, the typia build is a one-second esbuild pass.

**zod**
- `OBJECT.interface_all_optional`, `UTILITY.partial`, `UTILITY.deep_partial_recursive_mapped` get the plain-object guard back on the input side (`z.custom(...).pipe(schema)`; a `.refine` sees the parsed copy and still accepts a `Date`). The Correctness page and the alignment report both record zod as agreeing with RunTypes here, so this is the case fix rather than a sample override.

**tests / docs**
- `packages/devtools/test/bench-lane-contracts.test.ts` pins the manifest agreement, the fatal warm and cache path, the wrapper filter and the zod guard.
- Benchmarks README, SETUP.md, the audit collector comment and the parked TypeScript 7 note updated; the todo spec moved to `docs/done/` with what shipped.

## Verified

- Host: the typia lane builds from the warm cache in about one second and passes 279 cases (206 ok, 0 fail, 0 errored, 73 not-supported).
- In-container, on an image built from these manifests (on top of the published image, since Docker Hub is unreachable from this session): `bench-one typia` 206 ok / 0 fail, `bench-one zod` 239 ok / 0 fail on validationErrors, no plugin recompile at run time, `bench typecheck` and `bench smoke` green.
- `pnpm run lint` (0 errors), `pnpm run format`, `check:env`, `check:test-batches`, the devtools-core contract suite green.

## Not done here: the image republish

This session has the GHCR credentials but no arm64 emulation and no route to Docker Hub for the `node:26-bookworm` base, so the multi-arch push cannot run from it. After merge, a maintainer runs:

```
pnpm rtx container push website
pnpm rtx container push e2e
```

(`e2e` because its Containerfile label changed in PR #201.) Until then the staleness guard makes CI rebuild the website image locally, which is slow but green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfSyciWFyxQPBerX6pKcfy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfSyciWFyxQPBerX6pKcfy)_