### PR TITLE
chore(router): remove unused getRouteExecutableFromPath

### DIFF
--- a/docs/done/remove-get-route-executable-from-path.md
+++ b/docs/done/remove-get-route-executable-from-path.md
@@ -1,0 +1,31 @@
+---
+type: chore
+spec: guidelines
+status: done
+created: 2026-09-11
+---
+
+# Remove the unused getRouteExecutableFromPath
+
+## Intent
+
+`getRouteExecutableFromPath` (`packages/router/src/router.ts:304-311`) has no callers anywhere in the repo. Its last caller, the array-body reshape in the request deserializer, was replaced when the dispatch hot path was reworked, and the not-found fallback it duplicates now lives in `getExecutionChain` (`packages/router/src/callContext.ts:96-107`). Two copies of the same fallback drift; one already did (only one of them throws when the not-found route is missing). Found while tracing the not-found path; it predates the per-route size limit work.
+
+## Direction
+
+- Delete the function. It is reachable through the router's `export *` in `packages/router/index.ts`, so check the published API surface (`packages/router` d.ts, the docs under `container/website/content/01.rpc/`) and note the removal in the changelog if the repo tracks public removals there.
+- Search once more for dynamic uses (`getAnyExecutable`, string references in tests or examples) before deleting.
+- If a consumer-facing need for "route executable by path" turns out to exist, the replacement is `createCallContext(...).executionChain.methods[routeIndex]`, not a second lookup.
+- The implementer plans the details.
+
+## Done when
+
+The function is gone, lint and typecheck pass, no doc or example names it, and the router tests are green.
+
+## Plan (approved 2026-09-11)
+
+- Delete `getRouteExecutableFromPath` from `packages/router/src/router.ts`. A repo-wide search found no callers, no string references in tests or examples, and no mention under `container/website/content/`. The only other name is a historical note in a finished spec, which stays as history.
+- Public surface: the function reached consumers through the router's `export *`. The changelog is generated from commit subjects, so the `chore(router)` subject is the record of the removal. `createCallContext(...).executionChain.methods[routeIndex]` is the replacement for anyone who needs the route by path.
+- Tests: no new test, this is a pure deletion of dead code. The existing router suite proves the not-found path still works through `getExecutionChain`.
+- Docs: none, nothing user-facing named it.
+- Finish: lint, format, router tests, then move this spec to `docs/done/`.

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -288,15 +288,6 @@ export function shouldFullGenerateSpec(): boolean {
   return routerOptions.getPublicRoutesData || getENV('GENERATE_ROUTER_SPEC') === 'true';
 }
 
-export function getRouteExecutableFromPath(path: string): RouteMethod {
-  const executionChain = flatRouter.get(path);
-  if (!executionChain) {
-    // Return the not-found route executable
-    return getAnyExecutable(MION_ROUTES.notFound) as RouteMethod;
-  }
-  return executionChain.methods[executionChain.routeIndex] as RouteMethod;
-}
-
 // ############# PRIVATE METHODS #############
 
 /**


### PR DESCRIPTION
## What

Deletes `getRouteExecutableFromPath` from `packages/router/src/router.ts`. It had no callers anywhere in the repo. Its last caller went away when the dispatch hot path was reworked, and the not-found fallback it duplicated now lives in `getExecutionChain` in `callContext.ts`. Keeping two copies of the same fallback let them drift (only one of them threw when the not-found route was missing).

## Checks

- Repo-wide search: no callers, no string references in tests or examples, nothing under the website content tree names it.
- The function was reachable through the router's `export *`. Anyone who needs a route by path can use `createCallContext(...).executionChain.methods[routeIndex]` instead.
- No new test: pure removal of dead code. The existing router suite covers the not-found path through `getExecutionChain`.
- `pnpm run lint`, `pnpm run format`, and the router test suite (23 files, 349 tests) pass.
- Spec moved to `docs/done/remove-get-route-executable-from-path.md` with the plan recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01742yx7tTpKc8GGvPDCtC26

---
_Generated by [Claude Code](https://claude.ai/code/session_01742yx7tTpKc8GGvPDCtC26)_