### PR TITLE
feat(router)!: remove the CallContext pool, fix six dead doc anchors

### DIFF
--- a/container/website/content/01.rpc/01.introduction/03.manual-install.md
+++ b/container/website/content/01.rpc/01.introduction/03.manual-install.md
@@ -6,7 +6,7 @@ toc: false
 
 ## Server Side
 
-Install the router and Configure `tsConfig.json` to enable [runTypes metadata.](/rpc/introduction/about-mion-rpc#automatic-serialization-validation)
+Install the router and Configure `tsConfig.json` to enable [runTypes metadata](/runtypes/introduction/configuration#setting-options).
 
 ```bash
 npm i @mionjs/core @mionjs/router

--- a/container/website/content/01.rpc/02.server/01.routes.md
+++ b/container/website/content/01.rpc/02.server/01.routes.md
@@ -77,7 +77,7 @@ A shared field that starts out empty needs a return type on the factory, `(): {u
 
 ## Defining a Route
 
-Routes are declared with `mion.route`, one of the helpers the router returns, by passing the [`Handler`](#handler) as first parameter and [RouteOptions](#routedef) as second.
+Routes are declared with `mion.route`, one of the helpers the router returns, by passing the `Handler` as first parameter and the `RouteOptions` as second.
 
 ::tip
 **Quick Tip:** Never assign a type to Routes/MiddleFns, instead always use the [`satisfies`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator){target="_blank"} operator.
@@ -142,7 +142,7 @@ const mion = createMionRouter({alwaysAwait: false});
 
 ## Call Context
 
-The [`CallContext`](#callcontext) contains all the data related to the ongoing call.
+The `CallContext` contains all the data related to the ongoing call.
 
 Most of the data within the CallContext is marked as read-only, this is because it is not recommended to modify the context manually. It is still possible to modify it (the context is not a real Immutable JS object). 
 

--- a/container/website/content/01.rpc/02.server/02.middle-fns.md
+++ b/container/website/content/01.rpc/02.server/02.middle-fns.md
@@ -47,7 +47,7 @@ Header values are limited to `string` types only. Complex data types cannot be s
 
 ## Raw Middleware functions
 
-In case we need to access the raw or native underlying request and response, we must use [`mion.rawMiddleFn`](#rawmiddleFndef).
+In case we need to access the raw or native underlying request and response, we must use `mion.rawMiddleFn`.
 
 These are functions that receive the `CallContext`, `RawRequest`, `RawResponse` and `RouterOptions`, but can't receive any remote parameters or return any data. 
 `Raw Middleware functions` can only modify the CallContext and return or throw errors.

--- a/container/website/content/01.rpc/06.devtools/02.vite.md
+++ b/container/website/content/01.rpc/06.devtools/02.vite.md
@@ -104,7 +104,7 @@ Set `server.build` and one `vite build` emits both halves of your app: the stati
 Both bundles are built from one program by one type resolver, so a type shared between your client and your API is compiled once and cannot drift between them. Leave `server.build` out and the build is untouched: only the client half is emitted.
 
 ::tip
-Building a standalone API with no client of its own? Leave the `server` block out entirely and use a plain library build. See [Server](#server) above.
+Building a standalone API with no client of its own? Leave the `server` block out entirely and use a plain library build. See [Server Only](#server-only) above.
 ::
 
 ### Client Tests

--- a/docs/done/router-docs-drift-pool-default-and-dead-anchors.md
+++ b/docs/done/router-docs-drift-pool-default-and-dead-anchors.md
@@ -1,0 +1,150 @@
+---
+type: docs
+spec: guidelines
+status: done
+created: 2026-09-10
+completed: 2026-09-10
+---
+
+# Two bits of router documentation say something the code does not
+
+Both were found while reading the router for an unrelated change, and both predate it. Neither is on
+that change's code path, so they are delegated here rather than fixed inline.
+
+They are grouped in one spec on purpose: two small documentation fixes, one PR.
+
+## Finding 1: the context pool default is documented as off, and it is on
+
+`packages/router/src/types/general.ts` documents `maxContextPoolSize` as disabled by default:
+
+```ts
+  /**
+   * Maximum size of the CallContext pool for reduced memory allocations.
+   * ...
+   * Set to 0 to disable pooling.
+   * @default 0 (disabled)
+   */
+  maxContextPoolSize: number;
+```
+
+`packages/router/src/constants.ts:27` sets it to `100`:
+
+```ts
+export const DEFAULT_ROUTE_OPTIONS = {
+  ...
+  maxContextPoolSize: 100,
+  ...
+} as Readonly<RouterOptions>;
+```
+
+So pooling is ON by default and the type says it is off. Anyone reading the option to decide whether
+to turn pooling on gets the wrong answer, and pooling is not a cosmetic detail: it decides whether a
+`CallContext` object is reused between requests.
+
+`100` looks like the deliberate value (the pool code, `acquireCallContext` / `releaseCallContext` in
+`packages/router/src/callContext.ts`, is written to be the normal path), so the likely fix is the
+JSDoc, not the constant. Confirm which one is intended before editing, `git log` on both lines and
+the router's own docs are the places to look.
+
+Check whether the website repeats the wrong number too. `container/website/content/01.rpc/` does not
+appear to document this option today, but the whole `02.server/` dir is worth a grep for
+`maxContextPoolSize` and for "pool".
+
+## Finding 2: three dead in-page links on the routes page
+
+`container/website/content/01.rpc/02.server/01.routes.md` links to three anchors that have no
+matching heading anywhere on that page:
+
+```md
+line 80:  ... by passing the [`Handler`](#handler) as first parameter and [RouteOptions](#routedef) as second.
+line 145: The [`CallContext`](#callcontext) contains all the data related to the ongoing call.
+```
+
+The page's headings are `Jargon`, `Creating the Router`, `Defining a Route`, `Query and Mutation
+Handlers`, `Strict Types`, `Registering Routes`, `Naming Routes`, `Sanitize Params`, `Awaiting Every
+Step`, `Call Context`, `Sharing Data between MiddleFns and Routes`, `Context Data Factory`,
+`Defining a context data factory`. So all three links land nowhere: a reader clicking them stays put.
+
+They read like leftovers from an API-reference section that used to sit on this page. Decide per
+link whether to point it at a real destination (`#call-context` exists for the third one, and the
+`Handler` / `RouteOptions` types may be better served by a link to the relevant page section) or to
+drop the link and keep the plain text.
+
+While there, sweep the rest of `01.rpc/` for other in-page anchors with no heading behind them, so
+this is fixed once rather than one link at a time.
+
+## Done when
+
+- The context pool default is stated correctly in exactly one place, and nothing else repeats a
+  different number.
+- Every in-page link on the routes page reaches a heading that exists, and the sweep found no others
+  in `01.rpc/`.
+- If the fix changes anything a consumer reads, the website says the same thing as the code.
+
+## What shipped (2026-09-10)
+
+### Finding 1: the option was removed, not the tag corrected
+
+The first read confirmed the spec's guess. `git log` shows `maxContextPoolSize: 100` arriving with
+`constants.ts` itself, and `dispatch.ts` read it as the normal path rather than an opt-in, so `100`
+was deliberate and the tag was the drift.
+
+Correcting the tag was the plan. Reviewing the pool before doing it changed the answer: the pool is
+gone instead, so the wrong tag went with it. Measured over 300k and 600k dispatches by counting GC
+cycles with a 1MB young generation, it saved ~10 bytes per request (6% of the router's garbage), no
+time (+0.6% / -0.6% / -3.4% at 1 / 50 / 200 concurrent) and no GC time, with zero major collections
+either way. Against that it wiped a released context and handed the shell to the next request, so a
+handler holding its context past the response read nulls and then another request's data. Removing
+the binary wire had already taken `releaseBinBuffer`, the one part of a context worth reusing.
+
+That same binary removal also left `binSerializer` and `releaseBinBuffer` behind in
+`createCallContext`, off the `MionResponse` type and hidden by an `as` cast, so the pooled and fresh
+paths returned two differently shaped response objects. Both lines went with the pool.
+
+`maxContextPoolSize` is now `?: never`, the same retirement `serializer` got, so the old key is a
+type error rather than silently ignored. `getContextPoolStats`, `clearContextPool`,
+`acquireCallContext` and `releaseCallContext` are gone; `createCallContext` is the one path.
+
+The website never documented the option and `01.rpc/` has no router-options table, so nothing else
+in the tree had to change.
+
+### Finding 2: five dead anchors, not three
+
+Sweeping `01.rpc/` for links pointing at a heading (in-page `#x` and cross-page `/page#x` alike)
+turned up five, two more than the spec listed. The rest of the content tree, `02.runtypes/` and
+`03.benchmarks/` included, is clean.
+
+| Link | Was | Now |
+| --- | --- | --- |
+| `02.server/01.routes.md:80` | `[`Handler`](#handler)` | plain `` `Handler` ``, no section to link to |
+| `02.server/01.routes.md:80` | `[RouteOptions](#routedef)` | plain `` `RouteOptions` ``, same reason |
+| `02.server/01.routes.md:145` | `[`CallContext`](#callcontext)` | plain `` `CallContext` ``, the link sat under the `Call Context` heading it meant to reach |
+| `02.server/02.middle-fns.md:50` | `` [`mion.rawMiddleFn`](#rawmiddleFndef) `` | plain `` `mion.rawMiddleFn` ``, same self-link |
+| `01.introduction/03.manual-install.md:9` | `/rpc/introduction/about-mion-rpc#automatic-serialization-validation` | `/runtypes/introduction/configuration#setting-options`, where the tsconfig entry is actually documented |
+
+The first two had no destination anywhere on the site: no page documents `Handler` or `RouteOptions`
+under a heading, so the link was dropped and the type name kept.
+
+One near miss worth recording: `about-mion-rpc.md#rpc-like` looks dead to a naive sweep because its
+headings sit indented inside MDC cards. It resolves, and the new check indexes indented headings so
+it does not report it.
+
+### Guards, so neither comes back
+
+- `packages/devtools/test/website-links.test.ts` grew `website-anchor-links`: it indexes every
+  heading id the content tree publishes and resolves every `#anchor` link against the page it
+  targets. It joins the link checks already in that file, which skipped anchors entirely.
+- `packages/router/src/callContext.spec.ts` is new: one context per request, still readable after
+  the response, untouched by later requests, and kept apart across 50 concurrent requests. Every one
+  of those failed while pooling was on.
+
+Each guard was confirmed to fail when the bug it covers is put back. The anchor check earned itself
+immediately: rebasing onto main it caught a sixth dead link, `See [Server](#server)` on the vite
+devtools page, written by a doc rewrite that landed while this branch was open. It now points at
+`#server-only`, the section that exists.
+
+A third guard was written and then dropped: a test comparing every `@default` tag in `RouterOptions`
+to `DEFAULT_ROUTE_OPTIONS`. It would have caught finding 1 (TypeScript checks the type, never the
+comment text, which is why the wrong tag survived), but the option it was written for no longer
+exists, and pinning the remaining tags was judged not worth an obligatory JSDoc edit on every
+default change.

--- a/packages/devtools/test/website-links.test.ts
+++ b/packages/devtools/test/website-links.test.ts
@@ -9,7 +9,10 @@
 //   - no in-site link goes through a domain (runtypes.pages.dev is redirect-only now,
 //     and an absolute mion.pages.dev link would silently skip the client router);
 //   - every in-site redirect target in public/_redirects resolves the same way, and
-//     the legacy runtypes.pages.dev redirects all point at mion.pages.dev.
+//     the legacy runtypes.pages.dev redirects all point at mion.pages.dev;
+//   - every '#anchor' link lands on a heading that exists on the page it targets.
+//     Nothing renders the site here either, so a link to a section that was renamed
+//     or removed leaves the reader where they stood, with no error anywhere.
 
 import {describe, it, expect} from 'vitest';
 import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
@@ -159,6 +162,108 @@ describe('website-internal-links', () => {
       )
       .map(({file, line, target}) => `${file}:${line} -> ${target}`);
     expect(unprefixed).toEqual([]);
+  });
+});
+
+// Anchor links: `](/page#x)`, `](#x)`, `to="/page#x"`, `href="#x"`. An empty path is the
+// page the link sits on. External URLs are left alone, only in-site targets are resolved.
+const ANCHOR_LINK = /(?:\]\(|to="|href=")((?!https?:)[^\s)"']*#[^\s)"']+)/g;
+
+// Headings are indexed with a leading-space tolerance: inside an MDC component the
+// markdown is indented by its nesting, and those headings still get an id.
+const HEADING = /^\s*#{1,6}\s+(.*)$/;
+
+/**
+ * The id Nuxt Content gives a heading: its rendered text, lowercased, with everything
+ * that is not a letter, a digit or a space dropped and the spaces turned into dashes.
+ */
+function headingSlug(text: string): string {
+  return text
+    .replace(/`/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\*\*|\*|__|_/g, '')
+    .replace(/<[^>]*>/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9 -]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+/** Every heading id each page of the site publishes, keyed by the page's route. */
+function pageHeadings(): Map<string, Set<string>> {
+  const headings = new Map<string, Set<string>>();
+  const visit = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+        continue;
+      }
+      if (!name.endsWith('.md')) continue;
+      const slugs = new Set<string>();
+      let inFence = false;
+      for (const line of readFileSync(full, 'utf8').split('\n')) {
+        // A '#' inside a fenced block is a comment or a shell prompt, never a heading.
+        if (/^\s*```/.test(line)) inFence = !inFence;
+        else if (!inFence) {
+          const heading = HEADING.exec(line);
+          if (heading) slugs.add(headingSlug(heading[1]!));
+        }
+      }
+      headings.set(routeOfFile(posix.relative(REPO_ROOT, full.split('\\').join('/'))), slugs);
+    }
+  };
+  visit(CONTENT_DIR);
+  return headings;
+}
+
+function anchorLinks(): Link[] {
+  const links: Link[] = [];
+  const visit = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        visit(full);
+        continue;
+      }
+      if (!name.endsWith('.md') && name !== '.navigation.yml') continue;
+      const rel = posix.relative(REPO_ROOT, full.split('\\').join('/'));
+      readFileSync(full, 'utf8')
+        .split('\n')
+        .forEach((text, i) => {
+          for (const match of text.matchAll(ANCHOR_LINK)) links.push({file: rel, line: i + 1, target: match[1]!});
+        });
+    }
+  };
+  visit(CONTENT_DIR);
+  return links;
+}
+
+describe('website-anchor-links', () => {
+  const headings = pageHeadings();
+  const links = anchorLinks();
+
+  it('finds the headings and anchor links it claims to check', () => {
+    expect(headings.get('/rpc/server/routes')?.has('call-context')).toBe(true);
+    expect(headings.get('/rpc/server/request-and-response')?.has('mionrequest')).toBe(true);
+    // A heading nested inside an MDC card still publishes an id.
+    expect(headings.get('/rpc/introduction/about-mion-rpc')?.has('rpc-like')).toBe(true);
+    expect(links.length).toBeGreaterThan(20);
+    expect(links.some(({target}) => target.startsWith('#'))).toBe(true);
+  });
+
+  it('lands every anchor link on a heading that exists', () => {
+    const broken = links
+      .map(({file, line, target}) => {
+        const [path, anchor] = target.split('#') as [string, string];
+        const route = path === '' ? routeOfFile(file) : withoutTrailingSlash(path);
+        const slugs = headings.get(route);
+        if (!slugs) return `${file}:${line} -> ${target} (no such page: ${route})`;
+        if (!slugs.has(anchor)) return `${file}:${line} -> ${target} (no heading '#${anchor}' on ${route})`;
+        return undefined;
+      })
+      .filter((entry) => entry !== undefined);
+    expect(broken).toEqual([]);
   });
 });
 

--- a/packages/router/src/callContext.spec.ts
+++ b/packages/router/src/callContext.spec.ts
@@ -1,0 +1,88 @@
+/* ########
+ * 2026 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+// The router used to reuse CallContext objects between requests, from a pool sized by
+// `maxContextPoolSize` (100 by default). Releasing a context wiped it, so a handler that kept the
+// context past its response read nulls, and once the shell was handed to the next request it read
+// that request's data instead. Pooling saved ~10 bytes of short-lived garbage per request and no
+// measurable time, so it was removed. These tests pin what that restored: one context per request,
+// still readable after the response.
+
+import {describe, it, expect, beforeEach} from 'vitest';
+import {createMionRouter, resetRouter} from './router.ts';
+import {dispatchRoute} from './dispatch.ts';
+import {headersFromRecord} from './lib/headers.ts';
+import type {CallContext} from './types/context.ts';
+
+type User = {name: string; surname: string};
+
+const call = (name: string): ReturnType<typeof dispatchRoute> =>
+  dispatchRoute('/echo', JSON.stringify({echo: [{name, surname: 'b'}]}), headersFromRecord({}), headersFromRecord({}), {});
+
+describe('call context per request', () => {
+  beforeEach(() => resetRouter());
+
+  /** Registers one echo route that records the context it ran with. */
+  const setup = (seen: CallContext[]): void => {
+    const mion = createMionRouter({skipClientRoutes: true, contextDataFactory: () => ({tag: 'none'})});
+    mion.initRoutes({
+      echo: mion.route((ctx, user: User): User => {
+        seen.push(ctx as CallContext);
+        (ctx.shared as {tag: string}).tag = user.name;
+        return user;
+      }),
+    });
+  };
+
+  it('gives every request its own context', async () => {
+    const seen: CallContext[] = [];
+    setup(seen);
+    await call('first');
+    await call('second');
+    expect(seen.length).toBe(2);
+    expect(seen[0]).not.toBe(seen[1]);
+    expect(seen[0]!.request).not.toBe(seen[1]!.request);
+    expect(seen[0]!.response).not.toBe(seen[1]!.response);
+  });
+
+  it('leaves the context readable after the response is returned', async () => {
+    const seen: CallContext[] = [];
+    setup(seen);
+    const response = await call('first');
+    const ctx = seen[0]!;
+    // Under pooling all three of these read null / undefined the moment dispatch returned.
+    expect(ctx.shared).toEqual({tag: 'first'});
+    expect(ctx.request.body).toEqual({echo: [{name: 'first', surname: 'b'}]});
+    expect(ctx.response).toBe(response);
+  });
+
+  it('keeps a held context untouched by later requests', async () => {
+    const seen: CallContext[] = [];
+    setup(seen);
+    await call('first');
+    await call('second');
+    // The first handler's context still describes the first request, not the second.
+    expect(seen[0]!.shared).toEqual({tag: 'first'});
+    expect(seen[1]!.shared).toEqual({tag: 'second'});
+  });
+
+  it('keeps concurrent requests apart', async () => {
+    const seen: CallContext[] = [];
+    setup(seen);
+    const names = Array.from({length: 50}, (unused, i) => `user${i}`);
+    await Promise.all(names.map((name) => call(name)));
+    expect(seen.length).toBe(50);
+    expect(new Set(seen).size).toBe(50);
+    expect(seen.map((ctx) => (ctx.shared as {tag: string}).tag).sort()).toEqual([...names].sort());
+  });
+
+  it('rejects the old pooling option at the type level', () => {
+    // @ts-expect-error the option is gone, so the key is not one RouterOptions knows
+    const old = (): unknown => createMionRouter({maxContextPoolSize: 100});
+    expect(typeof old).toBe('function');
+  });
+});

