### PR TITLE
Add security audit specs for mion RPC and RunTypes

### DIFF
--- a/docs/todos/runtypes-security-fuzzer.md
+++ b/docs/todos/runtypes-security-fuzzer.md
@@ -1,0 +1,71 @@
+---
+type: feature
+spec: guidelines
+status: ready
+created: 2026-09-03
+---
+
+# Security fuzz lanes for the RunTypes decoders
+
+## Intent
+
+The existing fuzz harness (`packages/run-types/test/fuzz/`) is thorough about correctness on
+valid input: round trips, strategy agreement, size estimates, cloning. What it does not do is act
+as an attacker. No lane feeds random or mutated bytes to the binary decoder, and the value lane's
+junk stream only checks that `validate` is total (oracle O3) while the decoders are only run on
+conforming values (oracles O5, O6, O7, O19). The spike that produced this doc found, by hand, a
+six-byte binary body that kills the process with an out-of-memory error and truncated buffers
+that decode to garbage; a fuzzer would have found both in seconds. This todo adds the lanes that
+hunt exactly that class of bug, using standard techniques: mutation of valid wires, structure
+aware generation, and resource oracles.
+
+## Direction
+
+The implementer plans the details. Constraints and pointers that were checked:
+
+- **Build on the shared core.** `core/runLoop.ts`, `core/seededRng.ts`, `core/crashGuard.ts`,
+  `core/typeGen.ts` and the compile harness in `type/typeFuzzHarness.ts` /
+  `roundtrip/roundtripHarness.ts` give seeded replay, crash capture and one compiled factory per
+  family for a random type. Follow the README's rule: real shipped types, imported, never copied.
+- **Lane 1, binary decoder bytes.** For each random serialisable type, encode a conforming value,
+  then feed the decoder (a) mutations of that wire: bit flips, byte substitution, truncation at
+  every offset, duplication, inflated varints in length and count positions, swapped union tags
+  and discriminants, and (b) pure random bytes and structured junk (varint for a huge count
+  followed by nothing). Oracles: the decoder either returns a value that `validate` accepts or
+  throws one typed decode error (never a raw `RangeError`, never `undefined` in a string slot);
+  it never reads past the buffer silently; wall time and allocation are bounded by a small multiple
+  of the input length; a valid wire still decodes after every mutated one (no shared state
+  poisoning, the string cache in `dataView.ts` is a candidate). Run each decode in a child process
+  or with a heap cap so an out-of-memory finding is a report with a seed, not a dead vitest
+  worker.
+- **Lane 2, JSON decoders and parse.** Same shape over the four decode strategies and
+  `createParseFn`: start from a valid JSON wire and mutate the parsed tree (type confusion at one
+  position, `__proto__` / `constructor` / `prototype` keys at object positions, Invalid Date
+  strings, bigint strings with junk, RegExp strings with bad flags or catastrophic patterns,
+  numbers out of range, very deep nesting, very long strings and arrays). Oracles: `parse` throws
+  only `RTParseError` (extends O19 to the mutated space); a decoder's result, when it returns, has
+  `Object.prototype` or a null prototype at every object position and no inherited enumerable
+  keys; nothing hangs past a time budget; the global `Object.prototype` is untouched after the run.
+- **Lane 3, format patterns.** Pump strings against every shipped format validator and every
+  regex literal under `packages/run-types/src/formats/`, with a time oracle, so a slow pattern is a
+  finding.
+- **Wire it in like every other lane.** A row in the `FUZZ` table in `scripts/miondevx.mjs` with
+  quick and soak budgets, a `MION_FUZZ_<LANE>_SOAK_MS` row in the `REGISTRY` in
+  `scripts/lib/env.mjs` and `.env.sample`, the CI partition in `.github/workflows/ci.yml`
+  (time-boxed lanes run sequentially on the `js tests + lint` runner; the pin is
+  `packages/devtools/test/fuzz-lane-contracts.test.ts`), and a section in
+  `packages/run-types/test/fuzz/README.md` with the new oracle ids in the catalog.
+- **Findings are fixes.** A red lane means the bug is fixed in the same PR with a seed-pinned
+  repro under `test/features/` or a `*.smoke.test.ts`, per the README's replay loop. The known
+  ones (unbounded counts, silent short reads) are expected to be fixed by the RunTypes audit; if
+  that has not landed, the first run of lane 1 will find them and this PR fixes them.
+- **Docs.** The fuzz README is the developer map and must describe the new lanes; the website
+  needs no change unless a decoder contract changes.
+
+## Done when
+
+- Three new lanes run in `pnpm test` at a fixed budget and in the quick and soak tiers.
+- Lane 1 demonstrably catches the out-of-memory and silent-truncation bugs when run against the
+  pre-fix decoder (keep that as a negative control in a unit test, like `elisionOracle.unit`).
+- A full soak round is clean, or every finding it produced is fixed and pinned.
+- The README catalog lists the new oracles.

