### PR TITLE
Update references from bin/ to mion-bin/ after rename

### DIFF
--- a/.github/workflows/drizzle-e2e.yml
+++ b/.github/workflows/drizzle-e2e.yml
@@ -80,7 +80,7 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/free-disk
       - uses: ./.github/actions/bootstrap
-      # bin/mion FIRST: the @mionjs/* vite builds run the devtools plugin,
+      # mion-bin/mion FIRST: the @mionjs/* vite builds run the devtools plugin,
       # which spawns it. Without this the dist build dies on @mionjs/core.
       - name: Build the resolver + dists
         run: pnpm run check:builds

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/bootstrap
-      # The command spawns bin/mion and the vitest project reads both
+      # The command spawns mion-bin/mion and the vitest project reads both
       # dists; a build failure should read as a build failure, not a conversion one.
       - name: Build the resolver + dists
         run: pnpm run check:builds

--- a/packages/devtools/test/eslint/plugin.test.ts
+++ b/packages/devtools/test/eslint/plugin.test.ts
@@ -1,5 +1,5 @@
 // Integration suite for the lint plugin: real fixture projects on disk, the
-// real bin/mion behind the session bridge, and the rules driven the
+// real mion-bin/mion behind the session bridge, and the rules driven the
 // way a lint host drives them (create → Program visitor → reports).
 //
 // Marker coverage rule (CLAUDE.md): the Family A fixtures cover BOTH
@@ -225,7 +225,7 @@ function locate(text: string, needle: string): {line: number; column: number} {
 }
 
 describe.runIf(hasBinary())(
-  'lint plugin (integration through bin/mion)',
+  'lint plugin (integration through mion-bin/mion)',
   () => {
     let project: FixtureProject;
     let settings: Record<string, unknown>;
@@ -251,7 +251,7 @@ describe.runIf(hasBinary())(
       // configurable), exactly like a real editor/CI run from the project
       // root — so drive this in-process suite from the fixture dir. Restored
       // in afterAll. No binary setting: getExePath() resolves the built
-      // bin/mion in this repo, the same path the old `binary` pointed at.
+      // mion-bin/mion in this repo, the same path the old `binary` pointed at.
       originalCwd = process.cwd();
       process.chdir(project.dir);
       settings = {};

--- a/packages/devtools/test/eslint/tsconfig-resolution.test.ts
+++ b/packages/devtools/test/eslint/tsconfig-resolution.test.ts
@@ -6,7 +6,7 @@
 //
 // Two layers: a pure unit check that buildResolverArgs now forwards --tsconfig
 // in server mode (the exact guard that caused the bug), and an integration run
-// of the real rules through bin/mion over an on-disk monorepo whose only
+// of the real rules through mion-bin/mion over an on-disk monorepo whose only
 // resolvable cross-package entry is behind `source`.
 //
 // Marker coverage rule (CLAUDE.md): the consumer fixture uses BOTH getRunTypeId
@@ -80,7 +80,7 @@ const TSCONFIG_NO_CONDITIONS = JSON.stringify({
   },
 });
 
-describe.runIf(hasBinary())('eslint tsconfig resolution (integration through bin/mion)', () => {
+describe.runIf(hasBinary())('eslint tsconfig resolution (integration through mion-bin/mion)', () => {
   let project: FixtureProject;
   let consumerAbs: string;
   let originalCwd: string;


### PR DESCRIPTION
Updates documentation, comments, and gitignore rules to reflect the rename of the Go binary output directory from `bin/` to `mion-bin/`, and the uws cache from `packages/uws/.uws-cache/` to `packages/bin-uws/.uws-cache/`.

**Key changes:**

- **gitignore**: Added entries for pre-rename legacy directories (`/bin/` and `packages/uws/.uws-cache/`) with explanatory comments noting these should be removed once no working tree predates the rename
- **clean script**: Added a new "legacy layout" cleanup group to remove old output directories that are no longer written to or read from
- **test comments**: Updated references in eslint plugin tests and tsconfig resolution tests from `bin/mion` to `mion-bin/mion`
- **workflow comments**: Updated GitHub Actions workflow comments in drizzle-e2e and release-gate to reference `mion-bin/mion` instead of `bin/mion`

These changes ensure the repository handles both pre-rename and post-rename working trees gracefully during the transition period, while keeping documentation and comments accurate.

https://claude.ai/code/session_01NqUfGB7KqXN3ssWhV1x4Xc