### PR TITLE
Add match() API spec and client call outcome design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Cross-package deps use the `workspace:*` protocol. All devDependencies live root
 The mion framework packages (`@mionjs/*`):
 
 - [core](packages/core/) — shared framework foundation (`RpcError`/`TypedError`, router metadata, binary body framing, the mion↔mion reflection adapter under `src/runtypes/`).
-- [router](packages/router/) — HTTP routing and request handling. [client](packages/client/) — client-side utilities.
+- [router](packages/router/) — HTTP routing and request handling. [client](packages/client/) — client-side utilities; read [its CLAUDE.md](packages/client/CLAUDE.md) before touching the call result tuple.
 - [devtools](packages/devtools/) (`@mionjs/devtools`) — Vite plugin (wraps `@mionjs/devtools`) + ESLint plugin.
 - [drizzle-orm](packages/drizzle-orm/) (`@mionjs/drizzle-orm`) — the dialect-agnostic slim recorder core (column/table/entry/sql recorders, flat Infer* models, refineTableType); never imports drizzle.
 - [drizzle-orm-pg-core](packages/drizzle-orm-pg-core/) / [-mysql-core](packages/drizzle-orm-mysql-core/) / [-sqlite-core](packages/drizzle-orm-sqlite-core/) — the per-dialect authoring surfaces: drizzle-identical builders/helpers that RECORD calls, with `toDrizzle` on the `./drizzle` subpath as the one drizzle-importing module (drizzle-orm is an optional peer). All four ride the drizzle version line instead of the lockstep train (the `versionLine` package.json marker) and republish only when their own published sources changed ([scripts/lib/drizzle-line.mjs](scripts/lib/drizzle-line.mjs)). Generator config: [drizzle-dialects.json](drizzle-dialects.json); the same run emits the import map `mion drizzle-migrate` rewrites with.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Cross-package deps use the `workspace:*` protocol. All devDependencies live root
 The mion framework packages (`@mionjs/*`):
 
 - [core](packages/core/) — shared framework foundation (`RpcError`/`TypedError`, router metadata, binary body framing, the mion↔mion reflection adapter under `src/runtypes/`).
-- [router](packages/router/) — HTTP routing and request handling. [client](packages/client/) — client-side utilities; read [its CLAUDE.md](packages/client/CLAUDE.md) before touching the call result tuple.
+- [router](packages/router/) — HTTP routing and request handling. [client](packages/client/) — client-side utilities.
 - [devtools](packages/devtools/) (`@mionjs/devtools`) — Vite plugin (wraps `@mionjs/devtools`) + ESLint plugin.
 - [drizzle-orm](packages/drizzle-orm/) (`@mionjs/drizzle-orm`) — the dialect-agnostic slim recorder core (column/table/entry/sql recorders, flat Infer* models, refineTableType); never imports drizzle.
 - [drizzle-orm-pg-core](packages/drizzle-orm-pg-core/) / [-mysql-core](packages/drizzle-orm-mysql-core/) / [-sqlite-core](packages/drizzle-orm-sqlite-core/) — the per-dialect authoring surfaces: drizzle-identical builders/helpers that RECORD calls, with `toDrizzle` on the `./drizzle` subpath as the one drizzle-importing module (drizzle-orm is an optional peer). All four ride the drizzle version line instead of the lockstep train (the `versionLine` package.json marker) and republish only when their own published sources changed ([scripts/lib/drizzle-line.mjs](scripts/lib/drizzle-line.mjs)). Generator config: [drizzle-dialects.json](drizzle-dialects.json); the same run emits the import map `mion drizzle-migrate` rewrites with.