--- a/docs/todos/security-audit-mion-rpc.md
+++ b/docs/todos/security-audit-mion-rpc.md
@@ -1,0 +1,120 @@
+---
+type: fix
+spec: guidelines
+status: ready
+created: 2026-09-03
+---
+
+# Security audit of the mion RPC framework, plus an HTTP-level fuzzer
+
+## Intent
+
+mion has never had a security pass. The request path (platform adapter, body parsing, route
+lookup, header handling, deserialization, validation, error envelope) needs to be read with an
+attacker's eyes, every probable hole fixed or defended, and the result pinned by tests so it cannot
+regress. The same task adds a small HTTP-level fuzzer that throws junk at a running router and
+checks a handful of rules that must hold for every request.
+
+The spike that produced this doc verified several concrete problems by running code, listed
+below. They are the starting point, not the whole audit.
+
+## Verified findings (fix these, then keep looking)
+
+Ranked by severity. Each was reproduced on this tree.
+
+1. **A six-byte binary body kills the server process.** The binary body framing reads an element
+   count from the wire and allocates before checking there are bytes to back it. `packages/core/src/binary/bodyDeserializer.ts:28` reads `itemsLength` as a raw uint32 and loops that many
+   times; the compiled per-route decoder (`ts-go-runtypes/internal/cachegen/typefunctions/binary_from.go:282`) does `new Array(len)` with `len` from an unbounded varint and then loops
+   `len` times. A request whose body is the varint for `2^31` followed by nothing made the vitest
+   worker die with `FATAL ERROR: invalid table size Allocation failed - JavaScript heap out of memory`. A count of `2^24` with no data returned a 16 million element array of empty strings in
+   four seconds. Any platform adapter that accepts `content-type: application/octet-stream` is
+   exposed (`packages/platform-node/src/mionHttp.ts:150`). The fix belongs on both sides: the
+   framing must bound the count by the remaining byte length, and the RunTypes decoder must do the
+   same (that half is the RunTypes audit's job, coordinate so both land).
+2. **Out-of-range reads in the binary reader are silent.** `desLength()` and `desString()` in
+   `packages/run-types/src/runtypes/dataView.ts:686-707` index a `Uint8Array` past its end and get
+   `undefined`, which the varint loop treats as zero and the string decoder as an empty slice. A
+   truncated buffer decoded to `["hello","world","a"]` instead of failing; a string whose declared
+   length exceeds the buffer decoded to the bytes that were there. Garbage in, garbage accepted.
+   Every read must fail loudly on a short buffer (shared with the RunTypes audit).
+3. **Route id lookups walk the prototype chain.** `packages/core/src/routerUtils.ts:71-77` keeps the
+   method cache in a plain object and tests membership with `in`. Ids like `constructor`,
+   `toString` or `__proto__` come back as found (`hasMetadata('constructor')` is `true`), and
+   `getMethodJitFns` then throws a generic `Jit function isType not found for jitHash undefined`
+   instead of reporting an unknown route. Binary bodies name their routes on the wire
+   (`bodyDeserializer.ts:35`), so this is reachable. Use a `Map` or a null-prototype object and
+   `hasOwnProperty` semantics everywhere a wire string indexes a table (also
+   `packages/router/src/lib/headers.ts:27-49`, which does the same with the header record).
+4. **Deserialize runs before validate, on raw input.** `packages/router/src/dispatch.ts:120-146`
+   calls `restoreFromJson` first and `isType` after. The restore step runs type transforms on
+   untrusted values (`new RegExp(src, flags)`, `BigInt(v)`, `Temporal.X.from(v)`), so bad input
+   throws a raw JS error that is mapped to a `serialization-error` with the engine's message copied
+   into `errorData.deserializeError`. Decide the contract (a typed 4xx with no engine text) and pin
+   it. Also decide the policy for `RegExp` in route parameters: a client can send any pattern and
+   validation accepts it, so a handler that runs it on a string is open to catastrophic
+   backtracking. A build-time warning for `RegExp` in a route's params type is probably the right
+   defence.
+5. **Engine error text reaches the client.** `bodyDeserializer.ts:55`, `dispatch.ts:199` and
+   `packages/router/src/routes/serializer.routes.ts:40` copy `err.message` into `publicMessage` or
+   `errorData`. Stack traces do not leak (checked: `stack` stays non-enumerable and `JSON.stringify`
+   of an `RpcError` carries only the public fields), but messages like
+   `Offset is outside the bounds of the DataView` are still internal detail. Replace with fixed
+   public strings and keep the original on `originalError` for server logs.
+6. **Body size limits are uneven.** node and uws enforce `maxBodySize` (256 KB default). bun passes
+   it to the runtime but its own test marks the limit as not working (`packages/platform-bun/src/bunHttp.test.ts:117`). cloudflare, aws, gcloud and vercel have no limit at all and rely on
+   the platform. Decide and document the contract per adapter; add a router-level guard on
+   `rawBody` length so no adapter can forget it.
+7. **No depth or recursion limit anywhere.** `JSON.parse` of a deeply nested valid document plus
+   a recursive route type makes the compiled validator recurse to a stack overflow, which the router
+   reports as an unknown 422 error. Not a crash, but worth a documented bound.
+
+## Direction
+
+The implementer plans the details. Constraints and pointers that were checked:
+
+- **Read the whole request path once, end to end,** for each adapter: body read → `queryBody.ts`
+  → `serializer.routes.ts` (`deserializeRequestBody`) → `dispatch.ts` → handler → response
+  serialization → `dispatchError.ts`. Note every place a wire string indexes an object, every
+  `JSON.parse`, every `for...in` over parsed data, every spread of parsed data onto an existing
+  object, and every message copied into a response.
+- **Already guarded, keep it that way:** the routesFlow query is shape-checked at one trust boundary
+  (`packages/router/src/routesFlow.ts:71-127`), server mappers are allow-listed
+  (`packages/core/src/runtypes/serverMappers.ts:43-70`), error envelopes drop `message`, `name`
+  and `stack`, and the route table itself is a `Map` (`packages/router/src/router.ts:59-65`).
+- **The client materializes server-sent code** with `new Function`
+  (`packages/core/src/runtypes/mionAdapter.ts:122`, restored from localStorage in
+  `packages/client/src/lib/clientMethodsMetadata.ts:96-140`). That is the design (the server is the
+  trusted party), but an unsigned code cache in localStorage is a persistence vector after any
+  cross-site scripting bug. Record the threat model in the docs and consider an integrity check
+  keyed on the server's build id.
+- **The metadata route** (`packages/router/src/routes/client.routes.ts`) answers any list of ids.
+  Confirm `isPrivateExecutable` hides everything that should be hidden and that the
+  `getAllRemoteMethodsMaxNumber` cap holds.
+- **Other areas to cover** even without a finding yet: header count and size, the `x-rpc-error`
+  response header value, `content-length` handling on each adapter, behaviour on a body that is
+  valid JSON but not an object or array, and the binary response path with a handler return value
+  that does not match its declared type.
+- **The HTTP fuzzer.** Add a lane under the router or test-server package that starts the router
+  in process (or `packages/test-server`), sends generated requests (random paths including
+  prototype names, JSON bodies mutated from valid ones, binary bodies with flipped bits, inflated
+  lengths and counts, truncation, random headers) and checks rules that hold for every request: the
+  process stays alive, every response is a well-formed envelope, malformed input never yields a
+  5xx, no response body contains engine error text or a file path, and each request finishes inside
+  a time budget. Reuse the seeded loop and crash guard from
+  `packages/run-types/test/fuzz/core/` so findings replay by seed. Register the lane in the `FUZZ`
+  table in `scripts/miondevx.mjs`, the env registry, the CI partition pinned by
+  `packages/devtools/test/fuzz-lane-contracts.test.ts`, and the fuzz README.
+- **Docs.** The website gets one page under `container/website/content/01.rpc/02.server/` that
+  states the security contract in plain words: what the router validates, what limits apply per
+  adapter, what an error envelope can contain, and what is the app's own responsibility (auth,
+  CORS, rate limiting). Follow the writing rules in `container/website/CLAUDE.md`.
+
+## Done when
+
+- Every verified finding above is fixed with its own test (a crafted request per finding), and
+  the binary count fix is proven on both the framing and the RunTypes decoder.
+- The audit produced a short written list of what was reviewed and the verdict per area; every
+  new finding is fixed in the same PR or delegated to a parallel session.
+- The HTTP fuzzer lane runs in `pnpm test` at a fixed budget, is enrolled in the quick and soak
+  tiers, and its first soak is clean.
+- The website documents the security contract per adapter.

