### PR TITLE
fix(website): mount twoslash package types from each manifest's own types entry

### DIFF
--- a/.github/workflows/pr-heavy.yml
+++ b/.github/workflows/pr-heavy.yml
@@ -67,8 +67,9 @@ jobs:
       # fails on a 404 that says nothing about the PR. Regenerating the published
       # numbers is website-deploy.yml's job, on prod, with typia.
       #
-      # `website check --docs` is not used either: its twoslash hover assertion
-      # fails on main too, so it would report a pre-existing problem as this PR's.
+      # `website check --docs` is not used either: it renders the home page's hover
+      # cards through the twoslash endpoint, which needs every @mionjs/* dist built
+      # first (a whole-workspace build this lane does not run).
       - name: Build both docs sites
         run: pnpm rtx website container-build --site both
 

--- a/container/website/CLAUDE.md
+++ b/container/website/CLAUDE.md
@@ -196,10 +196,15 @@ script, so doc drift fails CI instead of rotting.
   must use the **published** names (`@mionjs/run-types`, `@mionjs/router`, …), not the
   `packages/` directory names. A mismatch is silent here but breaks every example
   import; `packages/devtools/test/repo-contracts.test.ts` guards it.
-- **One endpoint serves both sites**, so it mounts both scopes. The `@mionjs/*` mounts
-  read `.dist/esm`, which means those packages must be BUILT: `site.mjs` runs
-  `build:mion` before serving the mion site, because without it every hover card on the
-  mion home page renders an error and the build still exits 0.
+- **One endpoint serves both sites**, so it mounts both scopes. The mount root is not
+  written in the list: the endpoint reads each package's `package.json` and mounts the
+  directory holding its `.` types entry (`.dist/esm` for core, `.dist/esm/src` for the
+  drizzle packages, `dist` for run-types, the committed `lib` for uws), so a package's
+  own manifest is the one place its dist layout lives. That means those packages must
+  be BUILT: `site.mjs` builds the `@mionjs/*` dists before serving the mion site,
+  because without them every hover card on the mion home page renders an error and
+  the build still exits 0. `pnpm rtx website check --docs` renders every home page
+  card through the endpoint and fails on the first one without hovers.
 - Third-party `.d.ts` come in through a named allowlist (`externalDeps`, today just
   `drizzle-orm`), mirrored by `TWOSLASH_EXTERNAL_DEPS` in `scripts/website/site.mjs`,
   which mounts that one dir into the container. Both ends must move together.

