### PR TITLE
docs(router): state the real context pool default and fix five dead doc anchors

### DIFF
--- a/container/website/content/01.rpc/01.introduction/03.manual-install.md
+++ b/container/website/content/01.rpc/01.introduction/03.manual-install.md
@@ -6,7 +6,7 @@ toc: false
 
 ## Server Side
 
-Install the router and Configure `tsConfig.json` to enable [runTypes metadata.](/rpc/introduction/about-mion-rpc#automatic-serialization-validation)
+Install the router and Configure `tsConfig.json` to enable [runTypes metadata](/runtypes/introduction/configuration#setting-options).
 
 ```bash
 npm i @mionjs/core @mionjs/router

--- a/container/website/content/01.rpc/02.server/01.routes.md
+++ b/container/website/content/01.rpc/02.server/01.routes.md
@@ -77,7 +77,7 @@ A shared field that starts out empty needs a return type on the factory, `(): {u
 
 ## Defining a Route
 
-Routes are declared with `mion.route`, one of the helpers the router returns, by passing the [`Handler`](#handler) as first parameter and [RouteOptions](#routedef) as second.
+Routes are declared with `mion.route`, one of the helpers the router returns, by passing the `Handler` as first parameter and the `RouteOptions` as second.
 
 ::tip
 **Quick Tip:** Never assign a type to Routes/MiddleFns, instead always use the [`satisfies`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator){target="_blank"} operator.
@@ -142,7 +142,7 @@ const mion = createMionRouter({alwaysAwait: false});
 
 ## Call Context
 
-The [`CallContext`](#callcontext) contains all the data related to the ongoing call.
+The `CallContext` contains all the data related to the ongoing call.
 
 Most of the data within the CallContext is marked as read-only, this is because it is not recommended to modify the context manually. It is still possible to modify it (the context is not a real Immutable JS object). 
 

--- a/container/website/content/01.rpc/02.server/02.middle-fns.md
+++ b/container/website/content/01.rpc/02.server/02.middle-fns.md
@@ -47,7 +47,7 @@ Header values are limited to `string` types only. Complex data types cannot be s
 
 ## Raw Middleware functions
 
-In case we need to access the raw or native underlying request and response, we must use [`mion.rawMiddleFn`](#rawmiddleFndef).
+In case we need to access the raw or native underlying request and response, we must use `mion.rawMiddleFn`.
 
 These are functions that receive the `CallContext`, `RawRequest`, `RawResponse` and `RouterOptions`, but can't receive any remote parameters or return any data. 
 `Raw Middleware functions` can only modify the CallContext and return or throw errors.

--- a/docs/done/router-docs-drift-pool-default-and-dead-anchors.md
+++ b/docs/done/router-docs-drift-pool-default-and-dead-anchors.md
@@ -1,0 +1,135 @@
+---
+type: docs
+spec: guidelines
+status: done
+created: 2026-09-10
+completed: 2026-09-10
+---
+
+# Two bits of router documentation say something the code does not
+
+Both were found while reading the router for an unrelated change, and both predate it. Neither is on
+that change's code path, so they are delegated here rather than fixed inline.
+
+They are grouped in one spec on purpose: two small documentation fixes, one PR.
+
+## Finding 1: the context pool default is documented as off, and it is on
+
+`packages/router/src/types/general.ts` documents `maxContextPoolSize` as disabled by default:
+
+```ts
+  /**
+   * Maximum size of the CallContext pool for reduced memory allocations.
+   * ...
+   * Set to 0 to disable pooling.
+   * @default 0 (disabled)
+   */
+  maxContextPoolSize: number;
+```
+
+`packages/router/src/constants.ts:27` sets it to `100`:
+
+```ts
+export const DEFAULT_ROUTE_OPTIONS = {
+  ...
+  maxContextPoolSize: 100,
+  ...
+} as Readonly<RouterOptions>;
+```
+
+So pooling is ON by default and the type says it is off. Anyone reading the option to decide whether
+to turn pooling on gets the wrong answer, and pooling is not a cosmetic detail: it decides whether a
+`CallContext` object is reused between requests.
+
+`100` looks like the deliberate value (the pool code, `acquireCallContext` / `releaseCallContext` in
+`packages/router/src/callContext.ts`, is written to be the normal path), so the likely fix is the
+JSDoc, not the constant. Confirm which one is intended before editing, `git log` on both lines and
+the router's own docs are the places to look.
+
+Check whether the website repeats the wrong number too. `container/website/content/01.rpc/` does not
+appear to document this option today, but the whole `02.server/` dir is worth a grep for
+`maxContextPoolSize` and for "pool".
+
+## Finding 2: three dead in-page links on the routes page
+
+`container/website/content/01.rpc/02.server/01.routes.md` links to three anchors that have no
+matching heading anywhere on that page:
+
+```md
+line 80:  ... by passing the [`Handler`](#handler) as first parameter and [RouteOptions](#routedef) as second.
+line 145: The [`CallContext`](#callcontext) contains all the data related to the ongoing call.
+```
+
+The page's headings are `Jargon`, `Creating the Router`, `Defining a Route`, `Query and Mutation
+Handlers`, `Strict Types`, `Registering Routes`, `Naming Routes`, `Sanitize Params`, `Awaiting Every
+Step`, `Call Context`, `Sharing Data between MiddleFns and Routes`, `Context Data Factory`,
+`Defining a context data factory`. So all three links land nowhere: a reader clicking them stays put.
+
+They read like leftovers from an API-reference section that used to sit on this page. Decide per
+link whether to point it at a real destination (`#call-context` exists for the third one, and the
+`Handler` / `RouteOptions` types may be better served by a link to the relevant page section) or to
+drop the link and keep the plain text.
+
+While there, sweep the rest of `01.rpc/` for other in-page anchors with no heading behind them, so
+this is fixed once rather than one link at a time.
+
+## Done when
+
+- The context pool default is stated correctly in exactly one place, and nothing else repeats a
+  different number.
+- Every in-page link on the routes page reaches a heading that exists, and the sweep found no others
+  in `01.rpc/`.
+- If the fix changes anything a consumer reads, the website says the same thing as the code.
+
+## What shipped (2026-09-10)
+
+### Finding 1: the JSDoc was wrong, the constant was right
+
+`git log` on `packages/router/src/constants.ts` shows `maxContextPoolSize: 100` arriving with the
+file itself, and `dispatch.ts` reads the option as the normal path rather than an opt-in:
+
+```ts
+const usePooling = opts.maxContextPoolSize > 0;
+```
+
+So the value is deliberate and the tag was the drift. The tag now states it:
+
+```ts
+   * Set to 0 to disable pooling.
+-  * @default 0 (disabled)
++  * @default 100
+```
+
+The website never documented the option, and `01.rpc/` has no router-options table, so the JSDoc
+stays the single place the default is stated. Nothing else in the tree repeats a number for it.
+
+### Finding 2: five dead anchors, not three
+
+Sweeping `01.rpc/` for links pointing at a heading (in-page `#x` and cross-page `/page#x` alike)
+turned up five, two more than the spec listed. The rest of the content tree, `02.runtypes/` and
+`03.benchmarks/` included, is clean.
+
+| Link | Was | Now |
+| --- | --- | --- |
+| `02.server/01.routes.md:80` | `[`Handler`](#handler)` | plain `` `Handler` ``, no section to link to |
+| `02.server/01.routes.md:80` | `[RouteOptions](#routedef)` | plain `` `RouteOptions` ``, same reason |
+| `02.server/01.routes.md:145` | `[`CallContext`](#callcontext)` | plain `` `CallContext` ``, the link sat under the `Call Context` heading it meant to reach |
+| `02.server/02.middle-fns.md:50` | `` [`mion.rawMiddleFn`](#rawmiddleFndef) `` | plain `` `mion.rawMiddleFn` ``, same self-link |
+| `01.introduction/03.manual-install.md:9` | `/rpc/introduction/about-mion-rpc#automatic-serialization-validation` | `/runtypes/introduction/configuration#setting-options`, where the tsconfig entry is actually documented |
+
+The first two had no destination anywhere on the site: no page documents `Handler` or `RouteOptions`
+under a heading, so the link was dropped and the type name kept.
+
+One near miss worth recording: `about-mion-rpc.md#rpc-like` looks dead to a naive sweep because its
+headings sit indented inside MDC cards. It resolves, and both new checks index indented headings so
+they do not report it.
+
+### Guards, so neither comes back
+
+- `packages/devtools/test/website-links.test.ts` grew `website-anchor-links`: it indexes every
+  heading id the content tree publishes and resolves every `#anchor` link against the page it
+  targets. It joins the link checks already in that file, which skipped anchors entirely.
+- `packages/router/src/routerOptionsDocs.spec.ts` is new: it reads the `@default` tags straight out
+  of `types/general.ts` and compares each to `DEFAULT_ROUTE_OPTIONS`. Options the constant does not
+  declare are skipped, since their default is applied further down the pipeline (`encoder` is
+  resolved at build time). Both tests were confirmed to fail when the original bugs are put back.

--- a/packages/devtools/test/website-links.test.ts
+++ b/packages/devtools/test/website-links.test.ts
@@ -9,7 +9,10 @@
 //   - no in-site link goes through a domain (runtypes.pages.dev is redirect-only now,
 //     and an absolute mion.pages.dev link would silently skip the client router);
 //   - every in-site redirect target in public/_redirects resolves the same way, and
-//     the legacy runtypes.pages.dev redirects all point at mion.pages.dev.
+//     the legacy runtypes.pages.dev redirects all point at mion.pages.dev;
+//   - every '#anchor' link lands on a heading that exists on the page it targets.
+//     Nothing renders the site here either, so a link to a section that was renamed
+//     or removed leaves the reader where they stood, with no error anywhere.
 
 import {describe, it, expect} from 'vitest';
 import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
@@ -159,6 +162,108 @@ describe('website-internal-links', () => {
       )
       .map(({file, line, target}) => `${file}:${line} -> ${target}`);
     expect(unprefixed).toEqual([]);
+  });
+});
+
+// Anchor links: `](/page#x)`, `](#x)`, `to="/page#x"`, `href="#x"`. An empty path is the
+// page the link sits on. External URLs are left alone, only in-site targets are resolved.
+const ANCHOR_LINK = /(?:\]\(|to="|href=")((?!https?:)[^\s)"']*#[^\s)"']+)/g;
+
+// Headings are indexed with a leading-space tolerance: inside an MDC component the
+// markdown is indented by its nesting, and those headings still get an id.
+const HEADING = /^\s*#{1,6}\s+(.*)$/;
+
+/**
+ * The id Nuxt Content gives a heading: its rendered text, lowercased, with everything
+ * that is not a letter, a digit or a space dropped and the spaces turned into dashes.
+ */
+function headingSlug(text: string): string {
+  return text
+    .replace(/`/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\*\*|\*|__|_/g, '')
+    .replace(/<[^>]*>/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+/** Every heading id each page of the site publishes, keyed by the page's route. */
+function pageHeadings(): Map<string, Set<string>> {
+  const headings = new Map<string, Set<string>>();
+  const visit = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+        continue;
+      }
+      if (!name.endsWith('.md')) continue;
+      const slugs = new Set<string>();
+      let inFence = false;
+      for (const line of readFileSync(full, 'utf8').split('\n')) {
+        // A '#' inside a fenced block is a comment or a shell prompt, never a heading.
+        if (/^\s*```/.test(line)) inFence = !inFence;
+        else if (!inFence) {
+          const heading = HEADING.exec(line);
+          if (heading) slugs.add(headingSlug(heading[1]!));
+        }
+      }
+      headings.set(routeOfFile(posix.relative(REPO_ROOT, full.split('\\').join('/'))), slugs);
+    }
+  };
+  visit(CONTENT_DIR);
+  return headings;
+}
+
+function anchorLinks(): Link[] {
+  const links: Link[] = [];
+  const visit = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+        continue;
+      }
+      if (!name.endsWith('.md') && name !== '.navigation.yml') continue;
+      const rel = posix.relative(REPO_ROOT, full.split('\\').join('/'));
+      readFileSync(full, 'utf8')
+        .split('\n')
+        .forEach((text, i) => {
+          for (const match of text.matchAll(ANCHOR_LINK)) links.push({file: rel, line: i + 1, target: match[1]!});
+        });
+    }
+  };
+  visit(CONTENT_DIR);
+  return links;
+}
+
+describe('website-anchor-links', () => {
+  const headings = pageHeadings();
+  const links = anchorLinks();
+
+  it('finds the headings and anchor links it claims to check', () => {
+    expect(headings.get('/rpc/server/routes')?.has('call-context')).toBe(true);
+    expect(headings.get('/rpc/server/request-and-response')?.has('mionrequest')).toBe(true);
+    // A heading nested inside an MDC card still publishes an id.
+    expect(headings.get('/rpc/introduction/about-mion-rpc')?.has('rpc-like')).toBe(true);
+    expect(links.length).toBeGreaterThan(20);
+    expect(links.some(({target}) => target.startsWith('#'))).toBe(true);
+  });
+
+  it('lands every anchor link on a heading that exists', () => {
+    const broken = links
+      .map(({file, line, target}) => {
+        const [path, anchor] = target.split('#') as [string, string];
+        const route = path === '' ? routeOfFile(file) : withoutTrailingSlash(path);
+        const slugs = headings.get(route);
+        if (!slugs) return `${file}:${line} -> ${target} (no such page: ${route})`;
+        if (!slugs.has(anchor)) return `${file}:${line} -> ${target} (no heading '#${anchor}' on ${route})`;
+        return undefined;
+      })
+      .filter((entry) => entry !== undefined);
+    expect(broken).toEqual([]);
   });
 });
 