--- a/docs/todos/security-audit-runtypes-generated-code.md
+++ b/docs/todos/security-audit-runtypes-generated-code.md
@@ -1,0 +1,110 @@
+---
+type: fix
+spec: guidelines
+status: ready
+created: 2026-09-03
+---
+
+# Security audit of RunTypes, including the generated code
+
+## Intent
+
+RunTypes turns types into JavaScript at build time: validators, JSON encoders and decoders,
+binary encoders and decoders, cloners, parsers and mock generators. The decoders are the delicate
+part. They take attacker-controlled input and run type transforms on it (`new Date(v)`,
+`BigInt(v)`, `new RegExp(src, flags)`, `Temporal.X.from(v)`, `JSON.parse(s)` for `any`), and the
+binary decoder parses an ArrayBuffer by hand with no JSON in between. The audit has two halves:
+read the emitters and runtime helpers, and read a corpus of the code they generate, because the
+hole can be in the template rather than in any hand-written file.
+
+The spike that produced this doc verified the problems listed below by running code.
+
+## Verified findings
+
+1. **Unbounded counts and lengths in the binary decoder.** `desLength()` in
+   `packages/run-types/src/runtypes/dataView.ts:686` accepts any varint width and returns values
+   past 2^32. The array arm of the emitter (`ts-go-runtypes/internal/cachegen/typefunctions/binary_from.go:282-285`) does `new Array(len)` and loops `len` times; the index-signature and
+   tuple-rest arms (`:326-333`, `:535-536`, `:585-608`) loop the same way. A `string[]` decoder
+   given the varint for 2^31 and no further bytes killed the process with
+   `FATAL ERROR: invalid table size Allocation failed - JavaScript heap out of memory`; 2^24 made a
+   16 million element array of empty strings in four seconds. Every count must be checked against
+   the bytes left in the buffer before allocating or looping (an element needs at least one byte).
+2. **Out-of-range reads are silent.** `desLength()` and `desString()` (`dataView.ts:686-707`) read
+   through a `Uint8Array`, which returns `undefined` past the end. The varint loop treats that as
+   zero and `subarray` clamps, so a truncated buffer decoded `["hello","world","a"]` and a string
+   declaring more bytes than exist decoded to the bytes present. Reads that go through the
+   `DataView` (`desFloat64`, `desByte`, `desU16`, `desI32`) do throw a `RangeError`, so today the
+   failure mode depends on the element type. Make every read throw one typed decode error on a
+   short buffer, and consider `new TextDecoder('utf-8', {fatal: true})` (`dataView.ts:76`) so
+   invalid UTF-8 is rejected rather than replaced.
+3. **Type transforms throw raw engine errors on bad input.** Checked on the JSON decoder:
+   `BigInt('12x')` throws `SyntaxError`, `BigInt(1.5)` throws `RangeError`, a RegExp with flags
+   `zz` throws `SyntaxError`, a RegExp arm given a number throws `TypeError: v.r.match is not a function` (`json_restore.go:114`), and the binary RegExp arm (`binary_from.go:134`) behaves the
+   same. `new Date('garbage')` does not throw but yields an Invalid Date that the decoder returns
+   as-is (`json_restore.go:126`); `createValidateFn` does reject it afterwards. Decide the
+   decoder contract per family (decoders assume validated input, or decoders reject) and make the
+   generated code honour it uniformly; `createParseFn` already promises an `RTParseError` and
+   nothing else (oracle O19 in `packages/run-types/test/fuzz/value/fuzzOracle.ts:370`).
+4. **A decoded RegExp is attacker-chosen.** A `RegExp` property on a decoded type accepts any
+   pattern, including ones that backtrack catastrophically (`/(a+)+$/` decoded fine on both
+   roads). The sidecar's 250 ms match budget (`packages/go-be-sidecar/src/jobs.ts:113`) only
+   guards format patterns at build time. Decide whether wire RegExps should be limited (length,
+   flags, a lint or build warning on the type) and document it.
+5. **Prototype-named keys.** The binary decoder guards index-signature keys with
+   `desSafePropName()` (`dataView.ts:708-717`, rejects `__proto__`, `prototype`, `constructor`).
+   The JSON decoders do not: the in-place restore loop (`json_restore.go:291`) walks `for (const k in v)` over the parsed object, and the compact decoder and the clone encoder rebuild objects
+   with `const _r = {}` and `_r[k] = …` (`json_compact_restore.go:235`,
+   `json_prepare_safe.go:810`). Writing `__proto__` on a fresh `{}` swaps its prototype and the
+   key vanishes from `Object.keys`, so `{"__proto__": {"admin": true}}` can produce an object
+   whose `admin` is inherited. Audit every rebuild site; null-prototype objects or an own-key guard
+   fix it.
+
+## Direction
+
+The implementer plans the details. Constraints and pointers that were checked:
+
+- **Emitter map.** Everything lives in `ts-go-runtypes/internal/cachegen/typefunctions/`:
+  `validate.go`, `json_prepare.go` / `json_prepare_safe.go` (encoders), `json_restore.go` and
+  `json_compact_restore.go` (decoders), `json_composite.go` (the wrapper that calls
+  `JSON.parse`), `binary_to.go` / `binary_from.go`, `clone_exact_shape.go`, `parse.go`,
+  `class_serializer.go` (which does `JSON.parse(desString())` then `deserializeClass`), and
+  `quote.go` (all string literals in emitted code go through `internal/jsquote`). Read
+  `ts-go-runtypes/CLAUDE.md` first; `third_party/` is off limits.
+- **Inspect the generated code, not only the templates.** Build a corpus: the random type
+  generator in `packages/run-types/test/fuzz/core/typeGen.ts` plus a hand-written set of nasty
+  types (property names with quotes, backslashes, newlines and unicode; literal types with the
+  same; enum members; template literal types; format patterns; `rt$errors` templates from a
+  FriendlyText mirror; index signatures with key patterns). Emit every family for every type,
+  then scan the emitted JavaScript with a checklist: every literal quoted through the one helper,
+  no raw `%s` of type-derived text (`module.go:1056` and `walker.go:598` were the only raw
+  `Sprintf` sites found, both non-attacker), no object rebuild that writes wire keys onto a plain
+  `{}`, every count checked before allocation, every `new Function` fed only build-time code.
+  Turn the checklist into a test that runs over the corpus so the audit repeats on every change.
+- **Build-time trust.** Generated code is materialized with `new Function`
+  (`packages/run-types/src/runtypes/rtUtils.ts:298-310`). Its inputs are the emitter output and
+  the disk cache under `node_modules/.cache/mion`. Confirm the cache is keyed by content and that
+  a tampered cache file cannot be executed without the resolver regenerating it; same for the
+  enrichment mirror files under the gen dir, which are user-editable and flow into messages.
+- **Validate is the one total function today.** Oracle O3 (`validate(anything)` returns a
+  boolean, never throws) is already fuzzed. It has no depth bound: a deeply nested input on a
+  recursive type overflows the stack. Decide whether a bound belongs in the validator.
+- **Shipped format regexes.** Only seven literal patterns live under
+  `packages/run-types/src/formats/` (`string-formats-pure-fns.ts:350-531` and siblings); the rest
+  are matched by hand-written code. Check each literal for catastrophic backtracking with a pump
+  string and pin the result.
+- **`any` / `unknown` / `object` arms** pass the parsed value straight through on the JSON road and
+  `JSON.parse` a wire string on the binary road (`binary_from.go:81`). Note it in the contract; a
+  consumer must know these fields are unvalidated.
+- **Docs.** One page in `container/website/content/02.runtypes/` states the decoder contract in
+  plain words: what a decoder checks, what it never checks, what it throws, and that `parse` is
+  the safe entry point for untrusted input. Follow `container/website/CLAUDE.md`.
+
+## Done when
+
+- Findings 1, 2 and 5 are fixed and each pinned by a test with the crafted input.
+- Findings 3 and 4 have a decided, documented contract and the generated code follows it, with a
+  test per family.
+- The generated-code corpus scan exists as a test and is clean.
+- The website documents the decoder contract.
+- Every extra finding surfaced by the audit is fixed in the same PR or delegated to a parallel
+  session.


