### PR TITLE
fix(platform-aws): decode base64 encoded event bodies

### DIFF
--- a/container/website/content/01.rpc/05.platforms/03.aws-lambda.md
+++ b/container/website/content/01.rpc/05.platforms/03.aws-lambda.md
@@ -34,6 +34,10 @@ functions:
           path: '/{proxy+}'
 ```
 
+::tip
+When API Gateway or a Lambda Function URL delivers the body base64 encoded (`isBase64Encoded: true`, common with binary media types), the handler decodes it first, so the request is served exactly like a plain one and the `maxBodySize` limit measures the decoded text.
+::
+
 ## Configuration
 
 You can pass configuration options to `createAwsLambdaHandler`. Router options like `basePath` or `maxBodySize` are set once in `createMionRouter`, see [Creating the Router](/rpc/server/routes#creating-the-router).

--- a/docs/done/aws-base64-encoded-body.md
+++ b/docs/done/aws-base64-encoded-body.md
@@ -1,0 +1,32 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-11
+---
+
+# AWS adapter ignores isBase64Encoded
+
+## Intent
+
+`awsLambdaHandler` (`packages/platform-aws/src/awsLambda.ts:51`) takes the body as `rawRequest.body || ''` and always treats it as JSON text. API Gateway and Lambda Function URLs set `isBase64Encoded: true` and base64-encode the body for binary media types and for some proxy setups, so such a request reaches the router as base64 text and fails with `parsing-json-request-error` instead of being served. The only mention of the flag in the package is a fixture in `awsLambda.spec.ts:59` that sets it to `false`. Found while surveying how every adapter reads the request body; it predates the per-route size limit work.
+
+## Direction
+
+- When `isBase64Encoded` is true, decode the body (`Buffer.from(body, 'base64').toString()`) before it is handed to `createCallContext`; the size check in the router must see the decoded text.
+- Decide what a decoded body that is not valid UTF-8 JSON answers (the router's existing parse error is fine); a byte body has no encoder in mion (`getRequestBodyType` throws for `ArrayBuffer`), so do not pass bytes through.
+- Check the response side too: `reply()` in the same file must set `isBase64Encoded` only if it ever returns bytes (today it returns text, so probably a no-op, but confirm).
+- Pin with tests in `packages/platform-aws/src/awsLambda.spec.ts`: a base64 event round-trips the same as its plain twin, `isBase64Encoded: false` is unchanged, and a base64 body over the route limit is still a 413.
+- The implementer plans the details.
+
+## Done when
+
+A base64-encoded event is served exactly like the plain one, the flag is covered by paired tests, and the AWS platform page in `container/website/content/01.rpc/` mentions binary and base64 bodies in one line if the behaviour is user-visible.
+
+## Plan (approved 2026-09-11, delegated session)
+
+- `awsLambdaHandler` reads the body through a new `decodeEventBody(rawRequest)` helper: when `isBase64Encoded` is true and the body is non-empty it returns `Buffer.from(body, 'base64').toString()`, otherwise the body as-is. The decoded text is what reaches `decodeQueryBody` and `dispatchRoute`, so the router's `maxBodySize` check measures the decoded text.
+- A body that is not valid base64 or not JSON gets the router's existing `parsing-json-request-error`; `Buffer.from(..., 'base64')` never throws, so the adapter has no new error path.
+- Response side confirmed a no-op: `reply()` only ever returns text (`stringifyJson` or `JSON.stringify`), so `isBase64Encoded` stays at API Gateway's default (false). A comment records that.
+- Tests in `awsLambda.spec.ts`: a base64 event round-trips identical to its plain twin (two routes), `isBase64Encoded: false` is unchanged, a base64 body that is not JSON answers the parse error, and a decoded body over `maxBodySize` is a 413 while a short body whose base64 form alone is over the limit is served.
+- Docs: one tip on the AWS Lambda platform page.

--- a/packages/platform-aws/src/awsLambda.spec.ts
+++ b/packages/platform-aws/src/awsLambda.spec.ts
@@ -49,14 +49,20 @@ describe('serverless router', () => {
     context.response.headers.set('server', 'my-server');
   });
 
-  const getDefaultGatewayEvent = (body: string, path: string, httpMethod = 'POST', headers: APIGatewayProxyEventHeaders = {}) => {
+  const getDefaultGatewayEvent = (
+    body: string,
+    path: string,
+    httpMethod = 'POST',
+    headers: APIGatewayProxyEventHeaders = {},
+    isBase64Encoded = false
+  ) => {
     const context = {} as any;
     const event = createEvent('aws:apiGateway', {
       body,
       headers,
       multiValueHeaders: {},
       httpMethod,
-      isBase64Encoded: false,
+      isBase64Encoded,
       path,
       pathParameters: null,
       queryStringParameters: null,
@@ -150,6 +156,91 @@ describe('serverless router', () => {
       expect(headers['content-type']).toEqual('application/json; charset=utf-8');
       // expect(headers['content-length']).toEqual('47'); // AWS manages content-length automatically
       expect(headers['server']).toEqual('@mionjs');
+
+      // Restore router state for subsequent tests
+      resetAwsLambdaOpts();
+      resetRouter();
+      mion.initRoutes({changeUserName, getDate, updateHeaders});
+    });
+  });
+
+  describe('with a base64 encoded body (isBase64Encoded: true)', () => {
+    const toBase64 = (text: string) => Buffer.from(text).toString('base64');
+    const getBase64GatewayEvent = (body: string, path: string) => getDefaultGatewayEvent(toBase64(body), path, 'POST', {}, true);
+
+    beforeAll(async () => {
+      resetAwsLambdaOpts();
+      resetRouter();
+      mion.initRoutes({changeUserName, getDate, updateHeaders});
+    });
+
+    it('serves a base64 encoded event exactly like its plain twin', async () => {
+      const requestData = JSON.stringify({changeUserName: [{name: 'John', surname: 'Doe'}]});
+      const plain = getDefaultGatewayEvent(requestData, '/api/changeUserName');
+      const encoded = getBase64GatewayEvent(requestData, '/api/changeUserName');
+      expect(encoded.event.body).not.toEqual(plain.event.body);
+
+      const plainResponse = await awsLambdaHandler(plain.event, plain.context);
+      const encodedResponse = await awsLambdaHandler(encoded.event, encoded.context);
+
+      expect(encodedResponse).toEqual(plainResponse);
+      expect(JSON.parse(encodedResponse.body)).toEqual({changeUserName: {name: 'NewName', surname: 'Doe'}});
+      expect(encodedResponse.isBase64Encoded).toBeUndefined();
+    });
+
+    it('serves a base64 encoded event with Date objects like its plain twin', async () => {
+      const requestData = JSON.stringify({getDate: [{date: new Date('2022-04-10T02:13:00.000Z')}]});
+      const plain = getDefaultGatewayEvent(requestData, '/api/getDate');
+      const encoded = getBase64GatewayEvent(requestData, '/api/getDate');
+
+      const plainResponse = await awsLambdaHandler(plain.event, plain.context);
+      const encodedResponse = await awsLambdaHandler(encoded.event, encoded.context);
+
+      expect(encodedResponse).toEqual(plainResponse);
+      expect(JSON.parse(encodedResponse.body)).toEqual({getDate: {date: '2022-04-10T02:13:00.000Z'}});
+    });
+
+    it('leaves a plain body alone when isBase64Encoded is false', async () => {
+      const requestData = JSON.stringify({changeUserName: [{name: 'John', surname: 'Doe'}]});
+      const {event, context} = getDefaultGatewayEvent(requestData, '/api/changeUserName', 'POST', {}, false);
+
+      const awsResponse = await awsLambdaHandler(event, context);
+
+      expect(JSON.parse(awsResponse.body)).toEqual({changeUserName: {name: 'NewName', surname: 'Doe'}});
+    });
+
+    it('answers a base64 body that is not JSON with the parse error, never a crash', async () => {
+      const {event, context} = getBase64GatewayEvent('not json at all', '/api/changeUserName');
+
+      const awsResponse = await awsLambdaHandler(event, context);
+      const parsedResponse = JSON.parse(awsResponse.body);
+
+      expect(awsResponse.statusCode).toEqual(StatusCodes.UNEXPECTED_ERROR);
+      expect(parsedResponse[MION_ROUTES.thrownErrors]['mionDeserializeRequest'].type).toEqual('parsing-json-request-error');
+    });
+
+    it('a decoded body over maxBodySize is a 413', async () => {
+      resetAwsLambdaOpts();
+      resetRouter();
+      createMionRouter({contextDataFactory: getSharedData, basePath: 'api/', maxBodySize: 50}).initRoutes({changeUserName});
+      const requestData = JSON.stringify({changeUserName: [{name: 'John', surname: 'Doe'}]});
+      expect(requestData.length).toBeGreaterThan(50);
+      const {event, context} = getBase64GatewayEvent(requestData, '/api/changeUserName');
+
+      const awsResponse = await awsLambdaHandler(event, context);
+      const parsedResponse = JSON.parse(awsResponse.body);
+
+      expect(awsResponse.statusCode).toEqual(StatusCodes.PAYLOAD_TOO_LARGE);
+      expect(parsedResponse[MION_ROUTES.thrownErrors]['mionDeserializeRequest'].type).toEqual('request-payload-too-large');
+
+      // the limit measures the decoded text: a short body whose base64 form is over the limit is served
+      const shortData = JSON.stringify({changeUserName: [{name: 'J', surname: 'D'}]});
+      expect(shortData.length).toBeLessThanOrEqual(50);
+      expect(toBase64(shortData).length).toBeGreaterThan(50);
+      const short = getBase64GatewayEvent(shortData, '/api/changeUserName');
+      const shortResponse = await awsLambdaHandler(short.event, short.context);
+      expect(shortResponse.statusCode).toEqual(StatusCodes.OK);
+      expect(JSON.parse(shortResponse.body)).toEqual({changeUserName: {name: 'NewName', surname: 'D'}});
 
       // Restore router state for subsequent tests
       resetAwsLambdaOpts();

--- a/packages/platform-aws/src/awsLambda.ts
+++ b/packages/platform-aws/src/awsLambda.ts
@@ -47,7 +47,7 @@ export function createAwsLambdaHandler(options?: Partial<AwsLambdaOptions>) {
 }
 
 export async function awsLambdaHandler(rawRequest: APIGatewayEvent, awsContext: AwsContext): Promise<APIGatewayProxyResult> {
-  let rawBody: any = rawRequest.body || '';
+  let rawBody: any = decodeEventBody(rawRequest);
   const reqHeaders = headersFromRecord(rawRequest.headers as Record<string, string>);
   const rawRespHeaders: Record<string, string> = {
     server: '@mionjs',
@@ -89,6 +89,17 @@ export async function awsLambdaHandler(rawRequest: APIGatewayEvent, awsContext: 
 }
 
 // ############# PRIVATE METHODS #############
+
+/** API Gateway and Lambda Function URLs base64-encode the body (`isBase64Encoded: true`) for binary
+ *  media types and some proxy setups. The router only ever sees text, so the body is decoded here
+ *  and the router's `maxBodySize` check measures the decoded text, not the base64 wire form. A
+ *  body that is not base64 decodes to garbage and fails the router's JSON parse like any other bad
+ *  body: `Buffer.from(..., 'base64')` never throws. */
+function decodeEventBody(rawRequest: APIGatewayEvent): string {
+  const body = rawRequest.body || '';
+  if (!body || !rawRequest.isBase64Encoded) return body;
+  return Buffer.from(body, 'base64').toString();
+}
 
 /** One pass into one string: the filter/map/join chain built three arrays and two closures per
  *  invocation. Same output, `undefined` values skipped and both parts still percent-encoded. */
@@ -136,6 +147,7 @@ function reply(routeResponse: MionResponse, headers: MionHeaders): APIGatewayPro
       throw new Error(`Unknown body type: ${bodyType}`);
   }
 
+  // the body is always text, so `isBase64Encoded` stays at API Gateway's default (false)
   const resp: APIGatewayProxyResult = {
     statusCode: routeResponse.statusCode,
     headers: singleHeaders,


### PR DESCRIPTION
## What

`awsLambdaHandler` took `rawRequest.body` as JSON text and ignored `isBase64Encoded`. API Gateway and Lambda Function URLs base64-encode the body for binary media types and some proxy setups, so such a request reached the router as base64 text and failed with `parsing-json-request-error`.

## Change

- `awsLambdaHandler` now reads the body through `decodeEventBody`: when `isBase64Encoded` is true the body is decoded with `Buffer.from(body, 'base64').toString()` before it reaches the router, so the router's `maxBodySize` check measures the decoded text.
- A body that is not base64 or not JSON gets the router's existing parse error; `Buffer.from` never throws, so no new error path.
- Response side confirmed a no-op: `reply()` only returns text, so `isBase64Encoded` stays at API Gateway's default. A comment records that.

## Tests

`packages/platform-aws/src/awsLambda.spec.ts`:
- a base64 event round-trips identical to its plain twin (two routes)
- `isBase64Encoded: false` is unchanged
- a base64 body that is not JSON answers the parse error
- a decoded body over `maxBodySize` is a 413, and a short body whose base64 form alone exceeds the limit is still served

## Docs

One tip on the AWS Lambda platform page. The spec moved to `docs/done/`.

Gate: `pnpm run lint`, `pnpm run format`, platform-aws (11 tests) and router (349 tests) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKj9Ud8kbDhTKcfAUZHPkv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKj9Ud8kbDhTKcfAUZHPkv)_