--- a/docs/todos/client-call-outcome-and-match.md
+++ b/docs/todos/client-call-outcome-and-match.md
@@ -1,0 +1,81 @@
+---
+type: feature
+spec: guidelines
+status: ready
+created: 2026-09-06
+---
+
+# Client call() returns a matchable outcome, callRaw() keeps the tuple
+
+## Intent
+
+Make error handling in `@mionjs/client` one obvious thing. Today `call()` returns a 5-tuple
+and every call site rewrites the same if / switch ladder over slots. The new default is the
+union the route handler itself returns, plus the undeclared error, matched with the runtypes
+`match()` family (its own todo; this one needs it first):
+
+```ts
+// server: (ctx, id: string): User | RpcError<'user-not-found', NotFoundData>
+const outcome = await routes.users.getById(id).call();
+// outcome: User | RpcError<'user-not-found', NotFoundData> | ValidationError | UndeclaredError
+
+match(outcome)
+  .when<User>(user => setUser(user))
+  .catchTyped('user-not-found', e => setMissing(e.errorData.requestedId))
+  .otherwise(e => setError(e.publicMessage));
+```
+
+Server and client see the same union. The lazy path stays one line:
+`if (isRpcError(outcome)) ...` narrows the rest to the value.
+
+`callRaw()` keeps the CURRENT 5-tuple, unchanged: `[result, error, undeclared,
+middleFnResults, middleFnErrors]`. The order is deliberate and documented in
+`packages/client/CLAUDE.md`; it stays the escape hatch for a call site that needs every
+outcome at once, middleware function slots included.
+
+## Direction
+
+The implementer plans the details. Decided shape and rules:
+
+- `call()` resolves to the outcome union. A middleware function's DECLARED fatal error (it
+  stopped the route) is part of that union, typed, since the middleware functions are known
+  at the call. A middleware error that did NOT stop the route is not in the outcome: the
+  value is, and the middleware's own `onError` / `onSuccess` listeners (prefill or per sub
+  request) carry its outcome. `callRaw()` still exposes it in slot 4.
+- The dispatch rules pinned by `packages/client/src/errorDispatch.spec.ts` keep holding for
+  `callRaw()`; the outcome union is derived from the same dispatch, not a second one.
+- `batch([...]).call()` resolves to ONE outcome per route, in order, each with the same union
+  its single call would have. A request-level failure (timeout, abort, network) fills every
+  slot with the same undeclared error; a middleware function stopping the batch fills every
+  slot with its typed error; a dependent route whose source failed already receives
+  `batch-mapping-source-failed` from the router (`packages/router/src/batches.ts`), undeclared.
+  `batch(...).callRaw()` keeps today's `BatchResult` 5-tuple.
+- `matchAll(outcomes)` for the "all or nothing" reading: pure TypeScript, collapses to the
+  first error in route order or the tuple of values, then hands that to the normal matcher
+  (`when<[Order, User]>` is the success branch). Its `catch` callback receives the slot index,
+  typed to the slots that declare that tag (the `catchTyped` branch), because two routes can declare the same tag or
+  both fail validation. Two errors at once is the per-slot match or the raw tuple.
+- The client's own lint rule, the reason the match union is built from its branches: the
+  union a `match` over a call outcome forms with its `when` / `catch` / `catchTyped` branches
+  must EQUAL the union the route declares (value, declared errors, `ValidationError`), with
+  `otherwise` standing in for the undeclared error. A missing branch or a branch the route
+  never returns is a lint error naming the member. This rule is the whole exhaustiveness
+  story for the client: `match` itself takes any value and cannot check its branches
+  against the outcome, by design (its union is built from the branches, so it can be read
+  back and compared here). The compiler already resolves route ids and handler types for the
+  batch diagnostics (`BAT001`-style codes routed to lint), follow that road. Plus the silence
+  case: an awaited `.call()` must be matched, narrowed with `isRpcError`, or explicitly
+  ignored with `void`.
+- Types: `Result` / `BatchResult` in `packages/client/src/types.ts` stay for `callRaw()`; the
+  outcome types are new. Every client example under `packages/examples/src/client/` and the
+  client error-handling and batch pages under `container/website/content/01.rpc/03.client/`
+  move to `call()` + `match`, with `callRaw()` shown once as the escape hatch.
+
+## Done when
+
+- `call()` and `batch().call()` return outcomes; `callRaw()` variants return the unchanged
+  tuples; the dispatch contract suite passes against both.
+- `matchAll` exists with the slot-typed `catch`.
+- The client lint rule exists: match branches vs route contract, and the silence case.
+- Examples and the website pages use the new default; `packages/client/CLAUDE.md` names
+  `callRaw()` as the tuple's home.

--- a/docs/todos/client-call-outcome-and-match.md
+++ b/docs/todos/client-call-outcome-and-match.md
@@ -55,17 +55,14 @@ The implementer plans the details. Decided shape and rules:
   (`when<[Order, User]>` is the success branch). Its `catch` callback receives the slot index,
   typed to the slots that declare that tag (the `catchTyped` branch), because two routes can declare the same tag or
   both fail validation. Two errors at once is the per-slot match or the raw tuple.