### PR DESCRIPTION
Adds three new security audit specification documents that define the scope, verified findings, and completion criteria for hardening the mion RPC framework and RunTypes decoder.

## Summary

These specs document a comprehensive security review effort split across two main areas:

1. **mion RPC framework audit** (`security-audit-mion-rpc.md`) - covers the full request path from platform adapter through routing, deserialization, validation, and error handling, plus an HTTP-level fuzzer to prevent regression.

2. **RunTypes decoder audit** (`security-audit-runtypes-generated-code.md`) - focuses on the code generation templates and runtime helpers that turn types into validators and decoders, which handle untrusted input.

3. **RunTypes security fuzz lanes** (`runtypes-security-fuzzer.md`) - defines three new fuzzing lanes to hunt decoder bugs via mutation, structure-aware generation, and resource oracles.

## Verified findings to fix

**mion RPC:**
- Six-byte binary body causes out-of-memory crash (unbounded array allocation)
- Out-of-range reads in binary framing are silent (return undefined instead of failing)
- Prototype chain pollution via route ID lookups (constructor, __proto__, toString)
- Deserialization runs before validation on raw input
- Engine error text leaks into client responses
- Body size limits are inconsistent across platform adapters
- No depth or recursion limit on nested structures

**RunTypes:**
- Unbounded counts and lengths in binary decoder (same OOM vector)
- Out-of-range reads are silent (varint loop treats undefined as zero)
- Type transforms throw raw engine errors (BigInt, RegExp, Date)
- Decoded RegExp patterns can cause catastrophic backtracking
- Prototype-named keys bypass validation in JSON decoders

## Completion criteria

Each spec defines "done when" sections that require:
- All verified findings fixed with dedicated tests
- Audit checklist completed with written verdict per area
- New fuzzer lanes integrated into test suite and CI
- Website documentation of security contracts per adapter/decoder

https://claude.ai/code/session_01MfrUkQxJfa4murtrckSSm8