--- a/packages/router/src/callContext.ts
+++ b/packages/router/src/callContext.ts
@@ -6,39 +6,14 @@
  * ######## */
 
 import {getRouteExecutionChain} from './router.ts';
-import type {CallContext, MionRequest, MionHeaders, RawRequestBody, BatchExecutionResult} from './types/context.ts';
+import type {CallContext, MionHeaders, RawRequestBody, BatchExecutionResult} from './types/context.ts';
 import type {RouterOptions} from './types/general.ts';
-import {
-  Mutable,
-  StatusCodes,
-  SerializerModes,
-  SerializerCode,
-  FatalError,
-  MION_ROUTES,
-  MION_BATCH_PATH,
-  getRoutePath,
-} from '@mionjs/core';
+import {StatusCodes, SerializerModes, SerializerCode, FatalError, MION_ROUTES, MION_BATCH_PATH, getRoutePath} from '@mionjs/core';
 import {getBatchExecutionChain} from './batches.ts';
-
-// ############# POOL STATE #############
-
-let contextPool: CallContext[] = [];
-
-/** Get current pool statistics for monitoring */
-export function getContextPoolStats(): {poolSize: number} {
-  return {
-    poolSize: contextPool.length,
-  };
-}
-
-/** Clear the context pool - useful for testing */
-export function clearContextPool(): void {
-  contextPool = [];
-}
 
 // ############# CONTEXT CREATION #############
 