--- a/container/website/server/api/twoslash.post.ts
+++ b/container/website/server/api/twoslash.post.ts
@@ -141,6 +141,22 @@ function findFiles(dir: string, pattern: RegExp, files: string[] = []): string[]
 }
 
 /**
+ * The built `.d.ts` a package's own package.json names as its `.` types entry, absolute.
+ * Reads the three spellings the workspace uses: a plain `exports['.'].types`, the
+ * conditional `exports['.'].import.types` (@mionjs/run-types), and a top-level `types`.
+ * Undefined when the manifest names none. Mirrored by repo-contracts.test.ts.
+ */
+function typesEntry(pkgDir: string): string | undefined {
+  const manifestPath = join(pkgDir, 'package.json')
+  if (!existsSync(manifestPath)) return undefined
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+  const root = manifest.exports?.['.']
+  const declared: unknown = typeof root === 'string' ? root : (root?.types ?? root?.import?.types ?? manifest.types)
+  if (typeof declared !== 'string' || !declared.endsWith('.d.ts')) return undefined
+  return resolve(pkgDir, declared)
+}
+
+/**
  * Load all .d.ts files from the RunTypes packages into a virtual file system Map
  */
 function loadPackageTypes(): Map<string, string> {
@@ -169,62 +185,69 @@ function loadPackageTypes(): Map<string, string> {
 
   // Packages to load. `dir` is the directory under packages/, `name` is the npm
   // package name: the specifier examples actually import, which is what the
-  // virtual node_modules path must use. The two differ on BOTH rows (the
-  // directory kept its pre-scope name when the packages moved onto the
+  // virtual node_modules path must use. The two differ on every row (the
+  // directories kept their pre-scope names when the packages moved onto the
   // @mionjs scope), and getting `name` wrong is silent: the VFS mounts a
   // module nothing imports, every example fails to resolve, and twoslash throws.
-  // Subpath imports (@mionjs/run-types/formats, /schema) resolve via the
-  // per-directory index.d.ts under classic node resolution, and
-  // @mionjs/devtools/runtypes/vite via the sibling vite.d.ts.
+  // The mount ROOT is not written here: it is the directory holding the package's
+  // own `.` types entry (typesEntry above), read from its package.json. The dists
+  // are not laid out alike (core emits `.dist/esm/index.d.ts`, the drizzle packages
+  // `.dist/esm/src/index.d.ts`, run-types `dist/`, uws a committed `lib/`), and a
+  // hand-written root that misses the real entry mounts a tree whose bare import
+  // resolves nothing, and the card renders a compiler error instead of hovers.
+  // Subpath imports (@mionjs/run-types/formats, @mionjs/drizzle-orm-pg-core/drizzle)
+  // resolve via the sibling `<sub>.d.ts` / `<sub>/index.d.ts` under classic node
+  // resolution, which is why every dist keeps its subpaths parallel to its exports.
   // `name` MUST be the PUBLISHED npm name, not the packages/ directory name — the
   // mount path is what an example's bare import resolves against. Both sites share
   // this list; a runtypes page simply never imports an @mionjs package, and vice versa.
   // Pinned by `repo-contracts.test.ts`.
   const packageConfigs = [
-    { dir: 'run-types', name: '@mionjs/run-types', distPath: 'dist' },
-    { dir: 'devtools', name: '@mionjs/devtools', distPath: 'dist' },
-    { dir: 'core', name: '@mionjs/core', distPath: '.dist/esm' },
-    { dir: 'router', name: '@mionjs/router', distPath: '.dist/esm' },
-    { dir: 'client', name: '@mionjs/client', distPath: '.dist/esm' },
-    { dir: 'drizzle-orm', name: '@mionjs/drizzle-orm', distPath: '.dist/esm' },
-    { dir: 'drizzle-orm-mysql-core', name: '@mionjs/drizzle-orm-mysql-core', distPath: '.dist/esm' },
-    { dir: 'drizzle-orm-pg-core', name: '@mionjs/drizzle-orm-pg-core', distPath: '.dist/esm' },
-    { dir: 'drizzle-orm-sqlite-core', name: '@mionjs/drizzle-orm-sqlite-core', distPath: '.dist/esm' },
-    { dir: 'platform-aws', name: '@mionjs/platform-aws', distPath: '.dist/esm' },
-    { dir: 'platform-bun', name: '@mionjs/platform-bun', distPath: '.dist/esm' },
-    { dir: 'platform-cloudflare', name: '@mionjs/platform-cloudflare', distPath: '.dist/esm' },
-    { dir: 'platform-gcloud', name: '@mionjs/platform-gcloud', distPath: '.dist/esm' },
-    { dir: 'platform-node', name: '@mionjs/platform-node', distPath: '.dist/esm' },
-    { dir: 'platform-uws', name: '@mionjs/platform-uws', distPath: '.dist/esm' },
+    { dir: 'run-types', name: '@mionjs/run-types' },
+    { dir: 'devtools', name: '@mionjs/devtools' },
+    { dir: 'core', name: '@mionjs/core' },
+    { dir: 'router', name: '@mionjs/router' },
+    { dir: 'client', name: '@mionjs/client' },
+    { dir: 'drizzle-orm', name: '@mionjs/drizzle-orm' },
+    { dir: 'drizzle-orm-mysql-core', name: '@mionjs/drizzle-orm-mysql-core' },
+    { dir: 'drizzle-orm-pg-core', name: '@mionjs/drizzle-orm-pg-core' },
+    { dir: 'drizzle-orm-sqlite-core', name: '@mionjs/drizzle-orm-sqlite-core' },
+    { dir: 'platform-aws', name: '@mionjs/platform-aws' },
+    { dir: 'platform-bun', name: '@mionjs/platform-bun' },
+    { dir: 'platform-cloudflare', name: '@mionjs/platform-cloudflare' },
+    { dir: 'platform-gcloud', name: '@mionjs/platform-gcloud' },
+    { dir: 'platform-node', name: '@mionjs/platform-node' },
+    { dir: 'platform-uws', name: '@mionjs/platform-uws' },
     // the loader shim platform-uws depends on: its types (AppOptions etc.) are a
     // committed hand-written lib/index.d.ts, not a built dist.
-    { dir: 'uws', name: '@mionjs/uws', distPath: 'lib' },
-    { dir: 'platform-vercel', name: '@mionjs/platform-vercel', distPath: '.dist/esm' },
-    // @mionjs/devtools ships one nested build tree per entry point rather than a flat
-    // dist, and classic node resolution ignores the `exports` map, so its entries need
-    // `entries` shims (below) to be reachable as `@mionjs/devtools` / `.../vite-plugin`.
-    {
-      dir: 'devtools',
-      name: '@mionjs/devtools',
-      distPath: 'build',
-      entries: {'.': 'eslint/esm/src/eslint/index', './vite-plugin': 'vite-plugin/esm/src/vite-plugin/index'},
-    },
+    { dir: 'uws', name: '@mionjs/uws' },
+    { dir: 'platform-vercel', name: '@mionjs/platform-vercel' },
   ]
 
   for (const pkg of packageConfigs) {
-    const pkgDistDir = join(packagesDir, pkg.dir, pkg.distPath)
+    const pkgDir = join(packagesDir, pkg.dir)
+    const entry = typesEntry(pkgDir)
+    if (!entry) {
+      console.warn(`[twoslash] ${pkg.name}: package.json declares no types entry, not mounted`)
+      continue
+    }
+    const pkgDistDir = dirname(entry)
     // dist/cjs/ is the CommonJS twin of the same declarations, mounting it would
     // double the VFS for no added resolution, so keep only the ESM tree.
     const dtsFiles = findFiles(pkgDistDir, /\.d\.ts$/).filter(
       (file) => !relative(pkgDistDir, file).startsWith('cjs' + sep),
     )
-    if (dtsFiles.length === 0) continue
+    if (dtsFiles.length === 0) {
+      console.warn(`[twoslash] ${pkg.name}: no .d.ts under ${relative(repoRoot, pkgDistDir)} (not built?), not mounted`)
+      continue
+    }
 
-    // Synthetic package.json so TS's Node resolver finds `index.d.ts` (and subpath
+    // Synthetic package.json so TS's Node resolver finds the entry (and subpath
     // exports like `@mionjs/run-types/formats`) for bare imports in examples.
+    const entryFile = relative(pkgDistDir, entry)
     fsMap.set(
       `/node_modules/${pkg.name}/package.json`,
-      JSON.stringify({ name: pkg.name, types: 'index.d.ts', main: 'index.d.ts' }),
+      JSON.stringify({ name: pkg.name, types: entryFile, main: entryFile }),
     )
 
     for (const dtsFile of dtsFiles) {
@@ -244,16 +267,6 @@ function loadPackageTypes(): Map<string, string> {
       } catch (e) {
         console.warn(`Failed to read ${dtsFile}:`, e)
       }
-    }
-
-    // Entry-point shims for a package whose declarations are not at the paths classic
-    // node resolution looks in. `'.'` becomes index.d.ts, `'./x'` becomes x/index.d.ts,
-    // each just re-exporting the real file that IS mounted above.
-    for (const [subpath, target] of Object.entries(pkg.entries ?? {})) {
-      const virtual = subpath === '.' ? 'index.d.ts' : `${subpath.replace(/^\.\//, '')}/index.d.ts`
-      const depth = virtual.split('/').length - 1
-      const from = `${'../'.repeat(depth) || './'}${target}`
-      fsMap.set(`/node_modules/${pkg.name}/${virtual}`, `export * from '${from}';\n`)
     }
   }
 

--- a/docs/done/twoslash-drizzle-dist-mount.md
+++ b/docs/done/twoslash-drizzle-dist-mount.md
@@ -1,7 +1,7 @@
 ---
 type: fix
 spec: guidelines
-status: ready
+status: done
 created: 2026-09-02
 ---
 
@@ -52,6 +52,48 @@ contains an `index.d.ts` (or resolves the package's `types` entry), and run
 
 ## Done when
 
-- The drizzle card on `/rpc` renders type hovers; the build log shows no twoslash error.
+- The drizzle card on the mion home page renders type hovers; the build log shows no
+  twoslash error.
 - A repo contract fails if a mounted package's dist root has no `index.d.ts` again.
 - `pnpm test`, `pnpm run lint`, `pnpm run format` green.
+
+## What shipped (2026-09-02)
+
+Why the drizzle dists nest `src/`: those packages keep their entry at `src/index.ts` with
+`rootDir: "."` (core, router and the platforms have a root-level `index.ts`), so the
+emitted tree mirrors the source tree. Their `package.json` exports already say so. Moving
+the emit would change every published drizzle entry path on a version line that republishes
+on any source change, for nothing the mount cannot read from the manifest. So the mount
+reads it:
+
+1. `container/website/server/api/twoslash.post.ts`: drop the hand-written `distPath` and
+   derive each mount root from the package's own manifest, the directory holding its `.`
+   `types` entry (`exports['.'].types`, the `import.types` form `@mionjs/run-types` uses, or
+   a top-level `types`). The synthetic package.json names that entry. A package whose
+   manifest declares no types entry is skipped with a warning instead of a silent
+   no-hover page.
+2. Same file: remove the second `@mionjs/devtools` row (`distPath: 'build'` plus its
+   `entries` shims). `packages/devtools/build` has not existed since the two devtools
+   packages merged; today the row is a no-op, but a populated `build/` would overwrite
+   the real devtools mount's package.json and index.d.ts.
+3. `packages/devtools/test/repo-contracts.test.ts`: the contract. For every mounted
+   package the manifest's `.` types entry must be an `index.d.ts` (that is what classic
+   node resolution finds at the mount root), every first-party subpath the examples import
+   must sit where classic resolution looks under that root (`<sub>.d.ts` or
+   `<sub>/index.d.ts`), and when the package is built on this host the file must exist.
+4. `scripts/website/site.mjs` `verify-docs`: render every example the site's home page
+   embeds (the five hover cards on the mion site) through `/api/twoslash`, not one
+   arbitrary example, so the check proves the cards the reader sees.
+5. Tests: the vitest contract above (`pnpm test`). Docs: none, the change is internal
+   docs tooling with no user-facing surface. Fuzzing: not a candidate (a fix, no oracle).
+6. Verified with `pnpm test`, `pnpm run lint`, `pnpm run format` and
+   `pnpm rtx website check --docs --site mion`, which now renders all five home page
+   cards (the drizzle card included) with hovers. The published `tsrt-website` image's
+   deps stamp differs from the tree, so the check ran against the pulled image
+   relabelled with the tree's stamp under `MION_WEBSITE_USE_LOCAL=1`; the endpoint
+   code the check exercises is bind-mounted, not baked, so the image's age does not
+   affect the result.
+
+Out of scope, on purpose: the drizzle packages keep emitting under `.dist/esm/src`,
+and `pr-heavy.yml` still leaves `website check --docs` out (it needs the `@mionjs/*`
+dists built in CI, a separate decision).

--- a/docs/done/twoslash-drizzle-dist-mount.md
+++ b/docs/done/twoslash-drizzle-dist-mount.md
@@ -1,0 +1,57 @@
+---
+type: fix
+spec: guidelines
+status: ready
+created: 2026-09-02
+---
+
+# Twoslash cannot resolve the drizzle packages: their dist sits under .dist/esm/src
+
+## Intent
+
+The rpc home page (`container/website/content/01.rpc/index.md`) renders five type-hover
+cards through the `/api/twoslash` endpoint. The drizzle card
+(`packages/examples/src/_homepage/home-drizzle.ts`, which imports
+`@mionjs/drizzle-orm-pg-core`) renders an error instead of hovers, and the site build
+logs:
+
+```
+ERROR  Twoslash rendering error:
+Compiler Errors:
+index.ts
+  [2307] 71 - Cannot find module '@mionjs/drizzle-orm-pg-core' or its corresponding type declarations.
+```
+
+Found while building the unified docs site (branch `claude/unified-website-structure-pkch05`);
+it predates that change: the mount list and the package layouts are untouched there, and
+`pr-heavy.yml` already notes that the twoslash hover assertion fails on `main`.
+
+## Direction
+
+`container/website/server/api/twoslash.post.ts` mounts every first-party package's built
+`.d.ts` into the twoslash virtual file system at `/node_modules/<npm name>/`, taking
+`packages/<dir>/<distPath>` as the package root (`packageConfigs`, `distPath: '.dist/esm'`
+for the `@mionjs/*` packages). That matches `core`, `router`, `client` and the platform
+packages, whose `.dist/esm/index.d.ts` sits at the root. The four drizzle packages
+(`drizzle-orm`, `drizzle-orm-pg-core`, `drizzle-orm-mysql-core`, `drizzle-orm-sqlite-core`)
+emit under `.dist/esm/src/` instead; their `package.json` exports point at
+`./.dist/esm/src/index.d.ts` (and `./.dist/esm/src/drizzle.d.ts` for the `./drizzle`
+subpath). So the mount root holds only a `src/` dir, and the bare import resolves nothing.
+
+Two ways to fix, the implementer picks after checking why the drizzle builds nest `src/`:
+
+- make the drizzle packages emit like the others (`.dist/esm/index.d.ts`), keeping their
+  `package.json` exports in step, or
+- teach the mount to read the real entry: mount `.dist/esm/src` for those packages, or
+  derive `distPath` from each package's `exports['.'].types` so the list cannot drift again.
+
+Whichever lands, add the contract: `packages/devtools/test/repo-contracts.test.ts`
+already pins the twoslash mount names; extend it so every mounted `distPath` actually
+contains an `index.d.ts` (or resolves the package's `types` entry), and run
+`pnpm rtx website check --docs` to see the hovers render.
+
+## Done when
+
+- The drizzle card on `/rpc` renders type hovers; the build log shows no twoslash error.
+- A repo contract fails if a mounted package's dist root has no `index.d.ts` again.
+- `pnpm test`, `pnpm run lint`, `pnpm run format` green.

--- a/packages/devtools/test/repo-contracts.test.ts
+++ b/packages/devtools/test/repo-contracts.test.ts
@@ -285,6 +285,97 @@ describe('twoslash VFS mounts the packages the examples import', () => {
   it('mounts them under their scoped npm names, not the pre-scope directory names', () => {
     for (const name of mountedPackageNames()) expect(name).toMatch(/^@mionjs\//);
   });
+
+  // The mount ROOT is not written in the list: twoslash.post.ts reads each package's
+  // own package.json and mounts the directory holding its `.` types entry. The dists
+  // are not laid out alike (core emits `.dist/esm/index.d.ts`, the drizzle packages
+  // `.dist/esm/src/index.d.ts`, run-types `dist/`, uws a committed `lib/`), and the
+  // hand-written `distPath` this replaced mounted `.dist/esm` for the drizzle
+  // packages: a root holding only `src/`, so `import ... from
+  // '@mionjs/drizzle-orm-pg-core'` resolved nothing and the home page's drizzle card
+  // rendered a compiler error. Reading the manifest removes that drift; what is left
+  // to pin is that every manifest names an entry, that a built dist really holds it
+  // where the manifest says, and that the subpaths the examples import sit where
+  // classic node resolution looks under that root.
+  const TYPES_SPELLINGS = 'exports["."].types, exports["."].import.types or a top-level types';
+
+  // Mirrors typesEntry() in twoslash.post.ts: the `.` types entry relative to the
+  // package dir, in the three spellings the workspace uses.
+  function declaredTypes(manifest: Record<string, any>, subpath: string): string | undefined {
+    const entry = manifest.exports?.[subpath];
+    const declared =
+      typeof entry === 'string'
+        ? entry
+        : (entry?.types ?? entry?.import?.types ?? (subpath === '.' ? manifest.types : undefined));
+    return typeof declared === 'string' && declared.endsWith('.d.ts') ? posix.normalize(declared) : undefined;
+  }
+
+  function mountedPackages(): {dir: string; name: string; manifest: Record<string, any>}[] {
+    const source = readFileSync(TWOSLASH_API, 'utf8');
+    const configs = /const packageConfigs = \[(.*?)\]/s.exec(source);
+    if (!configs) throw new Error('packageConfigs literal not found in twoslash.post.ts');
+    return [...configs[1].matchAll(/\{\s*dir:\s*'([^']+)',\s*name:\s*'([^']+)'/g)].map((match) => ({
+      dir: match[1],
+      name: match[2],
+      manifest: JSON.parse(readFileSync(join(REPO_ROOT, 'packages', match[1], 'package.json'), 'utf8')),
+    }));
+  }
+
+  it('every mounted package names its `.` types entry, the file the mount root is derived from', () => {
+    const packages = mountedPackages();
+    expect(packages.length).toBeGreaterThan(0);
+    const missing = packages.filter(({manifest}) => declaredTypes(manifest, '.') === undefined).map(({name}) => name);
+    expect(missing, `no ${TYPES_SPELLINGS}`).toEqual([]);
+  });
+
+  // A built package must hold its entry where its manifest says. "Built" is judged by
+  // the top-level output dir (`.dist`, `dist`, `lib`): a host that never built the
+  // package is skipped, a build that emits a different layout than the manifest
+  // declares (the drizzle shape, had the manifest not followed it) fails.
+  it('a built dist holds the entry the manifest declares', () => {
+    const wrong: string[] = [];
+    for (const {dir, name, manifest} of mountedPackages()) {
+      const entry = declaredTypes(manifest, '.');
+      if (!entry) continue;
+      const outDir = join(REPO_ROOT, 'packages', dir, entry.split('/')[0]);
+      if (!existsSync(outDir)) continue;
+      if (!existsSync(join(REPO_ROOT, 'packages', dir, entry))) wrong.push(`${name}: ${entry}`);
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  // The endpoint resolves with classic node resolution (it ignores `exports`), so a
+  // subpath import `@mionjs/x/sub` is found only as `<root>/sub.d.ts` or
+  // `<root>/sub/index.d.ts` under the mounted root. Every subpath an example imports
+  // must declare its types at one of those two places relative to the `.` entry.
+  it('every first-party subpath the examples import sits where classic resolution finds it', () => {
+    const byName = new Map(mountedPackages().map((pkg) => [pkg.name, pkg]));
+    const subpaths = new Set<string>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) walk(full);
+        else if (entry.endsWith('.ts')) {
+          for (const match of readFileSync(full, 'utf8').matchAll(/from\s+'(@mionjs\/[^'/]+)\/([^']+)'/g))
+            subpaths.add(`${match[1]}\t${match[2]}`);
+        }
+      }
+    };
+    walk(EXAMPLES_SRC);
+    expect(subpaths.size).toBeGreaterThan(0);
+    const unreachable: string[] = [];
+    for (const key of subpaths) {
+      const [name, sub] = key.split('\t');
+      const pkg = byName.get(name);
+      if (!pkg) continue; // the mount-list test above reports it
+      const root = posix.dirname(declaredTypes(pkg.manifest, '.') ?? '');
+      const declared = declaredTypes(pkg.manifest, `./${sub}`);
+      const reachable = [posix.join(root, `${sub}.d.ts`), posix.join(root, sub, 'index.d.ts')];
+      if (!declared || !reachable.includes(declared))
+        unreachable.push(`${name}/${sub}: types ${declared ?? '(none)'} is not one of ${reachable.join(' | ')}`);
+    }
+    expect(unreachable).toEqual([]);
+  });
 });
 
 // The rtx release area is the only one whose no-subcommand default performs an

--- a/packages/devtools/test/repo-contracts.test.ts
+++ b/packages/devtools/test/repo-contracts.test.ts
@@ -328,21 +328,33 @@ describe('twoslash VFS mounts the packages the examples import', () => {
     expect(missing, `no ${TYPES_SPELLINGS}`).toEqual([]);
   });
 
-  // A built package must hold its entry where its manifest says. "Built" is judged by
-  // the top-level output dir (`.dist`, `dist`, `lib`): a host that never built the
-  // package is skipped, a build that emits a different layout than the manifest
-  // declares (the drizzle shape, had the manifest not followed it) fails.
+  // A built package must hold its entry where its manifest says. "Built" means what
+  // the endpoint means: the root holds `.d.ts` files (it mounts nothing otherwise), so
+  // a host that never built the package is skipped, and a build that emits a
+  // different layout than the manifest declares (the drizzle shape, had the manifest
+  // not followed it) fails. Not "the output dir exists": the root tsconfig is
+  // incremental, so a package's `tsc --noEmit` typecheck (part of `pnpm run lint`)
+  // leaves `.dist/esm/tsconfig.tsbuildinfo` behind with no types in it, which is
+  // what an unbuilt CI checkout looks like.
   it('a built dist holds the entry the manifest declares', () => {
     const wrong: string[] = [];
     for (const {dir, name, manifest} of mountedPackages()) {
       const entry = declaredTypes(manifest, '.');
       if (!entry) continue;
-      const outDir = join(REPO_ROOT, 'packages', dir, entry.split('/')[0]);
-      if (!existsSync(outDir)) continue;
+      const root = join(REPO_ROOT, 'packages', dir, posix.dirname(entry));
+      if (!existsSync(root) || !hasDeclarations(root)) continue;
       if (!existsSync(join(REPO_ROOT, 'packages', dir, entry))) wrong.push(`${name}: ${entry}`);
     }
     expect(wrong).toEqual([]);
   });
+
+  function hasDeclarations(dir: string): boolean {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory() ? hasDeclarations(full) : entry.endsWith('.d.ts')) return true;
+    }
+    return false;
+  }
 
   // The endpoint resolves with classic node resolution (it ignores `exports`), so a
   // subpath import `@mionjs/x/sub` is found only as `<root>/sub.d.ts` or

--- a/scripts/website/site.mjs
+++ b/scripts/website/site.mjs
@@ -18,7 +18,7 @@
 // exit/SIGINT/SIGTERM. The in-container `sh -c '…'` blocks stay shell (they run
 // inside the Linux container, which always has sh).
 
-import {existsSync, globSync, mkdirSync, realpathSync, renameSync, rmSync, statSync} from 'node:fs';
+import {existsSync, globSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync} from 'node:fs';
 import {join} from 'node:path';
 import {ensureImage} from '../container/image.mjs';
 import {loadEnv, REPO_ROOT, SITES} from '../lib/env.mjs';
@@ -397,6 +397,15 @@ function containerHttp(cfg, cname, path, body) {
   return {status, body: result.stdout.slice(nl + 1)};
 }
 
+// The example files the site's home page renders through ::twoslash-code, in page
+// order: every `path: packages/examples/src/…` its index.md names. Empty for a site
+// whose home page has no card (the runtypes site).
+function homeTwoslashPaths(cfg) {
+  const index = join(WEBSITE_DIR, 'sites', cfg.site, 'content', 'index.md');
+  if (!existsSync(index)) return [];
+  return [...readFileSync(index, 'utf8').matchAll(/^\s*path:\s*(packages\/examples\/src\/\S+\.ts)\s*$/gm)].map((match) => match[1]);
+}
+
 async function cmdVerifyDocs(cfg) {
   ensureImage();
   const cname = `${cfg.containerBase}-verify`;
@@ -439,9 +448,17 @@ async function cmdVerifyDocs(cfg) {
   };
 
   let fails = 0;
-  // 1. twoslash endpoint renders hovers from the mounted packages' .d.ts.
-  if (postIncludes('/api/twoslash', {path: relpath, hoverMode: 'all'}, 'twoslash')) console.log(`  PASS  twoslash: rendered hovers for ${relpath}`);
-  else (console.error(`  FAIL  twoslash: no hover markup for ${relpath}`), (fails = 1));
+  // 1. twoslash endpoint renders hovers from the mounted packages' .d.ts: every card
+  //    the site's home page embeds (the five on the mion home page; a home page with
+  //    no card falls back to the example above). A card imports the packages the
+  //    reader sees documented, so it is the mount list this actually proves. The
+  //    endpoint answers 500 on a compiler error (an unresolved import included), and
+  //    2xx-with-no-markup is the same failure with the noise stripped.
+  const cards = homeTwoslashPaths(cfg);
+  for (const card of cards.length > 0 ? cards : [relpath]) {
+    if (postIncludes('/api/twoslash', {path: card, hoverMode: 'all'}, 'twoslash')) console.log(`  PASS  twoslash: rendered hovers for ${card}`);
+    else (console.error(`  FAIL  twoslash: no hover markup for ${card}`), (fails = 1));
+  }
   // 2. file read (the resolver code-import uses) returns code from the context.
   if (postIncludes('/api/read-file', {path: relpath}, '"code"')) console.log(`  PASS  code read: ${relpath}`);
   else (console.error(`  FAIL  code read: ${relpath}`), (fails = 1));


### PR DESCRIPTION
## What

The mion home page's drizzle hover card rendered a compiler error instead of type hovers:

```
ERROR  Twoslash rendering error:
Compiler Errors:
index.ts
  [2307] 71 - Cannot find module '@mionjs/drizzle-orm-pg-core' or its corresponding type declarations.
```

The twoslash endpoint mounted every `@mionjs/*` package at a hand-written `.dist/esm` root. The four drizzle packages emit under `.dist/esm/src` (their entry is `src/index.ts`, and their `package.json` exports already say so), so the mounted root held only a `src/` dir and the bare import resolved nothing.

## Changes

- **`container/website/server/api/twoslash.post.ts`**: the mount root is no longer written in the list. It is derived from each package's own manifest, the directory holding its `.` types entry (`exports['.'].types`, the `import.types` form `@mionjs/run-types` uses, or a top-level `types`). The synthetic package.json names that entry. A package whose manifest declares no entry, or whose dist is not built, is skipped with a warning instead of silently.
  Also removes the stale second `@mionjs/devtools` row (`distPath: 'build'` plus entry shims): `packages/devtools/build` has not existed since the two devtools packages merged, and a populated one would have overwritten the real devtools mount.
- **`packages/devtools/test/repo-contracts.test.ts`**: three new contracts. Every mounted package names a `.` types entry; a built dist holds that entry where the manifest says; every first-party subpath the examples import (`@mionjs/run-types/formats`, `@mionjs/drizzle-orm-pg-core/drizzle`, ...) sits where classic node resolution finds it under that root. Verified to fail on a manifest pointing at the wrong entry.
- **`scripts/website/site.mjs`**: `pnpm rtx website check --docs` now renders every twoslash card the site's home page embeds (the five mion cards) instead of one arbitrary example, so it catches this class of bug. The stale "fails on main" note in `pr-heavy.yml` is updated accordingly.
- Contributor note in `container/website/CLAUDE.md` updated; the spec moved to `docs/done/twoslash-drizzle-dist-mount.md`.

## Verification

- `pnpm run test:ci`: all 21 vitest projects green.
- `pnpm run lint`, `pnpm run format` / `check-format`: clean.
- `pnpm rtx website check --docs --site mion`: all five home page cards render hovers, including `home-drizzle.ts`. Re-run with the old endpoint code, the same check fails on the drizzle card only, so the fix is what makes it pass.

Note on the website image: the published `tsrt-website` image's deps stamp differs from the tree on `main`, so the scripts wanted to rebuild it locally, which the sandbox network blocks (Docker Hub). The check above ran against the pulled image relabelled with the tree's stamp under `MION_WEBSITE_USE_LOCAL=1`. The endpoint code the check exercises is bind-mounted, not baked into the image, so the image's age does not affect the result.

Out of scope, on purpose: the drizzle packages keep emitting under `.dist/esm/src`, and `pr-heavy.yml` still leaves `check --docs` out (it needs every `@mionjs/*` dist built in that lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uk7irvJrvVTBiSTsCV7bd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk7irvJrvVTBiSTsCV7bd7)_