-- The client's own lint rule, the reason the match union is built from its branches: the
-  union a `match` over a call outcome forms with its `when` / `catch` / `catchTyped` branches
-  must EQUAL the union the route declares (value, declared errors, `ValidationError`), with
-  `otherwise` standing in for the undeclared error. A missing branch or a branch the route
-  never returns is a lint error naming the member. This rule is the whole exhaustiveness
-  story for the client: `match` itself takes any value and cannot check its branches
-  against the outcome, by design (its union is built from the branches, so it can be read
-  back and compared here). The compiler already resolves route ids and handler types for the
-  batch diagnostics (`BAT001`-style codes routed to lint), follow that road. Plus the silence
-  case: an awaited `.call()` must be matched, narrowed with `isRpcError`, or explicitly
-  ignored with `void`.
+- TypeScript already does most of the checking: `match` reads the union from the outcome,
+  so a branch the route never returns is a compile error, and `otherwise` is always required
+  because the undeclared error can never be a branch. The client's own lint rule adds the
+  strictness a type cannot express: every DECLARED error of the route gets its own branch
+  rather than falling into `otherwise` (a lint error naming the member), and the silence
+  case, an awaited `.call()` must be matched, narrowed with `isRpcError`, or explicitly
+  ignored with `void`. The compiler already resolves route ids and handler types for the
+  batch diagnostics (`BAT001`-style codes routed to lint), follow that road.
 - Types: `Result` / `BatchResult` in `packages/client/src/types.ts` stay for `callRaw()`; the
   outcome types are new. Every client example under `packages/examples/src/client/` and the
   client error-handling and batch pages under `container/website/content/01.rpc/03.client/`
@@ -76,6 +73,6 @@ The implementer plans the details. Decided shape and rules:
 - `call()` and `batch().call()` return outcomes; `callRaw()` variants return the unchanged
   tuples; the dispatch contract suite passes against both.
 - `matchAll` exists with the slot-typed `catch`.
-- The client lint rule exists: match branches vs route contract, and the silence case.
+- The client lint rule exists: a branch per declared error, and the silence case.
 - Examples and the website pages use the new default; `packages/client/CLAUDE.md` names
   `callRaw()` as the tuple's home.

--- a/docs/todos/runtypes-match-on-union-member.md
+++ b/docs/todos/runtypes-match-on-union-member.md
@@ -19,21 +19,23 @@ and its declared errors (a separate todo).
 The shape agreed on:
 
 ```ts
-match(outcome)
+match(outcome)                                       // outcome: User | NotFound | ValidationError | UndeclaredError
   .when<User>(user => ...)                             // a VALUE member, by type: generated member check
   .catch<RangeError>(e => ...)                         // an ERROR member, by class: E extends Error
   .catchTyped('user-not-found', e => e.errorData.id)   // a TAGGED error, by tag: pure TS narrowing
-  .otherwise(v => ...);                                // the fallback, v: unknown
-// or .exhaustive(): no fallback, a value no branch matches throws
-// the chain returns the branch's return value
+  .otherwise(e => ...);                                // e: exactly what no branch claimed
+// or .exhaustive(), which only compiles when nothing is left; the chain returns the branch's return value
 ```
 