-/** Creates a new CallContext without pooling (original behavior) */
+/** Creates the CallContext for one request */
 export function createCallContext(
   path: string,
   opts: RouterOptions,
@@ -68,8 +43,6 @@ export function createCallContext(
       body: {},
       rawBody: '',
       serializer: SerializerModes.json,
-      binSerializer: undefined,
-      releaseBinBuffer: undefined,
     },
     executionChain,
     shared: opts.contextDataFactory ? opts.contextDataFactory() : {},
@@ -77,81 +50,6 @@ export function createCallContext(
     batchId,
     batchRouteIds,
   } as CallContext;
-}
-
-/** Acquires a CallContext from the pool or creates a new one */
-export function acquireCallContext(
-  usePooling: boolean,
-  path: string,
-  opts: RouterOptions,
-  reqRawBody: RawRequestBody,
-  rawRequest: unknown,
-  reqHeaders: MionHeaders,
-  respHeaders: MionHeaders,
-  reqBodyType?: SerializerCode,
-  urlQuery?: string
-): CallContext {
-  if (!usePooling) return createCallContext(path, opts, reqRawBody, rawRequest, reqHeaders, respHeaders, reqBodyType, urlQuery);
-  const pooledContext = contextPool.pop();
-  const transformedPath = opts.pathTransform?.(rawRequest, path) || path;
-
-  if (pooledContext) {
-    // Reuse the pooled context shell, but create fresh body objects
-    const ctx = pooledContext as Mutable<CallContext>;
-    ctx.path = transformedPath;
-    // Reset request - reuse the request object shell
-    const req = ctx.request as Mutable<MionRequest>;
-    req.headers = reqHeaders;
-    req.rawBody = reqRawBody;
-    req.bodyType = reqBodyType ?? getRequestBodyType(reqRawBody);
-    req.body = {}; // Must be fresh - handlers write to this
-    req.thrownErrors = undefined;
-    // The response is built here, not on release: it is handed to the platform adapter and must not
-    // be shared with the next request, so it is a fresh object either way.
-    ctx.response = {
-      statusCode: StatusCodes.OK,
-      hasErrors: false,
-      fatalError: undefined,
-      headers: respHeaders,
-      body: {}, // Must be fresh - handlers write to this
-      rawBody: '',
-      serializer: SerializerModes.json,
-    };
-    // Reset execution chain and batch ids
-    const {executionChain, batchId, batchRouteIds} = getExecutionChain(path, transformedPath, urlQuery, rawRequest, opts);
-    ctx.executionChain = executionChain;
-    ctx.batchId = batchId;
-    ctx.batchRouteIds = batchRouteIds;
-    // Reset shared data
-    ctx.shared = opts.contextDataFactory ? opts.contextDataFactory() : {};
-    // Reset urlQuery
-    ctx.urlQuery = urlQuery;
-    return ctx;
-  }
-  // No pooled context available, create new one
-  return createCallContext(path, opts, reqRawBody, rawRequest, reqHeaders, respHeaders, reqBodyType, urlQuery);
-}
-
-/** Releases a CallContext back to the pool for reuse */
-export function releaseCallContext(ctx: CallContext, maxPoolSize: number): void {
-  if (contextPool.length < maxPoolSize) {
-    const mutableCtx = ctx as Mutable<CallContext>;
-    const req = mutableCtx.request as Mutable<MionRequest>;
-    // Clear request data - safe to mutate since request is not returned to caller
-    req.rawBody = '';
-    req.body = null as any; // Will be set when context is acquired
-    req.thrownErrors = undefined;
-    // Drop the response instead of rebuilding it: the old one may still be referenced by the caller,
-    // so it must not be mutated, but every one of its fields was overwritten on acquire anyway.
-    // A fresh object is built there, once, rather than built here and rewritten field by field.
-    mutableCtx.response = undefined as any;
-    mutableCtx.shared = null as any;
-    mutableCtx.executionChain = null as any;
-    mutableCtx.batchId = undefined;
-    mutableCtx.batchRouteIds = undefined;
-    contextPool.push(ctx);
-  }
-  // If pool is full, let the context be garbage collected
 }
 
 // ############# HELPER FUNCTIONS #############

