### PR TITLE
fix(client): send the prefills scoped to the route on the optimistic first call

### DIFF
--- a/container/website/content/01.rpc/03.client/00.client-overview.md
+++ b/container/website/content/01.rpc/03.client/00.client-overview.md
@@ -59,7 +59,7 @@ Some routes need data from a middleware function, for example an auth token. Pas
 
 ## Prefilling Middleware Function Data
 
-When a middleware function is required by every request, like authorization, use `prefill()` on the `MiddleFnSubRequest`. Every later route call that needs it is filled in automatically.
+When a middleware function is required by every request, like authorization, use `prefill()` on the `MiddleFnSubRequest`. Every later route call that needs it is filled in automatically, a route's very first call included, so that call is accepted in one round trip.
 
 Results and errors of a prefilled middleware function reach you in two ways:
 

--- a/docs/done/optimistic-request-restores-prefilled-middlefns.md
+++ b/docs/done/optimistic-request-restores-prefilled-middlefns.md
@@ -56,10 +56,10 @@ Shipped as planned, on the same code path for the prefilled and the explicit cas
   pointer alone. Every top-level prefill plus the prefills scoped to the route's group ride along
   (single route and batch alike, skipping the route ids and ids the call already carries); a prefill
   scoped to another group is never sent, so an app with many scoped prefills pays nothing for them.
-  Sending ALL prefills was considered and rejected for that reason. The restored ids are remembered in
-  `optimisticPrefillIds`; once the answer has cached the metadata, `pruneOptimisticPrefills()` drops any
-  of them the chain did not list (a safety net: the server ignores body keys outside the chain), so the
-  resolved middleFns match what a call with cached metadata restores. The standard-flow restore kept
+  Sending ALL prefills was considered and rejected for that reason. Nothing is pruned after the answer:
+  a public middleFn in scope is always in the chain (the router builds a chain from the same group
+  nesting), and if the server did not run one, no value comes back and both the result tuple and the
+  event handlers already skip an undefined `resolvedValue`. The standard-flow restore kept
   its chain-driven behaviour (`restorePrefilledMiddleFns`, single route and batch merged into one loop
   over `getRouteIds()`), with `errors` now required since only that flow calls it.
 - `packages/client/src/lib/headers.ts`: new `hasHeadersSubsetParam(id, params)`, the one rule for
@@ -74,8 +74,7 @@ Shipped as planned, on the same code path for the prefilled and the explicit cas
   header and no `auth` body key for a PREFILLED auth, for an EXPLICIT auth, and for a batch; every
   top-level prefill rides along and the in-chain ones resolve (`session`); a SCOPED prefill (the new
   `utils/scopeTag` middleFn of the test server, inside the `utils` group) is left off a top-level route's