--- a/packages/router/src/routerOptionsDocs.spec.ts
+++ b/packages/router/src/routerOptionsDocs.spec.ts
@@ -1,0 +1,57 @@
+/* ########
+ * 2022 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+// The `@default` tag on a RouterOptions field is what a consumer reads to decide whether to set the
+// option at all, and nothing linked it to the value the router actually uses: `maxContextPoolSize`
+// was documented as `0 (disabled)` while DEFAULT_ROUTE_OPTIONS set it to 100, so the option that
+// decides whether a CallContext is reused between requests read as off while it was on.
+// This reads the tags straight out of the source and compares each one to the real default.
+
+import {describe, it, expect} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, join} from 'node:path';
+import {DEFAULT_ROUTE_OPTIONS} from './constants.ts';
+
+const GENERAL_TYPES = join(dirname(fileURLToPath(import.meta.url)), 'types/general.ts');
+
+// A JSDoc block followed by the field it documents: `/** ... */ name?: type;`
+const DOCUMENTED_FIELD = /\/\*\*([\s\S]*?)\*\/\s*(\w+)\??\s*:/g;
+
+/** Every `@default` tag in RouterOptions, keyed by the option it sits on. */
+function documentedDefaults(): Map<string, string> {
+  const defaults = new Map<string, string>();
+  const source = readFileSync(GENERAL_TYPES, 'utf8');
+  for (const [, comment, field] of source.matchAll(DOCUMENTED_FIELD)) {
+    const tag = /@default\s+(.*)/.exec(comment!);
+    if (tag) defaults.set(field!, tag[1]!.replace(/\*\/\s*$/, '').trim());
+  }
+  return defaults;
+}
+
+describe('router-options-documented-defaults', () => {
+  const documented = documentedDefaults();
+
+  it('finds the tags it claims to check', () => {
+    expect(documented.get('maxBodySize')).toBe('256000');
+    expect(documented.get('alwaysAwait')).toBe('true');
+    expect(documented.get('encoder')).toBe("{params: 'clone', return: 'clone'}");
+  });
+
+  it('documents the value DEFAULT_ROUTE_OPTIONS actually uses', () => {
+    // Options missing from the constant get their default further down the pipeline (`encoder` is
+    // resolved at build time), so only the ones the constant declares can be checked here.
+    const wrong: string[] = [];
+    for (const [option, tag] of documented) {
+      if (!(option in DEFAULT_ROUTE_OPTIONS)) continue;
+      const actual = DEFAULT_ROUTE_OPTIONS[option as keyof typeof DEFAULT_ROUTE_OPTIONS];
+      // The tag must be the bare literal: `0 (disabled)` is how the pool default drifted unnoticed.
+      if (tag !== JSON.stringify(actual)) wrong.push(`${option}: @default ${tag}, actual ${JSON.stringify(actual)}`);
+    }
+    expect(wrong).toEqual([]);
+  });
+});

--- a/packages/router/src/types/general.ts
+++ b/packages/router/src/types/general.ts
@@ -60,7 +60,7 @@ export interface RouterOptions<Req = any, ContextData extends Record<string, any
    * instead of creating new ones for each request. This can improve
    * performance in high-throughput scenarios by reducing GC pressure.
    * Set to 0 to disable pooling.
-   * @default 0 (disabled)
+   * @default 100
    */
   maxContextPoolSize: number;
   /**


### PR DESCRIPTION
Closed in favour of #261, which now carries this work as its second commit.

Splitting it made no sense once the pool review landed: the one line here that touched the router (`@default 0 (disabled)` → `@default 100` on `maxContextPoolSize`) is deleted outright by #261, which removes the option. Keeping two PRs meant a wasted line, an overlap in `packages/router/src/types/general.ts`, and a `docs/done/` record that would have described a fix that no longer exists.

Everything else here is unchanged in #261: the five dead documentation anchors, the `website-anchor-links` guard, and the `@default` versus `DEFAULT_ROUTE_OPTIONS` guard. The spec doc has been rewritten there to record the removal rather than the tag correction originally planned.