--- a/packages/router/src/constants.ts
+++ b/packages/router/src/constants.ts
@@ -23,8 +23,6 @@ export const DEFAULT_ROUTE_OPTIONS = {
   autoGenerateErrorId: false,
   /** client routes are initialized by default */
   skipClientRoutes: IS_TEST_ENV,
-  /** Context pooling size == 100 by default */
-  maxContextPoolSize: 100,
   /** Every chain step is awaited by default, so the chain keeps yielding between steps */
   alwaysAwait: true,
   /** Request body limit == 256KB by default */

--- a/packages/router/src/dispatch.ts
+++ b/packages/router/src/dispatch.ts
@@ -12,7 +12,7 @@ import {getRouterOptions, getAlwaysAwait} from './router.ts';
 import {Mutable, AnyObject, StatusCodes, HeadersSubset, SerializerCode} from '@mionjs/core';
 import {RpcError, FatalError, HandlerType, ValidationError, isNativeError} from '@mionjs/core';
 import {onExecutableError, markResponseFailed} from './lib/dispatchError.ts';
-import {acquireCallContext, releaseCallContext} from './callContext.ts';
+import {createCallContext} from './callContext.ts';
 
 /*
  * PERFORMANCE PROFILING NOTE:
@@ -35,30 +35,12 @@ export async function dispatchRoute<Req, Resp>(
   urlQuery?: string
 ): Promise<MionResponse> {
   const opts = getRouterOptions();
-  const usePooling = opts.maxContextPoolSize > 0;
-  const context = acquireCallContext(
-    usePooling,
-    path,
-    opts,
-    reqRawBody,
-    rawRequest,
-    reqHeaders,
-    respHeaders,
-    reqBodyType,
-    urlQuery
-  );
+  const context = createCallContext(path, opts, reqRawBody, rawRequest, reqHeaders, respHeaders, reqBodyType, urlQuery);
 
   // No catch: runExecutionChain handles every exception itself, and a catch that only re-rejects
-  // changes nothing. The finally stays, it is what hands a pooled context back on either path.
-  try {
-    await runExecutionChain(context, rawRequest, rawResponse, opts);
-    return context.response;
-  } finally {
-    // Release context back to pool if pooling is enabled
-    if (usePooling) {
-      releaseCallContext(context, opts.maxContextPoolSize);
-    }
-  }
+  // changes nothing.
+  await runExecutionChain(context, rawRequest, rawResponse, opts);
+  return context.response;
 }
 
 // ############# PRIVATE METHODS #############

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -47,7 +47,6 @@ import {getPublicApi, resetRemoteMethodsMetadata} from './lib/remoteMethods.ts';
 import {mionClientRoutes, mionClientMiddleFns, useOnDemandMetadataCaller} from './routes/client.routes.ts';
 import {mionErrorsRoutes} from './routes/errors.routes.ts';
 import {clearBatches} from './batches.ts';
-import {clearContextPool} from './callContext.ts';
 import {headersFn, middleFn, mutation, query, rawMiddleFn, route} from './lib/handlers.ts';
 import type {
   HeadersFnHelper,
@@ -150,7 +149,6 @@ export const resetRouter = () => {
   platformConfig = undefined;
   resetRemoteMethodsMetadata();
   resetRoutesCache();
-  clearContextPool();
   clearBatches();
   // Note: We intentionally do NOT call resetJitFnCaches() here because:
   // 1. JIT function caches are global and should persist across router resets

--- a/packages/router/src/types/general.ts
+++ b/packages/router/src/types/general.ts
@@ -55,15 +55,6 @@ export interface RouterOptions<Req = any, ContextData extends Record<string, any
   /** client routes are initialized by default */
   skipClientRoutes: boolean;
   /**
-   * Maximum size of the CallContext pool for reduced memory allocations.
-   * When set to a value > 0, CallContext objects are reused from a pool
-   * instead of creating new ones for each request. This can improve
-   * performance in high-throughput scenarios by reducing GC pressure.
-   * Set to 0 to disable pooling.
-   * @default 0 (disabled)
-   */
-  maxContextPoolSize: number;
-  /**
    * Await every step of the execution chain, even one that returned a plain value.
    * The await is what makes the chain yield between steps, so a long chain never holds the event
    * loop. It is honoured only when the router HAS something async in it: when every registered

--- a/packages/router/test/fuzz/security/httpFuzzRunner.ts
+++ b/packages/router/test/fuzz/security/httpFuzzRunner.ts
@@ -44,7 +44,7 @@ import {setNodeHttpOpts, startNodeServer, resetNodeHttpOpts} from '../../../../p
 
 // the test-server fixture module already created its own factory at import: clear the once-guard first
 resetRouter();
-const mion = createMionRouter({contextDataFactory: () => ({user: null}), maxBodySize: 64_000, maxContextPoolSize: 8});
+const mion = createMionRouter({contextDataFactory: () => ({user: null}), maxBodySize: 64_000});
 
 // ############# oracles #############
 


### PR DESCRIPTION
Rebased on `208d871`. Supersedes and closes #260, whose work is the second commit here. Two commits, one subject: reading `maxContextPoolSize` to fix its wrong `@default` tag is what led to reviewing the pool itself.

## Removing the pool

Every request now builds its own `CallContext`. Measured by counting GC cycles with a 1 MB young generation, so each scavenge is roughly 1 MB allocated. One config per process, repeated.

| | 300k requests | 600k requests | Per request |
| --- | --- | --- | --- |
| Pool on | 46 scavenges | 88 scavenges | ~154 bytes |
| Pool off | 49 scavenges | 94 scavenges | ~164 bytes |

The pool saved about **10 bytes per request, 6% of the router's garbage**, and that did not turn into anything you can feel:

- Zero major collections in 600k requests either way. Everything died young, the cheapest case for V8.
- GC time was the same: 54 ms on, 47 ms off per 600k requests.
- Throughput was the same or slightly worse: +0.6% / −0.6% / −3.4% at 1 / 50 / 200 concurrent requests.

The saving is small because the pooled path reused only two object shells and rebuilt everything expensive anyway (the response object, the parsed body, `shared`, the execution chain lookup). Under load it also drained: after 200 concurrent requests the pool held 100, so most requests allocated fresh regardless.

Against that, a released context was wiped and handed to the next request. A handler that kept its context past the response saw this:

```
pooling ON : shared=null  body=null  response=undefined
pooling OFF: shared={"tag":"first"}  body={"echo":[...]}  response=present
```

Any detached async work (a fire-and-forget logger, a metrics call) read nulls, then another request's data once the shell was reused. Nothing documented it, and nothing tested pooling at all.

Removing the binary wire in c38cc78 had already taken `releaseBinBuffer`, the one part of a context genuinely worth reusing.

### Stale fields that commit left behind

c38cc78 deleted these two from the pooled branch but left the identical pair in `createCallContext`, off the `MionResponse` type and hidden by the `as CallContext` cast:

```ts
      serializer: SerializerModes.json,
-     binSerializer: undefined,
-     releaseBinBuffer: undefined,
```

The effect was two different response shapes for the same route:

```
fresh-path response keys : statusCode,hasErrors,fatalError,headers,body,rawBody,serializer,binSerializer,releaseBinBuffer
pooled-path response keys: statusCode,hasErrors,fatalError,headers,body,rawBody,serializer
```

Both lines go with the pool.

### Breaking changes

`maxContextPoolSize` is deleted from `RouterOptions` outright, not left as a `?: never` slot, matching `208d871`: the presets do not carry migration machinery for options that no longer exist. Passing the key is still a type error, because an object literal with an unknown property fails the excess-property check; `callContext.spec.ts` pins that with a `@ts-expect-error`.

`getContextPoolStats` and `clearContextPool` are gone from the public surface, as are `acquireCallContext` and `releaseCallContext`. `createCallContext` is the one path.

## The documentation half (was #260)

Six links in `01.rpc/` pointed at headings that do not exist. Three sat directly under the section they were trying to reach.

| Link | Was | Now |
| --- | --- | --- |
| `02.server/01.routes.md:80` | ``[`Handler`](#handler)`` | plain `` `Handler` ``, no section to link to |
| `02.server/01.routes.md:80` | `[RouteOptions](#routedef)` | plain `` `RouteOptions` ``, same reason |
| `02.server/01.routes.md:145` | ``[`CallContext`](#callcontext)`` | plain `` `CallContext` ``, the link sat under the `Call Context` heading |
| `02.server/02.middle-fns.md:50` | ``[`mion.rawMiddleFn`](#rawmiddleFndef)`` | plain `` `mion.rawMiddleFn` ``, same self-link |
| `01.introduction/03.manual-install.md:9` | `about-mion-rpc#automatic-serialization-validation` | `/runtypes/introduction/configuration#setting-options`, where the tsconfig entry is documented |
| `06.devtools/02.vite.md:107` | `[Server](#server)` | `[Server Only](#server-only)`, the section that exists |

The sixth is new: it arrived with the doc rewrites in `93403ae` / `4999d31` and the guard below caught it on the rebase, which is the case for having the guard at all.

## Guards

- `packages/router/src/callContext.spec.ts` — one context per request, still readable after the response, untouched by later requests, and kept apart across 50 concurrent requests. All five failed while pooling was on.
- `packages/devtools/test/website-links.test.ts` grows `website-anchor-links` — indexes every heading id the content tree publishes (including headings nested inside MDC components) and resolves every `#anchor` against the page it targets. It joins the link checks already there, which dropped anchors on purpose. Nothing else covers this: the site is containerized so no build here renders it, the Nuxt config has no link checker and no `crawlLinks`, and the docs-site lane is gated behind the `website` label.

A third guard was written and dropped on review: a test pinning every `@default` tag in `RouterOptions` to `DEFAULT_ROUTE_OPTIONS`. It would have caught the original drift, since TypeScript checks the type and never the comment text, but it is not worth an obligatory JSDoc edit on every default change.

## Checks

- `pnpm run test:ci`: all 7 batches green on the rebased branch
- `pnpm run lint` (oxlint + eslint + typecheck): clean
- `pnpm run check-format`: clean
- Checked the diff against everything `208d871`, `2c32cbe` and `4999d31` removed: no removed file resurrected, and no added line names `assertNoRemovedOptions`, `failOnError`, `TS_RUNTYPES_BIN`, `middlewareMode` or `resolveRtBinary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVDi26zJDA9vojvT8Ksg28