### PR TITLE
docs: count seven container images and list drizzle-cloudflare

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ The full map and rules (directory layout, submodule/patch workflow, Marker test 
 
 Supplementary apps whose heavy, unrelated dependencies (Nuxt/Docus, competitor validators like zod/typebox/ajv/typia, verdaccio + multi-bundler toolchains) run **only inside podman images** — never installed on the host, never mixed into the workspace lockfile.
 
-SIX images, all owned by [scripts/container/image.mjs](scripts/container/image.mjs) (`pnpm rtx container <cmd> [website|e2e|mion-bench|drizzle-pg|drizzle-mysql|drizzle-sqlite]`), published to GHCR under `ghcr.io/mionkit/`.
-`pnpm rtx container push` with no target builds + pushes ALL SIX. Shared podman/GHCR helpers in [scripts/lib/engine.mjs](scripts/lib/engine.mjs).
+SEVEN images, all owned by [scripts/container/image.mjs](scripts/container/image.mjs) (`pnpm rtx container <cmd> [website|e2e|mion-bench|drizzle-pg|drizzle-mysql|drizzle-sqlite|drizzle-cloudflare]`), published to GHCR under `ghcr.io/mionkit/`.
+`pnpm rtx container push` with no target builds + pushes ALL SEVEN. Shared podman/GHCR helpers in [scripts/lib/engine.mjs](scripts/lib/engine.mjs).
 Pulling or pushing needs `GHCR_PAT`, `GHCR_OWNER`, `GHCR_USER` and `GHCR_REGISTRY` in the environment or in `.env` (see [SETUP.md → GHCR](SETUP.md#publishing--consuming-the-image-via-ghcr)); without them a run falls back to building the image locally, which needs a Docker Hub base image.
 See [SETUP.md → Containerized apps](SETUP.md#containerized-apps-docs-website--benchmarks).
 
@@ -83,7 +83,7 @@ See [SETUP.md → Containerized apps](SETUP.md#containerized-apps-docs-website--
 - **`tsrt-e2e`** ← [pre-publish-e2e/](container/pre-publish-e2e/); run with `pnpm rtx release e2e`. Its OWN image so the light smoke / benchmark / website-build lanes never pull the heavy toolchains.
   - Verdaccio + the multi-bundler builder toolchains at `/e2e`; the mion consumer toolchain at `/e2e-mion` (separate root: the matrix pins rolldown-vite + TypeScript 5, a mion consumer runs plain vite 8 + TypeScript 6).
   - ONE gate covers BOTH families: the same verdaccio serves `RunTypes/*` and `@mionjs/*`, so a packed `@mionjs/core` resolves its exact sibling `@mionjs/run-types`.
-- **`mion-drizzle-pg|mysql|sqlite`** ← [drizzle-e2e/](container/drizzle-e2e/); run with `pnpm rtx release drizzle-e2e`. The ONLY thing that proves a `toDrizzle()` table works against a real database.
+- **`mion-drizzle-pg|mysql|sqlite|cloudflare`** ← [drizzle-e2e/](container/drizzle-e2e/); run with `pnpm rtx release drizzle-e2e`. FOUR images cover FIVE lanes: `pg` / `mysql` / `sqlite` are dialects, and the `cloudflare` image serves BOTH Cloudflare storage-driver lanes (`d1` and `durable`), which are drivers rather than dialects. The ONLY thing that proves a `toDrizzle()` table works against a real database.
   - Each translates drizzle's OWN integration suites onto the slim packages with `mion drizzle-migrate`, converts that tree AGAIN onto the pure-type road with `mion convert --to type`, then runs all three trees (control, builders, types) against three databases, typechecks them, and crosses both reports against the manifests. The type-road tree runs through the devtools build transform, which is the only place a `tableFromType<T>()` marker resolves.
   - The DATABASE image is the base (`postgres:17-trixie`, `mysql:8.4`, `node:26-trixie` for sqlite), with Node from the official tarball: drizzle's suites want real postgres and real MySQL, and Debian ships MariaDB.
   - NO docker-in-docker: drizzle's runners prefer `PG_CONNECTION_STRING` / `MYSQL_CONNECTION_STRING` / `SQLITE_DB_PATH` over their own docker helper.

--- a/SETUP.md
+++ b/SETUP.md
@@ -179,7 +179,7 @@ Six deps-only images are published to the GitHub Container Registry so any host 
 | ---- | ------- | ----- |
 | Authenticate (once) | `pnpm rtx container login` | Reads the PAT from `GHCR_PAT`, pipes via `--password-stdin`. Only needed for a **private** package. |
 | Run (consume) | `pnpm rtx website dev` / `pnpm rtx bench` | Pulls the latest published image, then runs. This is the default. |
-| Publish | `pnpm rtx container push` | Builds the **multi-arch** (`linux/amd64,linux/arm64`) images and pushes them. No target = ALL SIX; add `website`, `e2e`, `mion-bench`, `drizzle-pg`, `drizzle-mysql` or `drizzle-sqlite` to push just one. |
+| Publish | `pnpm rtx container push` | Builds the **multi-arch** (`linux/amd64,linux/arm64`) images and pushes them. No target = ALL SEVEN; add `website`, `e2e`, `mion-bench`, `drizzle-pg`, `drizzle-mysql`, `drizzle-sqlite` or `drizzle-cloudflare` to push just one. |
 | Build/run locally | `MION_WEBSITE_USE_LOCAL=1 pnpm rtx website dev` (or `MION_VALIDATION_BENCH_USE_LOCAL=1`) | Skip the pull; build/use a local image. The maintainer/offline loop — also how you test a dep bump before pushing. |
 | Pull only | `pnpm rtx container pull` | Fetch + retag without running. |
 

--- a/scripts/rt.mjs
+++ b/scripts/rt.mjs
@@ -515,8 +515,8 @@ bench
   rtx bench servers <one <app>|suite <key>|sweep|build|prep|aggregate|build-image|push|pull|clean>
 
 ${RELEASE_HELP}
-container  rtx container <build-image|ensure|login|push|pull|lock|clean> [website|e2e]
-           (build-image/push/pull/clean act on BOTH images when no target is given)
+container  rtx container <build-image|ensure|login|push|pull|lock|clean> [website|e2e|mion-bench|drizzle-pg|drizzle-mysql|drizzle-sqlite|drizzle-cloudflare]
+           (build-image/push/pull/clean act on ALL SEVEN images when no target is given)
 env        rtx env [push-image|publish-npm|deploy-website|--create-env]
 
 verify     build if stale, then lint + typecheck + format check


### PR DESCRIPTION
## What

`drizzle-cloudflare` was added to `scripts/container/image.mjs` but never to the docs. Three places still claimed **SIX** images and left it out of every target list:

- `CLAUDE.md` — the image count, the target list, and the `mion-drizzle-*` bullet
- `SETUP.md:182` — the publish table row
- `scripts/rt.mjs:518` — the `rtx container` help text

The code has seven:

```js
// scripts/container/image.mjs:70
const DRIZZLE_DIALECTS = ['pg', 'mysql', 'sqlite', 'cloudflare'];
```

Four drizzle images cover five lanes: `pg` / `mysql` / `sqlite` are dialects, and the `cloudflare` image serves both Cloudflare storage-driver lanes (`d1` and `durable`), which are drivers rather than dialects.

## Why it mattered

`pnpm rtx container push` with no target pushes **all seven**. Anyone following the docs would have expected six and quietly missed republishing one image.

## Found while

Republishing the GHCR images after the unified-release merge.

## Checks

- `pnpm run lint` — 0 errors (34 pre-existing `CLS001` warnings in `packages/core` test files, untouched here)
- `pnpm run check-format` — clean
- `pnpm run check:builds` — clean
- Help text verified live:

```
container  rtx container <build-image|ensure|login|push|pull|lock|clean> [website|e2e|mion-bench|drizzle-pg|drizzle-mysql|drizzle-sqlite|drizzle-cloudflare]
           (build-image/push/pull/clean act on ALL SEVEN images when no target is given)
```

Docs-only, but `scripts/rt.mjs` matches the `pkg` path filter, so the full JS and Go suites run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)