-- THE UNION IS FORMED BY THE BRANCHES, never read from the matched value's static type.
-  `match(value)` accepts `unknown`; the union the generated check decides over is
-  `A | B | C`, the types named by the chain's `when<A>` / `catch<B>` / `catchTyped` branches.
-  That is what keeps the feature generic: it works on any value, and it is what lets a
-  separate rule compare the union a call site built against the union something else
-  declared (the mion client's route contract, in its own todo).
+- The runtime is the TC39 pattern matching proposal's (`match (subject) { when pattern: …
+  default: … }`): any subject, first pattern wins, no match without a fallback throws. Static
+  typing sits one level up, the way it does everywhere in TypeScript: `match<U>(value: U)`
+  knows `U`, so a `when<T>` where `T` is not a member of `U` is a compile error (it could
+  never match), each branch removes its member from what is left, `otherwise` receives
+  exactly the remainder, and `exhaustive()` compiles only when the remainder is `never`
+  (a type error naming the unhandled member otherwise). On an `unknown` subject the
+  constraint is vacuous and the chain behaves as the bare proposal, so nothing about the
+  rules changes with the input type.
 - `when<T>` is a marker. It injects T's typeId like `getRunTypeId<T>()` does; the matcher
   compares it against the member typeIds the generated entry carries. Members are matched
   EXACTLY (a `when<Admin>` next to a `when<User>` is an error, never a structural hit).
@@ -43,43 +45,27 @@ match(outcome)
 - `catchTyped<E>(tag, cb)` needs no generated code and no mion import. It binds structurally
   to `Error & {type: string}`: any error carrying a `type` literal qualifies, `TypedError` and
   `RpcError` from `@mionjs/core` included (core depends on run-types, never the reverse, so
-  run-types must not name them). The runtime check is one property read. Typing: `E` is the
-  branch's contribution to the union; when the matched value DOES have a static union type,
-  the tag alone narrows it (`Extract<U, {type: Tag}>`) and the payload (`errorData` for an
-  RpcError) is inferred, so `E` is rarely spelled out. A second callback argument carries
-  the source (`'route' | middleFnName`, or the batch slot) when the same tag can come from
-  several places. The client todo relies on that inference, since call outcomes are typed.
-- `otherwise(v => ...)` receives whatever no branch claimed, typed `unknown`. `exhaustive()`
-  closes the chain without a fallback: a value no branch matches throws. The chain returns
-  the branch's return value, so state or JSX can come straight out of it.
+  run-types must not name them). The runtime check is one property read. The tag alone
+  narrows the subject's union (`Extract<U, {type: Tag}>`), so the payload (`errorData` for
+  an RpcError) is inferred and `E` is only spelled out on an `unknown` subject. A second
+  callback argument carries the source (`'route' | middleFnName`, or the batch slot) when
+  the same tag can come from several places.
+- The chain returns the branch's return value, so state or JSX can come straight out of it.
 - First hit wins, exactly one branch runs, async branches pass their promise through
   untouched (all sync or all async).
 
-## Why the union comes from the branches, and why the name is `match`
+## Why the union comes from the input
 
-Two designs were weighed. They share the runtime and differ in where the union comes from.
-
-**A, the one to build: union from the branches.** `match(value)` takes `unknown`; the
-chain's `when` / `catch` / `catchTyped` types ARE the union. TypeScript can read that union
-back from the chain (a `MatchUnion<typeof matcher>` helper over the accumulated branch
-types), which is what an outside rule needs to compare it with a contract. TypeScript
-cannot, on its own, say a branch is wrong or missing, because there is no input type to
-check against; `exhaustive()` means "no match throws". The resolver has to read the whole
-chain as one site to synthesize the union for the generated check.
-
-**B, not built now: union from the input.** `typeMatch(outcome)` reads the union from the
-value's static type, `when<T>` requires `T` to be a member, `otherwise` receives exactly
-what is left and `exhaustive()` compiles only when that is `never`. Cheap to build (the
-union is a real checker type, one marker on the input) and exhaustive for free, but unusable
-on an `unknown` subject.
-
-A is the shape of the TC39 pattern matching proposal (`match (subject) { when pattern: …
-default: … }`: any subject, patterns independent of it, no exhaustiveness, no match without
-`default` throws), so A keeps the name `match`. B is a typed restriction of A, one extra
-constraint `T extends U` when the input has a static type. If it is ever wanted, it ships
-under its own name (`typeMatch`), never as a behaviour of `match` that changes with the
-input type: one function whose rules depend on the input is exactly what users should not
-have to remember.
+The alternative weighed was a `match` that ignores the subject's type and builds its union
+from the branches alone, so that some outside rule could read that union back and compare
+it with a contract. Dropped: TypeScript already knows the subject's type, and static typing
+discarding a branch that can never happen is the normal division of labour between the
+type level and the proposal's runtime, not a departure from it. Reading the union from the
+input also keeps the build trivial (the union is a real checker type, one marker on the
+subject) and gives exhaustiveness for free. The one thing an outside rule still adds is
+strictness a type cannot express, such as "every declared error gets its own branch rather
+than falling into `otherwise`"; that is a consumer's rule (the mion client's, in its own
+todo), not part of `match`.
 
 ## Direction
 
@@ -94,24 +80,25 @@ The implementer plans the details. Pointers verified at the time of writing:
   `cachegen/operations/operations.go`, a `createX` factory in
   `packages/run-types/src/createRTFunctions.ts`, emitting `(value) => memberIndex | -1` and
   the ordered member typeIds. Discriminator read when one exists, validate fallback otherwise.
-- Because the union comes from the branches, the resolver must read the whole chain
-  (`match(...).when<A>(...).catch<B>(...).otherwise(...)`) as ONE site and synthesize
-  `A | B | ...` as the type the entry is generated for. Which call carries the injected id
-  (the opening `match`, the closing `otherwise` / `exhaustive`, or every branch) is the
-  implementer's call; the safe-order and discriminator passes need the union node either way.
+- The entry is generated for the subject's static union `U`, the marker sits on `match`
+  itself, and each `when<T>` / `catch<E>` injects its own typeId, which the runtime maps to
+  a member index of that entry. Member typeIds are canonical hashes of the type, so
+  `when<User>` and the `User` member of `U` share one id without the resolver relating the
+  two calls. An `unknown` subject has no union to generate for; there each branch falls back
+  to its own validate entry, run in written order.
 - Chained method markers already work: the scanner reads the resolved call signature
   (`ts-go-runtypes/internal/compiler/resolver/scan.go`, `Checker_getResolvedSignature`) and
   `mion.route()` is itself a method marker (`packages/router/src/types/mionRouter.ts`). So
   `.when<T>()` needs no resolver change, but a `when` in ARGUMENT position of another call
   needs its paired test (Marker test coverage rule, both `getRunTypeId` shapes).
-- Safety comes from the compiler and the linter, not from TypeScript (see the A / B note
-  above). Build Errors, all "throws at runtime" cases: a chain never closed, two branches
+- Three layers, each catching what the one below cannot. TypeScript: the member constraint
+  on `when<T>`, the shrinking remainder, the typed `exhaustive()`. The compiler, as build
+  Errors since every one is a "throws at runtime" case: a chain never closed, two branches
   with the same runtime shape (cannot be told apart, refuse rather than pick one), a branch
-  an earlier one already covers (dead code, first hit wins). A lint rule for what the build
-  cannot see: a chain built and left dangling. The compiler-routed lint diagnostics already
-  exist for batches (`BAT001`-style codes), follow that road. Contract checks (do the
-  branches cover what a route declares) belong to the consumer, the client todo carries
-  mion's.
+  an earlier one already covers (dead code, first hit wins), a `when<T>` whose `T` is only
+  structurally inside `U` and not an exact member. A lint rule for what neither can see: a
+  chain built and left dangling. The compiler-routed lint diagnostics already exist for
+  batches (`BAT001`-style codes), follow that road.
 - An open error (`type: string`, the mion undeclared error) can never be a branch, so a
   chain that expects one always needs `otherwise`.
 - Docs: a new page under the runtypes site tree, plus an example file in
@@ -122,7 +109,7 @@ The implementer plans the details. Pointers verified at the time of writing:
 
 - `match` / `when` / `catch` / `catchTyped` / `otherwise` / `exhaustive` ship from `@mionjs/run-types`,
   with the generated `unionIndex` entry demand-driven like every other family.
-- The build Errors and the dangling-chain lint rule exist; `MatchUnion` reads the branch
-  union back at the type level.
+- The three layers exist: the typed constraint and `exhaustive()`, the build Errors, the
+  dangling-chain lint rule.
 - Marker tests cover both call shapes and `when` in argument position; the fuzz oracle runs.
 - The website documents it with a compiled example.

--- a/docs/todos/runtypes-match-on-union-member.md
+++ b/docs/todos/runtypes-match-on-union-member.md
@@ -93,12 +93,24 @@ The implementer plans the details. Pointers verified at the time of writing:
   needs its paired test (Marker test coverage rule, both `getRunTypeId` shapes).
 - Three layers, each catching what the one below cannot. TypeScript: the member constraint
   on `when<T>`, the shrinking remainder, the typed `exhaustive()`. The compiler, as build
-  Errors since every one is a "throws at runtime" case: a chain never closed, two branches
-  with the same runtime shape (cannot be told apart, refuse rather than pick one), a branch
-  an earlier one already covers (dead code, first hit wins), a `when<T>` whose `T` is only
-  structurally inside `U` and not an exact member. A lint rule for what neither can see: a
-  chain built and left dangling. The compiler-routed lint diagnostics already exist for
-  batches (`BAT001`-style codes), follow that road.
+  Errors since every one is a "throws at runtime" or "a branch is dead" case: a chain never
+  closed, a `when<T>` whose `T` is only structurally inside `U` and not an exact member, and
+  the two branch-collision diagnostics below. A lint rule for what neither can see: a chain
+  built and left dangling. The compiler-routed lint diagnostics already exist for batches
+  (`BAT001`-style codes), follow that road.
+- Two diagnostics for branches that collide, each with its own code and message, since the
+  fix differs:
+  - SAME TYPE: two branches carry the same typeId (`when<User>` twice, or
+    `catch<RangeError>` and a later `catch<RangeError>`). The second can never run; the
+    message names both sites and says "same type".
+  - OVERLAP: two branches with different types can both match the same value, so the one
+    written first silently wins. The case to get right is a `when<RpcError<'my-error'>>`
+    next to a `catchTyped('my-error')`: different branch kinds, same runtime tag. Also two
+    `when` types where one is a structural subset of the other, and two `catchTyped` with the
+    same tag. The message names both sites and says "overlap", so the reader knows one of
+    them must go or the order is the intent. The safe-order pass already computes the
+    subset relation between union members (`SafeUnionChildren`), reuse it rather than
+    writing a second overlap check.
 - An open error (`type: string`, the mion undeclared error) can never be a branch, so a
   chain that expects one always needs `otherwise`.
 - Docs: a new page under the runtypes site tree, plus an example file in

--- a/docs/todos/runtypes-match-on-union-member.md
+++ b/docs/todos/runtypes-match-on-union-member.md
@@ -1,0 +1,128 @@
+---
+type: feature
+spec: guidelines
+status: ready
+created: 2026-09-06
+---
+
+# Match on the runtime member of a union
+
+## Intent
+
+A `match()` that branches on WHICH member of a union a value is, with the member check
+generated at build time from the type. Today that decision exists only inside the JSON
+walkers and the validators; it is never a function a user can call. Exposing it gives one
+opinionated way to branch on any union anywhere in user code, and it is the foundation the
+mion client needs to replace the call result tuple with a plain union of the route's value
+and its declared errors (a separate todo).
+
+The shape agreed on:
+
+```ts
+match(outcome)
+  .when<User>(user => ...)                             // a VALUE member, by type: generated member check
+  .catch<RangeError>(e => ...)                         // an ERROR member, by class: E extends Error
+  .catchTyped('user-not-found', e => e.errorData.id)   // a TAGGED error, by tag: pure TS narrowing
+  .otherwise(v => ...);                                // the fallback, v: unknown
+// or .exhaustive(): no fallback, a value no branch matches throws
+// the chain returns the branch's return value
+```
+
+- THE UNION IS FORMED BY THE BRANCHES, never read from the matched value's static type.
+  `match(value)` accepts `unknown`; the union the generated check decides over is
+  `A | B | C`, the types named by the chain's `when<A>` / `catch<B>` / `catchTyped` branches.
+  That is what keeps the feature generic: it works on any value, and it is what lets a
+  separate rule compare the union a call site built against the union something else
+  declared (the mion client's route contract, in its own todo).
+- `when<T>` is a marker. It injects T's typeId like `getRunTypeId<T>()` does; the matcher
+  compares it against the member typeIds the generated entry carries. Members are matched
+  EXACTLY (a `when<Admin>` next to a `when<User>` is an error, never a structural hit).
+- `catch<E extends Error>` is the same marker restricted to error members, so error classes
+  and plain values never share a branch kind. The generated check for a class member is the
+  class check the validators already emit.
+- `catchTyped<E>(tag, cb)` needs no generated code and no mion import. It binds structurally
+  to `Error & {type: string}`: any error carrying a `type` literal qualifies, `TypedError` and
+  `RpcError` from `@mionjs/core` included (core depends on run-types, never the reverse, so
+  run-types must not name them). The runtime check is one property read. Typing: `E` is the
+  branch's contribution to the union; when the matched value DOES have a static union type,
+  the tag alone narrows it (`Extract<U, {type: Tag}>`) and the payload (`errorData` for an
+  RpcError) is inferred, so `E` is rarely spelled out. A second callback argument carries
+  the source (`'route' | middleFnName`, or the batch slot) when the same tag can come from
+  several places. The client todo relies on that inference, since call outcomes are typed.
+- `otherwise(v => ...)` receives whatever no branch claimed, typed `unknown`. `exhaustive()`
+  closes the chain without a fallback: a value no branch matches throws. The chain returns
+  the branch's return value, so state or JSX can come straight out of it.
+- First hit wins, exactly one branch runs, async branches pass their promise through
+  untouched (all sync or all async).
+
+## Why the union comes from the branches, and why the name is `match`
+
+Two designs were weighed. They share the runtime and differ in where the union comes from.
+
+**A, the one to build: union from the branches.** `match(value)` takes `unknown`; the
+chain's `when` / `catch` / `catchTyped` types ARE the union. TypeScript can read that union
+back from the chain (a `MatchUnion<typeof matcher>` helper over the accumulated branch
+types), which is what an outside rule needs to compare it with a contract. TypeScript
+cannot, on its own, say a branch is wrong or missing, because there is no input type to
+check against; `exhaustive()` means "no match throws". The resolver has to read the whole
+chain as one site to synthesize the union for the generated check.
+
+**B, not built now: union from the input.** `typeMatch(outcome)` reads the union from the
+value's static type, `when<T>` requires `T` to be a member, `otherwise` receives exactly
+what is left and `exhaustive()` compiles only when that is `never`. Cheap to build (the
+union is a real checker type, one marker on the input) and exhaustive for free, but unusable
+on an `unknown` subject.
+
+A is the shape of the TC39 pattern matching proposal (`match (subject) { when pattern: …
+default: … }`: any subject, patterns independent of it, no exhaustiveness, no match without
+`default` throws), so A keeps the name `match`. B is a typed restriction of A, one extra
+constraint `T extends U` when the input has a static type. If it is ever wanted, it ships
+under its own name (`typeMatch`), never as a behaviour of `match` that changes with the
+input type: one function whose rules depend on the input is exactly what users should not
+have to remember.
+
+## Direction
+
+The implementer plans the details. Pointers verified at the time of writing:
+
+- The member pick already exists as a piece of the JSON walkers:
+  `ts-go-runtypes/internal/cachegen/typefunctions/json_prepare.go` (`unionMemberValidateCheck`,
+  inline leaf checks or the cross-family `val_<member>` entry), driven by the safe member order
+  and discriminator detection in `ts-go-runtypes/internal/cachegen/runtype/union_safeorder.go`
+  (`SafeUnionChildren` / `UnionDiscriminators`). A standalone family, `unionIndex` or similar,
+  is mostly wiring: one row in `cachegen/typefunctions/families.go`, one operation in
+  `cachegen/operations/operations.go`, a `createX` factory in
+  `packages/run-types/src/createRTFunctions.ts`, emitting `(value) => memberIndex | -1` and
+  the ordered member typeIds. Discriminator read when one exists, validate fallback otherwise.
+- Because the union comes from the branches, the resolver must read the whole chain
+  (`match(...).when<A>(...).catch<B>(...).otherwise(...)`) as ONE site and synthesize
+  `A | B | ...` as the type the entry is generated for. Which call carries the injected id
+  (the opening `match`, the closing `otherwise` / `exhaustive`, or every branch) is the
+  implementer's call; the safe-order and discriminator passes need the union node either way.
+- Chained method markers already work: the scanner reads the resolved call signature
+  (`ts-go-runtypes/internal/compiler/resolver/scan.go`, `Checker_getResolvedSignature`) and
+  `mion.route()` is itself a method marker (`packages/router/src/types/mionRouter.ts`). So
+  `.when<T>()` needs no resolver change, but a `when` in ARGUMENT position of another call
+  needs its paired test (Marker test coverage rule, both `getRunTypeId` shapes).
+- Safety comes from the compiler and the linter, not from TypeScript (see the A / B note
+  above). Build Errors, all "throws at runtime" cases: a chain never closed, two branches
+  with the same runtime shape (cannot be told apart, refuse rather than pick one), a branch
+  an earlier one already covers (dead code, first hit wins). A lint rule for what the build
+  cannot see: a chain built and left dangling. The compiler-routed lint diagnostics already
+  exist for batches (`BAT001`-style codes), follow that road. Contract checks (do the
+  branches cover what a route declares) belong to the consumer, the client todo carries
+  mion's.
+- An open error (`type: string`, the mion undeclared error) can never be a branch, so a
+  chain that expects one always needs `otherwise`.
+- Docs: a new page under the runtypes site tree, plus an example file in
+  `packages/examples/src/` so the snippet typechecks. Fuzz candidate: the generated index
+  must agree with running each member's validator in safe order (compare-to-trusted-source).
+
+## Done when
+
+- `match` / `when` / `catch` / `catchTyped` / `otherwise` / `exhaustive` ship from `@mionjs/run-types`,
+  with the generated `unionIndex` entry demand-driven like every other family.
+- The build Errors and the dangling-chain lint rule exist; `MatchUnion` reads the branch
+  union back at the type level.
+- Marker tests cover both call shapes and `when` in argument position; the fuzz oracle runs.
+- The website documents it with a compiled example.

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -1,0 +1,50 @@
+# @mionjs/client guidelines
+
+## The call result is a 5-tuple, and the order is deliberate
+
+`call()` resolves to `[result, error, undeclared, middleFnResults, middleFnErrors]`
+([src/types.ts](src/types.ts), `Result`; `batch()` returns the same layout with arrays in
+the first two slots, `BatchResult`). Do not "tidy" the shape or the order: it encodes WHO
+can produce each error, and that is what makes slots 1 and 4 closed, strongly typed unions.
+
+| slot | holds                                                        | who produced it                                                                                                                                                                 |
+| ---- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0    | the route's value                                            | the route handler, whenever it ran and succeeded                                                                                                                                |
+| 1    | the route's DECLARED errors + `ValidationError`              | the route (or its param validation), a CLOSED union                                                                                                                             |
+| 2    | `UndeclaredError`, an OPEN `RpcError<string>`                | anything outside the declared contract: transport (timeout, abort, network), platform, framework, an undeclared throw, an error for a middleFn that was not part of the request |
+| 3    | middleFn results, by name                                    | each middleFn sent with the request                                                                                                                                             |
+| 4    | each middleFn's DECLARED errors + `ValidationError`, by name | each middleFn, one slot per name so several failures are never collapsed into one                                                                                               |
+
+Why `undeclared` sits BEFORE the middleFn slots, which looks odd at first:
+
+- Everything the ROUTER runs, the route and every middleFn, has a slot of its own, typed from
+  what the handler declared. `undeclared` is the one slot for "anything else", and anything
+  else can be a network error the router never saw. Reading order follows frequency: the
+  route's own value and error first, then the catch-all a user MUST check before trusting
+  `result === undefined`, then the middleFn outcomes.
+- MiddleFn outcomes are meant to be handled by the middleFn's own callbacks
+  (`prefill().onError()` / `.onSuccess()`, or `onError` / `onSuccess` registered on the
+  middleFn sub request). The two trailing slots exist so a call site CAN still read them;
+  they are not the primary way. Prefer the callbacks and leave the tuple positions alone.
+
+The dispatch rules (which error lands where) are pinned by
+[src/errorDispatch.spec.ts](src/errorDispatch.spec.ts); the header of that file lists them.
+Two of them exist because of real bugs, keep them in mind when touching request handling:
+
+- A middleFn failing NEVER masks a route result that the server did produce (a returned,
+  non-fatal middleFn error does not abort the chain), so slot 0 keeps the value while slot 4
+  carries the middleFn error.
+- A middleFn error NEVER appears in slot 1. Slot 1 is the route's declared union and nothing
+  else, otherwise the typing of that slot would be a lie.
+
+## Calls never throw
+
+Every failure comes back inside the tuple. The ONE method that throws is `typeErrors()`,
+which validates params locally and is documented as such. Never add a throwing path to
+`call()` / `batch().call()`.
+
+## Batches need the build plugin
+
+`batch()` requires the batch id the build transform injects (`InjectBatchId`), because
+batches are compiled into the server at build time. A client without the transform gets a
+`batch-missing-id` error; that is by design, not a missing fallback.


### PR DESCRIPTION
Add two feature specs documenting the union-based pattern matching API and the client call outcome redesign.

## Summary

Two new spec documents outline the next phase of error handling in mion:

1. **runtypes-match-on-union-member.md** — Defines the `match()` API that branches on union members at runtime. The union is formed by the branches themselves (not read from the matched value's type), making it work on `unknown` values and enabling external contract validation. Includes `when<T>()` for value members, `catch<E>()` for error classes, `catchTyped(tag)` for tagged errors, and `otherwise()` / `exhaustive()` for fallback handling.

2. **client-call-outcome-and-match.md** — Redesigns `call()` to return the outcome union (value + declared errors + validation error + undeclared error) instead of the current 5-tuple. Keeps `callRaw()` for the tuple escape hatch. Introduces `matchAll()` for batch outcomes and a lint rule to enforce branch coverage against route contracts.

## Key changes

- **match() design** — Union built from branches, not input type; works on any value; foundation for contract validation
- **call() redesign** — Returns matchable outcome union by default; `callRaw()` preserves tuple for advanced use cases
- **Implementation pointers** — Identifies existing code paths (JSON walker member checks, safe union ordering, discriminators) and wiring points for the new `unionIndex` family
- **Safety strategy** — Build errors for unreachable/duplicate branches; lint rule for dangling chains and contract mismatches; fuzz oracle for index correctness
- **Documentation** — New website page with compiled example; client guidelines in `packages/client/CLAUDE.md` explaining the 5-tuple order and dispatch rules

## Notable details

- `catchTyped()` needs no generated code; binds structurally to `Error & {type: string}`
- Discriminator detection and safe member order already exist; mostly wiring to expose them
- Resolver must read entire chain as one site to synthesize the union for code generation
- Contract checks belong to the consumer (client lint rule); build errors handle what the compiler can see

https://claude.ai/code/session_01NZLs4gGNngcbwDz89Vd7ga