-  first call and rides along on a `utils/*` route's; the scope rule itself is pinned as a table; a
-  prefill the chain does not list (the answer's metadata rewritten) is dropped from the results. The query-route GET test now primes the metadata first: a route's first
+  first call and rides along on a `utils/*` route's; the scope rule itself is pinned as a table. The query-route GET test now primes the metadata first: a route's first
   call is optimistic and always a POST, and it only ever passed on the retry's GET.
 - Docs: one sentence in the client overview's prefill section (the very first call is one round trip).
 - Not a fuzz candidate: a single wire-shape property, pinned by the round-trip counters.

--- a/docs/done/optimistic-request-restores-prefilled-middlefns.md
+++ b/docs/done/optimistic-request-restores-prefilled-middlefns.md
@@ -50,14 +50,18 @@ The implementer plans the details.
 Shipped as planned, on the same code path for the prefilled and the explicit case:
 
 - `packages/client/src/request.ts`: the optimistic branch of `makeCall` now calls
-  `restoreAllPrefilledMiddleFns()`, which adds EVERY prefilled middleFn of the client (single route and
-  batch alike, skipping the route ids and ids the call already carries) and remembers them in
-  `optimisticPrefillIds`. The server only reads the body keys of the route's own chain, so a prefill
-  outside the chain is harmless on the wire. Once the answer has cached the metadata,
-  `pruneOptimisticPrefills()` drops those stray prefills from the subrequest list, so the resolved
-  middleFns match what a call with cached metadata restores. The standard-flow restore kept its
-  chain-driven behaviour (`restorePrefilledMiddleFns`, single route and batch merged into one loop over
-  `getRouteIds()`), with `errors` now required since only that flow calls it.
+  `restoreScopedPrefilledMiddleFns()`. The chain is not cached yet, but a middleFn's SCOPE is part of
+  its pointer: it runs for the routes of its own group and of the groups nested in it (that is how the
+  router builds a chain), so `isMiddleFnInScope(middleFnPointer, routePointer)` decides from the route
+  pointer alone. Every top-level prefill plus the prefills scoped to the route's group ride along
+  (single route and batch alike, skipping the route ids and ids the call already carries); a prefill
+  scoped to another group is never sent, so an app with many scoped prefills pays nothing for them.
+  Sending ALL prefills was considered and rejected for that reason. The restored ids are remembered in
+  `optimisticPrefillIds`; once the answer has cached the metadata, `pruneOptimisticPrefills()` drops any
+  of them the chain did not list (a safety net: the server ignores body keys outside the chain), so the
+  resolved middleFns match what a call with cached metadata restores. The standard-flow restore kept
+  its chain-driven behaviour (`restorePrefilledMiddleFns`, single route and batch merged into one loop
+  over `getRouteIds()`), with `errors` now required since only that flow calls it.
 - `packages/client/src/lib/headers.ts`: new `hasHeadersSubsetParam(id, params)`, the one rule for
   "this subrequest's first param is a headers middleFn's HeadersSubset": the cached metadata decides
   when there is any, else (a route's first optimistic call with an explicit headersFn) the value itself
@@ -68,9 +72,10 @@ Shipped as planned, on the same code path for the prefilled and the explicit cas
 - Tests (`client.spec.ts`, `batch.spec.ts`), all spying on `fetch` and forgetting the route's cached
   metadata first so the call is a real first call whatever ran before: one fetch with the Authorization
   header and no `auth` body key for a PREFILLED auth, for an EXPLICIT auth, and for a batch; every
-  prefilled middleFn rides along and the in-chain ones resolve (`session`); a prefill outside the chain
-  (the answer's metadata rewritten, since the test server runs every middleFn on every route) is sent
-  but dropped from the results. The query-route GET test now primes the metadata first: a route's first
+  top-level prefill rides along and the in-chain ones resolve (`session`); a SCOPED prefill (the new
+  `utils/scopeTag` middleFn of the test server, inside the `utils` group) is left off a top-level route's
+  first call and rides along on a `utils/*` route's; the scope rule itself is pinned as a table; a
+  prefill the chain does not list (the answer's metadata rewritten) is dropped from the results. The query-route GET test now primes the metadata first: a route's first
   call is optimistic and always a POST, and it only ever passed on the retry's GET.
 - Docs: one sentence in the client overview's prefill section (the very first call is one round trip).
 - Not a fuzz candidate: a single wire-shape property, pinned by the round-trip counters.

--- a/docs/done/optimistic-request-restores-prefilled-middlefns.md
+++ b/docs/done/optimistic-request-restores-prefilled-middlefns.md
@@ -1,0 +1,83 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-06
+---
+
+# The optimistic first request does not restore prefilled middleFns, so it always retries
+
+## Intent
+
+The client's `serializer: 'optimistic'` mode promises one round trip on a route's first call: plain
+JSON goes out with the metadata ask piggybacked, and the compiled functions arrive with the answer.
+That promise breaks as soon as a middleFn was prefilled: the optimistic request leaves every
+prefilled middleFn out, so on a server with a global headers middleFn (the test server's `auth`, any
+app with an auth check) the first request is rejected with the middleFn's validation error and the
+client silently retries with the metadata. Every "optimistic" first call with a prefill is therefore
+two round trips, and the user cannot tell.
+
+Found while pinning the optimistic gate in `packages/client/src/client.spec.ts` (the plain-JSON
+gate tests pass the auth middleFn explicitly to the call for that reason). It predates the encoder
+work: the retry path is what made the existing optimistic tests pass.
+
+Passing the auth middleFn explicitly only looked like a fix: with a cold metadata cache the explicit
+one retried too, because the optimistic body carried the HeadersSubset as a param and no
+Authorization header went out (`extractRequestHeaders` needs the middleFn's metadata, which the
+first call does not have). The existing tests never saw that: the metadata cache is process-wide, so
+by the time the optimistic tests ran, earlier tests had already cached `auth`.
+
+## Direction
+
+- `packages/client/src/request.ts`, `makeCall`: the optimistic branch calls
+  `restorePrefilledMiddleFns()`, but that restore only adds the prefilled middleFns that the route's
+  metadata lists (`middleFnIds`), which is exactly what the optimistic request does not have yet. So
+  nothing is restored, the body carries no middleFn params and the request goes out without the
+  prefilled headers.
+- The optimistic request should carry every prefilled middleFn of the client instead (the user
+  prefilled them for a reason), with a headers middleFn's `HeadersSubset` sent as HTTP headers and
+  kept out of the body, the way an explicitly passed one already is (`serializeJSonBodyOptimistic`,
+  `extractRequestHeaders`). Check what the server does with a prefilled middleFn that is not in the
+  route's chain (an unknown body key) before deciding whether to send all of them or to filter once
+  the metadata arrives.
+- A test in `client.spec.ts` should pin the one-round-trip property with a PREFILLED auth middleFn,
+  spying on `fetch` the way the plain-JSON gate tests do.
+
+The implementer plans the details.
+
+## Plan (approved 2026-09-06, delegated session)
+
+Shipped as planned, on the same code path for the prefilled and the explicit case:
+
+- `packages/client/src/request.ts`: the optimistic branch of `makeCall` now calls
+  `restoreAllPrefilledMiddleFns()`, which adds EVERY prefilled middleFn of the client (single route and
+  batch alike, skipping the route ids and ids the call already carries) and remembers them in
+  `optimisticPrefillIds`. The server only reads the body keys of the route's own chain, so a prefill
+  outside the chain is harmless on the wire. Once the answer has cached the metadata,
+  `pruneOptimisticPrefills()` drops those stray prefills from the subrequest list, so the resolved
+  middleFns match what a call with cached metadata restores. The standard-flow restore kept its
+  chain-driven behaviour (`restorePrefilledMiddleFns`, single route and batch merged into one loop over
+  `getRouteIds()`), with `errors` now required since only that flow calls it.
+- `packages/client/src/lib/headers.ts`: new `hasHeadersSubsetParam(id, params)`, the one rule for
+  "this subrequest's first param is a headers middleFn's HeadersSubset": the cached metadata decides
+  when there is any, else (a route's first optimistic call with an explicit headersFn) the value itself
+  (`instanceof HeadersSubset`).
+- `packages/client/src/lib/serializer.ts`: `serializeJSonBodyOptimistic` strips that HeadersSubset
+  from the body (and, like the compiled JSON path, omits a subrequest with no params left), and
+  `extractRequestHeaders` in `request.ts` uses the same rule to send it as HTTP headers, metadata or not.
+- Tests (`client.spec.ts`, `batch.spec.ts`), all spying on `fetch` and forgetting the route's cached
+  metadata first so the call is a real first call whatever ran before: one fetch with the Authorization
+  header and no `auth` body key for a PREFILLED auth, for an EXPLICIT auth, and for a batch; every
+  prefilled middleFn rides along and the in-chain ones resolve (`session`); a prefill outside the chain
+  (the answer's metadata rewritten, since the test server runs every middleFn on every route) is sent
+  but dropped from the results. The query-route GET test now primes the metadata first: a route's first
+  call is optimistic and always a POST, and it only ever passed on the retry's GET.
+- Docs: one sentence in the client overview's prefill section (the very first call is one round trip).
+- Not a fuzz candidate: a single wire-shape property, pinned by the round-trip counters.
+
+## Done when
+
+- A route's first optimistic call with a prefilled headers middleFn is accepted first time: one
+  `fetch`, the Authorization header present, no retry. SHIPPED, the same for an explicit headers
+  middleFn on a cold cache and for a batch.
+- The existing optimistic tests keep passing, and a new one counts the round trips. SHIPPED.

--- a/packages/client/src/batch.spec.ts
+++ b/packages/client/src/batch.spec.ts
@@ -5,11 +5,11 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import {initClient} from './client.ts';
 import {batch} from './batch.ts';
 import {MiddlewareSubRequest, RouteSubRequest} from './types.ts';
-import {HeadersSubset, RpcError, MION_ROUTES, getRoutePath} from '@mionjs/core';
+import {HeadersSubset, RpcError, MION_ROUTES, getRoutePath, routesCache} from '@mionjs/core';
 import {INPUT_MAPPER_NAMESPACE} from '@mionjs/core';
 import {TestServerApi} from '@mionjs/test-server';
 import {TEST_SERVER_BASE_URL} from '../globalSetup.ts';
@@ -45,6 +45,37 @@ describe('batch', () => {
 
       // Clean up
       void middleFns.auth(authHeaders).removePrefill();
+    });
+
+    it('the first batch call with a prefilled auth headersFn is one round trip (no retry)', async () => {
+      const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
+      const authHeaders = createAuthHeaders('XWYZ-TOKEN');
+      middleFns.auth(authHeaders).prefill();
+      // the metadata cache is process-wide: forgetting the routes makes this their first call again
+      const cache = routesCache.getCache();
+      delete cache.sayHello;
+      delete cache.calculateAge;
+
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      try {
+        const [[greeting, age], [greetingError, ageError], fatal] = await batch([
+          routes.sayHello(someUser),
+          routes.calculateAge(1990),
+        ]).call();
+        expect(fatal).toBeUndefined();
+        expect(greetingError).toBeUndefined();
+        expect(ageError).toBeUndefined();
+        expect(greeting).toEqual('Hello John Doe');
+        expect(age).toEqual(new Date().getFullYear() - 1990);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const init = fetchSpy.mock.calls[0][1] as RequestInit;
+        expect((init.headers as Record<string, string>).Authorization).toBe('XWYZ-TOKEN');
+        expect(JSON.parse(init.body as string).auth).toBeUndefined();
+      } finally {
+        fetchSpy.mockRestore();
+        void middleFns.auth(authHeaders).removePrefill();
+      }
     });
 
     it('should execute multiple routes in a batch', async () => {

--- a/packages/client/src/client.spec.ts
+++ b/packages/client/src/client.spec.ts
@@ -5,10 +5,10 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
-import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {initClient} from './client.ts';
 import {MiddlewareSubRequest, RouteSubRequest} from './types.ts';
-import {isRpcError, HeadersSubset} from '@mionjs/core';
+import {isRpcError, HeadersSubset, MION_ROUTES, routesCache} from '@mionjs/core';
 import {TestServerApi} from '@mionjs/test-server';
 import {TEST_SERVER_BASE_URL} from '../globalSetup.ts';
 
@@ -919,6 +919,9 @@ describe('client', () => {
     });
 
     it('query() route should use GET and send data in URL query', async () => {
+      // a route's FIRST call is optimistic and always a POST (the metadata ask rides in the body);
+      // GET is the shape of every call once the metadata is cached
+      await routes.getRequestInfo('primes the metadata').call();
       const [result, error] = await routes.getRequestInfo('hello from query').call();
 
       expect(error).toBeUndefined();
@@ -1033,6 +1036,125 @@ describe('client', () => {
       const [, , fatal2] = await routes.sayHello(someUser).call();
       expect(fatal2).toBeDefined();
       expect(isRpcError(fatal2)).toBe(true);
+    });
+
+    /** The metadata cache is shared by every client in the process; forgetting the ids under test
+     * makes the next call a route's FIRST call again, whatever ran before */
+    function forgetMetadata(...ids: string[]): void {
+      const cache = routesCache.getCache();
+      ids.forEach((id) => delete cache[id]);
+    }
+
+    /** Spies on fetch for one call and returns the calls it saw, the spy always restored. A prefill
+     * issues its own metadata fetch synchronously, before the spy exists, and call() waits for it. */
+    async function spyOnFetch(run: () => Promise<void>): Promise<{init: RequestInit; body: any}[]> {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      try {
+        await run();
+        return fetchSpy.mock.calls.map(([, init]) => ({
+          init: init as RequestInit,
+          body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+        }));
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    }
+
+    it('first optimistic call with a PREFILLED auth headersFn is one round trip (no retry)', async () => {
+      const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
+      const authHeaders = createAuthHeaders('XWYZ-TOKEN');
+      middleFns.auth(authHeaders).prefill();
+      forgetMetadata('sayHello');
+
+      const calls = await spyOnFetch(async () => {
+        const [greeting, error] = await routes.sayHello(someUser).call();
+        expect(error).toBeUndefined();
+        expect(greeting).toBe('Hello John Doe');
+      });
+
+      expect(calls).toHaveLength(1);
+      const [{init, body}] = calls;
+      expect((init.headers as Record<string, string>).Authorization).toBe('XWYZ-TOKEN');
+      // the prefilled headers travel as HTTP headers only, never inside the body
+      expect(body.auth).toBeUndefined();
+      expect(body.sayHello).toEqual([someUser]);
+      // the metadata ask piggybacks on that single request
+      expect(body[MION_ROUTES.methodsMetadata]).toBeDefined();
+
+      void middleFns.auth(authHeaders).removePrefill();
+    });
+
+    it('first optimistic call with an EXPLICIT auth headersFn is one round trip (no retry)', async () => {
+      const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
+      const authHeaders = createAuthHeaders('XWYZ-TOKEN');
+      forgetMetadata('sayHello', 'auth');
+
+      const calls = await spyOnFetch(async () => {
+        const [greeting, error] = await routes.sayHello(someUser).call({middleFns: {auth: middleFns.auth(authHeaders)}});
+        expect(error).toBeUndefined();
+        expect(greeting).toBe('Hello John Doe');
+      });
+
+      expect(calls).toHaveLength(1);
+      const [{init, body}] = calls;
+      expect((init.headers as Record<string, string>).Authorization).toBe('XWYZ-TOKEN');
+      expect(body.auth).toBeUndefined();
+    });
+
+    it('every prefilled middleFn rides along on the first optimistic call, and the ones in the chain resolve', async () => {
+      const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
+      const authHeaders = createAuthHeaders('XWYZ-TOKEN');
+      middleFns.auth(authHeaders).prefill();
+      middleFns.session('valid-token').prefill();
+      forgetMetadata('sayHello');
+
+      const calls = await spyOnFetch(async () => {
+        const [greeting, error, fatal, middleFnResults] = await routes.sayHello(someUser).call();
+        expect(error).toBeUndefined();
+        expect(fatal).toBeUndefined();
+        expect(greeting).toBe('Hello John Doe');
+        expect(middleFnResults?.session).toEqual(expect.objectContaining({userId: 'user-123'}));
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].body.session).toEqual(['valid-token']);
+
+      void middleFns.session('valid-token').removePrefill();
+      void middleFns.auth(authHeaders).removePrefill();
+    });
+
+    it('a prefilled middleFn outside the route chain is sent (harmless) but dropped from the results once the chain is known', async () => {
+      const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
+      const authHeaders = createAuthHeaders('XWYZ-TOKEN');
+      middleFns.auth(authHeaders).prefill();
+      middleFns.session('valid-token').prefill();
+      forgetMetadata('sayHello');
+
+      // every test-server route runs every middleFn, so the answer is rewritten to a chain without session
+      const realFetch = globalThis.fetch;
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+        const response = await realFetch(input, init);
+        const parsed = await response.json();
+        const metadata = parsed[MION_ROUTES.methodsMetadata];
+        const methods = (Array.isArray(metadata) ? metadata[1] : metadata).methods;
+        methods.sayHello.middleFnIds = methods.sayHello.middleFnIds.filter((id: string) => id !== 'session');
+        return new Response(JSON.stringify(parsed), {status: response.status, headers: response.headers});
+      });
+      try {
+        const [greeting, error, fatal, middleFnResults] = await routes.sayHello(someUser).call();
+        expect(error).toBeUndefined();
+        expect(fatal).toBeUndefined();
+        expect(greeting).toBe('Hello John Doe');
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(JSON.parse(fetchSpy.mock.calls[0][1]?.body as string).session).toEqual(['valid-token']);
+        expect(middleFnResults?.session).toBeUndefined();
+        expect(routesCache.getMetadata('sayHello')?.middleFnIds).not.toContain('session');
+      } finally {
+        fetchSpy.mockRestore();
+        forgetMetadata('sayHello'); // the rewritten chain must not leak into later tests
+        void middleFns.session('valid-token').removePrefill();
+        void middleFns.auth(authHeaders).removePrefill();
+      }
     });
 
     it('optimistic mode with simple types should work without retry (no auth required route)', async () => {

--- a/packages/client/src/client.spec.ts
+++ b/packages/client/src/client.spec.ts
@@ -7,6 +7,7 @@
 
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {initClient} from './client.ts';
+import {isMiddleFnInScope} from './request.ts';
 import {MiddlewareSubRequest, RouteSubRequest} from './types.ts';
 import {isRpcError, HeadersSubset, MION_ROUTES, routesCache} from '@mionjs/core';
 import {TestServerApi} from '@mionjs/test-server';
@@ -1121,6 +1122,50 @@ describe('client', () => {
 
       void middleFns.session('valid-token').removePrefill();
       void middleFns.auth(authHeaders).removePrefill();
+    });
+
+    it('a SCOPED prefill rides along only on the first optimistic call of a route in its group', async () => {
+      const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
+      const authHeaders = createAuthHeaders('XWYZ-TOKEN');
+      middleFns.auth(authHeaders).prefill();
+      middleFns.utils.scopeTag('tagged').prefill();
+      forgetMetadata('sayHello', 'utils/sumTwo');
+
+      // a top-level route: the utils-scoped prefill is not in its group, so it is never sent
+      const topLevelCalls = await spyOnFetch(async () => {
+        const [greeting, error, fatal, middleFnResults] = await routes.sayHello(someUser).call();
+        expect(error).toBeUndefined();
+        expect(fatal).toBeUndefined();
+        expect(greeting).toBe('Hello John Doe');
+        expect(middleFnResults?.['utils/scopeTag']).toBeUndefined();
+      });
+      expect(topLevelCalls).toHaveLength(1);
+      expect(topLevelCalls[0].body['utils/scopeTag']).toBeUndefined();
+
+      // a route of the group: the scoped prefill and the top-level auth both ride along, one round trip
+      const scopedCalls = await spyOnFetch(async () => {
+        const [sum, error, fatal, middleFnResults] = await routes.utils.sumTwo(5).call();
+        expect(error).toBeUndefined();
+        expect(fatal).toBeUndefined();
+        expect(sum).toBe(7);
+        expect(middleFnResults?.['utils/scopeTag']).toBe('tagged');
+      });
+      expect(scopedCalls).toHaveLength(1);
+      expect(scopedCalls[0].body['utils/scopeTag']).toEqual(['tagged']);
+      expect((scopedCalls[0].init.headers as Record<string, string>).Authorization).toBe('XWYZ-TOKEN');
+
+      void middleFns.utils.scopeTag('tagged').removePrefill();
+      void middleFns.auth(authHeaders).removePrefill();
+    });
+
+    it('isMiddleFnInScope: a middleFn covers its own group and the groups nested in it', () => {
+      expect(isMiddleFnInScope(['auth'], ['sayHello'])).toBe(true);
+      expect(isMiddleFnInScope(['auth'], ['utils', 'sumTwo'])).toBe(true);
+      expect(isMiddleFnInScope(['utils', 'scopeTag'], ['utils', 'sumTwo'])).toBe(true);
+      expect(isMiddleFnInScope(['utils', 'scopeTag'], ['utils', 'deep', 'route'])).toBe(true);
+      expect(isMiddleFnInScope(['utils', 'scopeTag'], ['sayHello'])).toBe(false);
+      expect(isMiddleFnInScope(['utils', 'scopeTag'], ['flow', 'getUser'])).toBe(false);
+      expect(isMiddleFnInScope(['utils', 'scopeTag'], ['utils'])).toBe(false);
     });
 
     it('a prefilled middleFn outside the route chain is sent (harmless) but dropped from the results once the chain is known', async () => {

--- a/packages/client/src/client.spec.ts
+++ b/packages/client/src/client.spec.ts
@@ -1168,40 +1168,6 @@ describe('client', () => {
       expect(isMiddleFnInScope(['utils', 'scopeTag'], ['utils'])).toBe(false);
     });
 
-    it('a prefilled middleFn outside the route chain is sent (harmless) but dropped from the results once the chain is known', async () => {
-      const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
-      const authHeaders = createAuthHeaders('XWYZ-TOKEN');
-      middleFns.auth(authHeaders).prefill();
-      middleFns.session('valid-token').prefill();
-      forgetMetadata('sayHello');
-
-      // every test-server route runs every middleFn, so the answer is rewritten to a chain without session
-      const realFetch = globalThis.fetch;
-      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
-        const response = await realFetch(input, init);
-        const parsed = await response.json();
-        const metadata = parsed[MION_ROUTES.methodsMetadata];
-        const methods = (Array.isArray(metadata) ? metadata[1] : metadata).methods;
-        methods.sayHello.middleFnIds = methods.sayHello.middleFnIds.filter((id: string) => id !== 'session');
-        return new Response(JSON.stringify(parsed), {status: response.status, headers: response.headers});
-      });
-      try {
-        const [greeting, error, fatal, middleFnResults] = await routes.sayHello(someUser).call();
-        expect(error).toBeUndefined();
-        expect(fatal).toBeUndefined();
-        expect(greeting).toBe('Hello John Doe');
-        expect(fetchSpy).toHaveBeenCalledTimes(1);
-        expect(JSON.parse(fetchSpy.mock.calls[0][1]?.body as string).session).toEqual(['valid-token']);
-        expect(middleFnResults?.session).toBeUndefined();
-        expect(routesCache.getMetadata('sayHello')?.middleFnIds).not.toContain('session');
-      } finally {
-        fetchSpy.mockRestore();
-        forgetMetadata('sayHello'); // the rewritten chain must not leak into later tests
-        void middleFns.session('valid-token').removePrefill();
-        void middleFns.auth(authHeaders).removePrefill();
-      }
-    });
-
     it('optimistic mode with simple types should work without retry (no auth required route)', async () => {
       const {routes, middleFns} = initClient<MyApi>({baseURL, serializer: 'optimistic'});
       const authHeaders = createAuthHeaders('XWYZ-TOKEN');

--- a/packages/client/src/lib/headers.ts
+++ b/packages/client/src/lib/headers.ts
@@ -5,6 +5,19 @@
  * The software is provided "as is", without warranty of any kind.
  * ######## */
 
+import {HandlerType, HeadersSubset, routesCache} from '@mionjs/core';
+
+/**
+ * True when a subrequest's first param is the HeadersSubset of a headers middleFn, so it travels as
+ * HTTP headers and stays out of the body. The cached metadata decides when there is any; on a route's
+ * FIRST optimistic call there may be none yet, and the value itself answers instead.
+ */
+export function hasHeadersSubsetParam(id: string, params: any[] | undefined): boolean {
+  const method = routesCache.getMetadata(id);
+  if (method) return method.type === HandlerType.headersMiddleFn && !!method.headersParam;
+  return params?.[0] instanceof HeadersSubset;
+}
+
 /**
  * Normalizes any `HeadersInit` into a plain record so it can be merged with the
  * per-request headers. Spreading a `HeadersInit` directly only works for the

--- a/packages/client/src/lib/serializer.ts
+++ b/packages/client/src/lib/serializer.ts
@@ -20,6 +20,7 @@ import {
 import type {MionClientRequest} from '../request.ts';
 import {DEFAULT_PREFILL_OPTIONS} from '../constants.ts';
 import {extractAndProcessMetadata} from './clientMethodsMetadata.ts';
+import {hasHeadersSubsetParam} from './headers.ts';
 import {ClientOptions} from '../types.ts';
 
 /** Result of serializing a request body - can be string (JSON) or Uint8Array (binary) */
@@ -91,14 +92,18 @@ function serializeJsonBody(req: MionClientRequest<any, any>): string {
   return `{${props.join(',')}}`;
 }
 
-/** Serializes request body as plain JSON without JIT functions */
+/** Serializes request body as plain JSON without JIT functions. A headers middleFn's HeadersSubset goes
+ * out as HTTP headers (extractRequestHeaders), never in the body, exactly like the compiled path. */
 function serializeJSonBodyOptimistic(req: MionClientRequest<any, any>): string {
   const body: Record<string, any> = {};
   const subRequestIds = Object.keys(req.subRequestList);
   for (const id of subRequestIds) {
     const subRequest = req.subRequestList[id];
     if (!subRequest) continue;
-    body[id] = subRequest.params;
+    const params = hasHeadersSubsetParam(id, subRequest.params)
+      ? getParamsWithoutHeadersSubset(subRequest.params)
+      : subRequest.params;
+    if (params?.length) body[id] = params;
   }
   return JSON.stringify(body);
 }

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -33,7 +33,7 @@ import {validateSubRequests} from './lib/validation.ts';
 import {sanitizeSubRequests} from './lib/sanitize.ts';
 import {serializeRequestBody, deserializeResponseBody} from './lib/serializer.ts';
 import {MAX_GET_URL_LENGTH, CLIENT_REQUEST_ERROR_ID} from './constants.ts';
-import {headersToRecord} from './lib/headers.ts';
+import {headersToRecord, hasHeadersSubsetParam} from './lib/headers.ts';
 
 export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequestsList extends MiddlewareSubRequest<any>[]> {
   readonly path: string;
@@ -41,6 +41,8 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
   readonly subRequestList: {[key: string]: SubRequest<any>} = {};
   /** ids in the RequestErrors map whose error is thrown/undeclared (unexpected) rather than a declared response */
   readonly thrownErrorIds = new Set<string>();
+  /** prefilled middleFns an optimistic request carried before knowing the route's chain (pruned once it does) */
+  private readonly optimisticPrefillIds = new Set<string>();
   response: Response | undefined;
 
   constructor(
@@ -88,7 +90,10 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
     try {
       if (isOptimistic) {
         (this.options as any).serializer = 'optimistic';
-        this.restorePrefilledMiddleFns();
+        // The route's chain is unknown until the metadata arrives with the answer, so every prefilled
+        // middleFn rides along: the server ignores the ones that are not in the chain, and leaving a
+        // required one out (a global auth) would fail the request and cost the retry round trip.
+        this.restoreAllPrefilledMiddleFns();
         // Add metadata subrequest (after prefilled restore so we include all IDs)
         const allSubRequestIds = Object.keys(this.subRequestList);
         this.addSubRequest(createMetadataSubRequest(allSubRequestIds));
@@ -144,6 +149,8 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
         return Promise.reject(errors);
       }
       const deserialized = await deserializeResponseBody(this.response, this.options);
+      // the metadata is cached now, so the prefills the chain never ran are dropped before resolving
+      if (isOptimistic) this.pruneOptimisticPrefills();
       if (this.handlePlatformError(deserialized, errors)) return Promise.reject(errors);
 
       // Never retry an aborted request — the user explicitly canceled it.
@@ -338,81 +345,73 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
     return respBody[id];
   }
 
-  /** When errors is omitted, silently skips routes without cached metadata (used by optimistic flow) */
-  private restorePrefilledMiddleFns(errors?: RequestErrors): void {
-    if (this.batchSubRequests && this.batchSubRequests.length > 0) {
-      this.restorePrefilledMiddleFnsForBatch(errors);
-      return;
-    }
+  /** The ids of the route(s) this request calls: the single route, or every route of the batch */
+  private getRouteIds(): string[] {
+    if (this.batchSubRequests && this.batchSubRequests.length > 0) return this.batchSubRequests.map((sr) => sr.id);
+    return [this.requestId];
+  }
 
-    const methodMeta = routesCache.getMetadata(this.requestId);
-    if (!methodMeta) {
-      if (errors) {
+  /** Restores the prefilled middleFns the cached metadata lists in the route's chain (standard flow) */
+  private restorePrefilledMiddleFns(errors: RequestErrors): void {
+    const routeIds = new Set(this.getRouteIds());
+    for (const routeId of routeIds) {
+      const methodMeta = routesCache.getMetadata(routeId);
+      if (!methodMeta) {
         this.setUndeclaredError(
-          this.requestId,
+          routeId,
           new RpcError({
             type: 'route-metadata-not-found',
-            publicMessage: `Metadata for Route '${this.requestId} not found.'.`,
+            publicMessage: `Metadata for Route '${routeId}' not found.`,
           }),
           errors
         );
-      }
-      return;
-    }
-    const missingIds = methodMeta.middleFnIds?.filter((id) => !!id && this.requestId !== id) || [];
-    missingIds.forEach((id) => {
-      const subRequest = this.subRequestList[id];
-      if (subRequest) return;
-      const cacheKey = this.getPrefilledMiddleFnCacheKey(id);
-      const cachedSubRequest = this.prefilledMiddleFnsCache.get(cacheKey);
-      if (cachedSubRequest) {
-        const clonedSubRequest: SubRequest<any> = {
-          ...cachedSubRequest,
-          isResolved: false,
-          resolvedValue: undefined,
-          error: undefined,
-        };
-        this.addSubRequest(clonedSubRequest);
-      }
-    });
-  }
-
-  /** Restore prefilled middleFns for all routes in a batch, deduplicating by ID */
-  private restorePrefilledMiddleFnsForBatch(errors?: RequestErrors): void {
-    const batchRouteIds = new Set(this.batchSubRequests!.map((sr) => sr.id));
-
-    for (const routeSubRequest of this.batchSubRequests!) {
-      const methodMeta = routesCache.getMetadata(routeSubRequest.id);
-      if (!methodMeta) {
-        if (errors) {
-          this.setUndeclaredError(
-            routeSubRequest.id,
-            new RpcError({
-              type: 'route-metadata-not-found',
-              publicMessage: `Metadata for Route '${routeSubRequest.id}' not found.`,
-            }),
-            errors
-          );
-        }
         continue;
       }
-      const missingIds = methodMeta.middleFnIds?.filter((id) => !!id && !batchRouteIds.has(id)) || [];
-      missingIds.forEach((id) => {
-        const subRequest = this.subRequestList[id];
-        if (subRequest) return;
-        const cacheKey = this.getPrefilledMiddleFnCacheKey(id);
-        const cachedSubRequest = this.prefilledMiddleFnsCache.get(cacheKey);
-        if (cachedSubRequest) {
-          const clonedSubRequest: SubRequest<any> = {
-            ...cachedSubRequest,
-            isResolved: false,
-            resolvedValue: undefined,
-            error: undefined,
-          };
-          this.addSubRequest(clonedSubRequest);
-        }
-      });
+      const missingIds = methodMeta.middleFnIds?.filter((id) => !!id && !routeIds.has(id)) || [];
+      missingIds.forEach((id) => this.restorePrefilledMiddleFn(id));
     }
+  }
+
+  /** Restores EVERY prefilled middleFn of this client (optimistic flow: the chain is not known yet) */
+  private restoreAllPrefilledMiddleFns(): void {
+    const routeIds = new Set(this.getRouteIds());
+    for (const [cacheKey, cachedSubRequest] of this.prefilledMiddleFnsCache) {
+      const id = cachedSubRequest.id;
+      // the cache is keyed by baseURL too: only this client's own prefills ride along
+      if (routeIds.has(id) || cacheKey !== this.getPrefilledMiddleFnCacheKey(id)) continue;
+      if (this.restorePrefilledMiddleFn(id)) this.optimisticPrefillIds.add(id);
+    }
+  }
+
+  /** Drops the optimistically restored prefills that are in no route's chain, so the resolved
+   * subrequests match what a call with cached metadata restores. Runs once the metadata is cached. */
+  private pruneOptimisticPrefills(): void {
+    if (!this.optimisticPrefillIds.size) return;
+    const chainIds = new Set<string>();
+    for (const routeId of this.getRouteIds()) {
+      const methodMeta = routesCache.getMetadata(routeId);
+      // no metadata means the router never answered; nothing can be pruned with certainty
+      if (!methodMeta) return;
+      methodMeta.middleFnIds?.forEach((id) => chainIds.add(id));
+    }
+    for (const id of this.optimisticPrefillIds) if (!chainIds.has(id)) delete this.subRequestList[id];
+    this.optimisticPrefillIds.clear();
+  }
+
+  /** Adds a fresh clone of the prefilled middleFn to the request, unless the request already carries
+   * that id or nothing was prefilled under it. Returns true when a clone was added. */
+  private restorePrefilledMiddleFn(id: string): boolean {
+    if (this.subRequestList[id]) return false;
+    const cachedSubRequest = this.prefilledMiddleFnsCache.get(this.getPrefilledMiddleFnCacheKey(id));
+    if (!cachedSubRequest) return false;
+    const clonedSubRequest: SubRequest<any> = {
+      ...cachedSubRequest,
+      isResolved: false,
+      resolvedValue: undefined,
+      error: undefined,
+    };
+    this.addSubRequest(clonedSubRequest);
+    return true;
   }
 
   private storePrefilledMiddleFns(errors: RequestErrors): void {
@@ -507,14 +506,8 @@ function extractRequestHeaders(req: MionClientRequest<any, any>): Record<string,
   for (let i = 0; i < subRequestIds.length; i++) {
     const id = subRequestIds[i];
     const subRequest = req.subRequestList[id];
-    if (!subRequest) continue;
-
-    const method = routesCache.getMetadata(id);
-    if (!method || method.type !== HandlerType.headersMiddleFn || !method.headersParam) continue;
-
-    const params = subRequest.params;
-    const extracted = extractHeadersFromParams(params);
-    Object.assign(headers, extracted);
+    if (!subRequest || !hasHeadersSubsetParam(id, subRequest.params)) continue;
+    Object.assign(headers, extractHeadersFromParams(subRequest.params));
   }
 
   return headers;

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -90,10 +90,11 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
     try {
       if (isOptimistic) {
         (this.options as any).serializer = 'optimistic';
-        // The route's chain is unknown until the metadata arrives with the answer, so every prefilled
-        // middleFn rides along: the server ignores the ones that are not in the chain, and leaving a
-        // required one out (a global auth) would fail the request and cost the retry round trip.
-        this.restoreAllPrefilledMiddleFns();
+        // The route's chain is unknown until the metadata arrives with the answer, but its scope is not:
+        // a middleFn runs for the routes of its own group and the groups below it, so the route pointer
+        // alone says which prefills belong. Leaving a required one out (an auth) would fail the request
+        // and cost the retry round trip; the server ignores any key that is not in the chain.
+        this.restoreScopedPrefilledMiddleFns();
         // Add metadata subrequest (after prefilled restore so we include all IDs)
         const allSubRequestIds = Object.keys(this.subRequestList);
         this.addSubRequest(createMetadataSubRequest(allSubRequestIds));
@@ -372,13 +373,22 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
     }
   }
 
-  /** Restores EVERY prefilled middleFn of this client (optimistic flow: the chain is not known yet) */
-  private restoreAllPrefilledMiddleFns(): void {
+  /** The pointers of the route(s) this request calls, in the same order as getRouteIds() */
+  private getRoutePointers(): string[][] {
+    if (this.batchSubRequests && this.batchSubRequests.length > 0) return this.batchSubRequests.map((sr) => sr.pointer);
+    return this.route ? [this.route.pointer] : [];
+  }
+
+  /** Restores the prefilled middleFns whose scope holds a route of this request (optimistic flow: the
+   * chain is not cached yet, but a middleFn's group is part of its pointer) */
+  private restoreScopedPrefilledMiddleFns(): void {
     const routeIds = new Set(this.getRouteIds());
+    const routePointers = this.getRoutePointers();
     for (const [cacheKey, cachedSubRequest] of this.prefilledMiddleFnsCache) {
       const id = cachedSubRequest.id;
       // the cache is keyed by baseURL too: only this client's own prefills ride along
       if (routeIds.has(id) || cacheKey !== this.getPrefilledMiddleFnCacheKey(id)) continue;
+      if (!routePointers.some((routePointer) => isMiddleFnInScope(cachedSubRequest.pointer, routePointer))) continue;
       if (this.restorePrefilledMiddleFn(id)) this.optimisticPrefillIds.add(id);
     }
   }
@@ -452,6 +462,15 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
   private getPrefilledMiddleFnCacheKey(id: string): string {
     return `${this.options.baseURL}:${id}`;
   }
+}
+
+/** A middleFn runs for every route of its own group and of the groups nested in it: its scope is its
+ * pointer minus the last segment, and a route is in scope when its pointer starts with that group. */
+export function isMiddleFnInScope(middleFnPointer: string[], routePointer: string[]): boolean {
+  const groupDepth = middleFnPointer.length - 1;
+  if (groupDepth >= routePointer.length) return false;
+  for (let i = 0; i < groupDepth; i++) if (middleFnPointer[i] !== routePointer[i]) return false;
+  return true;
 }
 
 /**

--- a/packages/client/src/request.ts
+++ b/packages/client/src/request.ts
@@ -41,8 +41,6 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
   readonly subRequestList: {[key: string]: SubRequest<any>} = {};
   /** ids in the RequestErrors map whose error is thrown/undeclared (unexpected) rather than a declared response */
   readonly thrownErrorIds = new Set<string>();
-  /** prefilled middleFns an optimistic request carried before knowing the route's chain (pruned once it does) */
-  private readonly optimisticPrefillIds = new Set<string>();
   response: Response | undefined;
 
   constructor(
@@ -150,8 +148,6 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
         return Promise.reject(errors);
       }
       const deserialized = await deserializeResponseBody(this.response, this.options);
-      // the metadata is cached now, so the prefills the chain never ran are dropped before resolving
-      if (isOptimistic) this.pruneOptimisticPrefills();
       if (this.handlePlatformError(deserialized, errors)) return Promise.reject(errors);
 
       // Never retry an aborted request — the user explicitly canceled it.
@@ -389,31 +385,16 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
       // the cache is keyed by baseURL too: only this client's own prefills ride along
       if (routeIds.has(id) || cacheKey !== this.getPrefilledMiddleFnCacheKey(id)) continue;
       if (!routePointers.some((routePointer) => isMiddleFnInScope(cachedSubRequest.pointer, routePointer))) continue;
-      if (this.restorePrefilledMiddleFn(id)) this.optimisticPrefillIds.add(id);
+      this.restorePrefilledMiddleFn(id);
     }
-  }
-
-  /** Drops the optimistically restored prefills that are in no route's chain, so the resolved
-   * subrequests match what a call with cached metadata restores. Runs once the metadata is cached. */
-  private pruneOptimisticPrefills(): void {
-    if (!this.optimisticPrefillIds.size) return;
-    const chainIds = new Set<string>();
-    for (const routeId of this.getRouteIds()) {
-      const methodMeta = routesCache.getMetadata(routeId);
-      // no metadata means the router never answered; nothing can be pruned with certainty
-      if (!methodMeta) return;
-      methodMeta.middleFnIds?.forEach((id) => chainIds.add(id));
-    }
-    for (const id of this.optimisticPrefillIds) if (!chainIds.has(id)) delete this.subRequestList[id];
-    this.optimisticPrefillIds.clear();
   }
 
   /** Adds a fresh clone of the prefilled middleFn to the request, unless the request already carries
-   * that id or nothing was prefilled under it. Returns true when a clone was added. */
-  private restorePrefilledMiddleFn(id: string): boolean {
-    if (this.subRequestList[id]) return false;
+   * that id or nothing was prefilled under it. */
+  private restorePrefilledMiddleFn(id: string): void {
+    if (this.subRequestList[id]) return;
     const cachedSubRequest = this.prefilledMiddleFnsCache.get(this.getPrefilledMiddleFnCacheKey(id));
-    if (!cachedSubRequest) return false;
+    if (!cachedSubRequest) return;
     const clonedSubRequest: SubRequest<any> = {
       ...cachedSubRequest,
       isResolved: false,
@@ -421,7 +402,6 @@ export class MionClientRequest<RR extends RouteSubRequest<any>, MiddleFnRequests
       error: undefined,
     };
     this.addSubRequest(clonedSubRequest);
-    return true;
   }
 
   private storePrefilledMiddleFns(errors: RequestErrors): void {

--- a/packages/test-server/src/test-server.ts
+++ b/packages/test-server/src/test-server.ts
@@ -309,6 +309,8 @@ const routes = {
   },
 
   utils: {
+    // a SCOPED middleFn: runs for the utils.* routes only, never for a top-level route
+    scopeTag: middleFn((_ctx, tag?: string): string | null => tag ?? null),
     sumTwo: route((ctx, a: number): number => a + 2),
     multiply: route((ctx, a: number, b: number): number => a * b),
     processUser: route((ctx, user: User): string => `Processed: ${user.name} ${user.surname}`),


### PR DESCRIPTION
## What

A route's first call in `serializer: 'optimistic'` mode promised one round trip. With a prefilled middleFn it was always two: the optimistic request restored only the prefills the route's metadata lists, which that request does not have yet, so a prefilled auth was left out, the server rejected the call with the middleFn's validation error, and the client silently retried with the metadata.

An explicitly passed auth middleFn was broken the same way on a cold cache: the optimistic body carried the `HeadersSubset` as a param and no `Authorization` header went out, because header extraction needed the middleFn's metadata. The existing tests never saw either case, since the process-wide metadata cache was already warm from earlier tests.

## Fix (`@mionjs/client`)

- `request.ts`: the chain is not cached on a first call, but a middleFn's SCOPE is part of its pointer: the router runs a middleFn for the routes of its own group and of the groups nested in it. So `isMiddleFnInScope(middleFnPointer, routePointer)` decides from the route pointer alone which prefills ride along: every top-level prefill plus the ones scoped to the route's group (single route and batch), never a prefill scoped to another group, so an app with many scoped prefills pays nothing for them. Nothing is pruned after the answer arrives: a public middleFn in scope is always in the chain, and when the server does not run one it returns no value, which the result tuple and the event handlers already skip. The standard-flow restore keeps its chain-driven behaviour (single route and batch merged into one loop).
- `lib/headers.ts`: new `hasHeadersSubsetParam(id, params)`, the one rule for "this subrequest's first param is a headers middleFn's HeadersSubset": the cached metadata decides when there is any, else the value itself (`instanceof HeadersSubset`).
- `lib/serializer.ts`: the optimistic body strips that HeadersSubset (and, like the compiled JSON path, omits a subrequest with no params left); `extractRequestHeaders` sends it as HTTP headers with the same rule, metadata or not.
- `@mionjs/test-server`: a scoped middleFn `utils/scopeTag` inside the `utils` group, so the scope rule can be pinned against a real server (every other middleFn there is top-level).

## Tests

All spy on `fetch` and forget the route's cached metadata first, so the call is a real first call whatever ran before:

- one fetch, `Authorization` header present, no `auth` body key: prefilled auth, explicit auth, and a batch
- every top-level prefill rides along and the in-chain ones resolve (`session`)
- a SCOPED prefill is left off a top-level route's first call and rides along on a `utils/*` route's, one round trip each; the scope rule itself is pinned as a table
- the query-route GET test now primes the metadata first: a route's first call is optimistic and always a POST, and it only ever passed on the retry's GET

`pnpm run test:ci` green on all 21 projects, `pnpm run lint` and `pnpm run format` clean.

## Docs

One sentence in the client overview's prefill section. The spec moved to `docs/done/` and records what shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETji1mCDtgKSYEMNg5tykN