### PR TITLE
Add review-pr skill: structured PR review with approved checklist

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -40,7 +40,7 @@ Picking the target:
 
 - Nothing named: current branch against `origin/main`.
 - A branch named: check it out or diff it, base still `origin/main`.
-- A PR number named: read it with `mcp__github__pull_request_read` for the description, the base branch and the open review threads, fetch the head branch, then diff locally against that PR's own base.
+- A PR number named: read it with `mcp__github__pull_request_read` for the description, the base branch, **the labels** and the open review threads, fetch the head branch, then diff locally against that PR's own base.
 
 Then **read the whole diff yourself**: `git diff <merge-base>..HEAD`. On a large change read it area by area. You cannot build a real list, or verify an agent's finding, about a change you have not seen.
 
@@ -50,7 +50,7 @@ Both are written before the code and often never updated. Treat them as claims t
 
 **Find the spec.** A `docs/todos/x.md -> docs/done/x.md` rename in the diff is this PR's spec. No rename means either the spec is still in `docs/todos/` or there is no spec. Read the whole file, including its metadata header, `Done when` and `Out of scope`.
 
-**Read the PR description**, when there is one.
+**Read the PR description and the labels**, when there is a PR. Labels gate CI lanes here, so note which ones are on it: a rule in the root CLAUDE.md says which the diff needs, and the G group checks the two against each other. Reviewing a branch with no PR yet turns that into an item for when it opens.
 
 Write the **intent**: one short paragraph saying what this change is meant to do. Every pass agent gets it, because a reviewer who does not know the goal reports noise.
 
@@ -180,6 +180,7 @@ Then ask what to do. The root CLAUDE.md sets where a finding goes: related ones 
 
 ## Gotchas
 
+- **Reviewing in the session that wrote the code? Compact or start fresh first.** Everything this skill needs is on disk: the diff, the spec, the CLAUDE.md files. Implementation context adds nothing and costs something, because the author's memory of why a line exists is exactly what talks a real finding out of the report in step 6. The passes run in clean subagents either way, so the bias lands on you, not them. A fresh session is better than a compact; a compact is better than neither.
 - **`origin/main..HEAD` is not the change.** Use the merge-base range from the script, or upstream commits show up as the author's work.
 - **A spec that reads perfectly can still be stalled.** It was written before the code. Check it against the diff, not against itself.
 - **The list is the deliverable of the first half.** If it is vague ("check the docs are good"), the pass will be vague too. Each item should be checkable against a line of the diff.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,26 +1,30 @@
 ---
 name: review-pr
-description: Review a pull request or a feature branch against this repo's own bar before it lands. Use whenever the user says review this PR, review my branch, review my changes, review the diff, look over what I changed, is this ready to open, pre-PR check, or names a PR number or branch to review, even if they do not use the word review. It diffs against the target branch, finds the todo spec behind the change and checks whether the spec and the PR description still match what shipped, reads every CLAUDE.md governing the changed files and verifies each rule, checks the website docs for plain language, hunts for new types and functions that could reuse something existing, looks for a simpler shape with fewer committed lines, and prunes comments that repeat the code. It reports findings and asks what to do next; it never edits code on its own.
+description: Review a pull request or a feature branch against this repo's own bar before it lands. Use whenever the user says review this PR, review my branch, review my changes, review the diff, look over what I changed, is this ready to open, pre-PR check, or names a PR number or branch to review, even if they do not use the word review. It scopes the diff against the target branch, finds the todo spec behind it and checks the spec and PR description still match what shipped, then builds a filtered review list from the CLAUDE.md rules that govern the changed files plus the general engineering checks, gets that list approved, and runs it as parallel passes covering docs language, type and code reuse, a simpler shape with fewer committed lines, comments, and test coverage. It reports findings against the approved list and asks what to do next; it never edits code on its own.
 ---
 
 # review-pr
 
-Judge a change the way this repo judges one. You produce a **findings report**, never edits. The user decides afterwards what gets fixed, delegated, posted or dropped.
+Judge a change the way this repo judges one. The review runs in two halves:
 
-Two things make this different from a generic code review, and they are where the real findings live:
+1. **Agree what to check.** Build one filtered list from the diff: the rules in the CLAUDE.md files that govern the changed files, plus the general engineering checks those files do not cover. Show it to the user and get it approved.
+2. **Check it.** Run the approved list as parallel passes, verify what they report, and answer against the list, item by item.
 
-- **Written rules beat taste.** Every changed file is governed by the CLAUDE.md files above it: root, package, sometimes a subdirectory. You read those files during the review and check the diff against what they say. They are the rulebook, so a finding that quotes one is blocking, and a finding that cannot is an opinion.
-- **Docs drift hardest.** The website content tree has its own written style rules, and it is the part that most often lands wordy, full of internals, or written in long chained clauses. Read the rules with the pages open, every time.
+You produce a **findings report**, never edits. The user decides afterwards what gets fixed, delegated, posted or dropped.
+
+Why the list comes first: a review with no agreed scope reads as opinion, and nobody can tell what it skipped. An approved list makes the review auditable, lets the user add or drop items before the work happens, and gives every finding a number to point at.
 
 The bias throughout: **fewer committed lines**. A new type that could be derived, a new file that could be three lines in an existing one, a comment that repeats the line under it. Each of those is a finding.
 
 ## The arc
 
-1. **Scope** the change: base ref, diff, governing CLAUDE.md files. One script does this.
-2. **Frame** it: the spec doc and the PR description against what the diff actually does.
-3. **Fan out** five review passes as parallel agents.
-4. **Verify** every reported finding against the diff. Drop what does not hold, merge duplicates.
-5. **Report**, then ask what to do.
+1. **Scope** the change. One script does it.
+2. **Frame** it: read the spec and the PR description, write the intent.
+3. **Build** the review list, filtered to what this diff actually contains.
+4. **Approve** it with the user.
+5. **Fan out** one pass per group, in parallel.
+6. **Verify** every reported finding against the diff.
+7. **Report** against the list, then ask what to do.
 
 ## Step 1 - Scope
 
@@ -30,7 +34,7 @@ bash .claude/skills/review-pr/scope.sh [base-ref]
 
 It prints the base ref and merge-base sha, the commits, the diff stat, the biggest added files, renames, the CLAUDE.md files governing each changed path, any spec doc in the diff, the website pages touched, and which source areas changed with no test change.
 
-**Pin the merge-base sha it prints.** Every pass diffs `<merge-base>..HEAD` so all five see one identical change set. Comparing against a moving `origin/main` makes upstream commits look like the author's work.
+**Pin the merge-base sha it prints.** Every pass diffs `<merge-base>..HEAD` so all of them see one identical change set. Comparing against a moving `origin/main` makes upstream commits look like the author's work.
 
 Picking the target:
 
@@ -38,83 +42,97 @@ Picking the target:
 - A branch named: check it out or diff it, base still `origin/main`.
 - A PR number named: read it with `mcp__github__pull_request_read` for the description, the base branch and the open review threads, fetch the head branch, then diff locally against that PR's own base.
 
-Then **read the whole diff yourself**: `git diff <merge-base>..HEAD`. On a large change read it area by area. You cannot verify an agent's finding about a change you have not seen.
+Then **read the whole diff yourself**: `git diff <merge-base>..HEAD`. On a large change read it area by area. You cannot build a real list, or verify an agent's finding, about a change you have not seen.
 
 ## Step 2 - Frame: the spec and the description
 
-Both of these are written before the code and often never updated. Treat them as claims to test, not as context to trust.
+Both are written before the code and often never updated. Treat them as claims to test, not as context to trust.
 
 **Find the spec.** A `docs/todos/x.md -> docs/done/x.md` rename in the diff is this PR's spec. No rename means either the spec is still in `docs/todos/` or there is no spec. Read the whole file, including its metadata header, `Done when` and `Out of scope`.
 
-Then compare it to the diff and name which case you have:
+**Read the PR description**, when there is one.
 
-| Case | What you should see | What to report |
+Write the **intent**: one short paragraph saying what this change is meant to do. Every pass agent gets it, because a reviewer who does not know the goal reports noise.
+
+Do not judge the spec yet. It becomes items `S1` to `S4` on the list, and you check those yourself in step 6, since you are the one who read it.
+
+## Step 3 - Build the review list
+
+Two sources, both filtered by what the diff actually contains.
+
+**Repo rules.** Read, in full, every CLAUDE.md the script named, most specific last since it wins on conflict. Where one points at another document for an area this diff touches, follow the pointer. Then pull out the rules that could apply to these changed files, one line each, quoting or closely paraphrasing the rule and naming the file it came from. Drop rules for areas the diff does not touch.
+
+Read the files each review. They change, and a remembered rule is a wrong rule.
+
+**General checks.** [global-checks.md](global-checks.md) is the catalog of what no CLAUDE.md covers: ordinary engineering review, grouped and triggered. Take the groups whose trigger the diff meets.
+
+Then merge both into one list, grouped by the pass that will check it:
+
+| Group | Covers | Pass owner |
 | --- | --- | --- |
-| Matches | Spec describes what shipped | Nothing |
-| Stalled | Spec plans approach A, diff does B | The spec has to describe what shipped before it moves |
-| Part shipped | Spec promises more than the diff does | Split it: the moved doc records what landed, the rest becomes a new spec |
-| Not moved | Spec still sits in `docs/todos/` | Check the repo's PR-readiness rules on this, then report against them |
-| Superseded | An old spec was linked instead of rewritten | Check the same rules, they cover this case |
-| Missing | Feature or fix with no spec | Not always wrong, but say so |
+| S | spec and description | you, in step 6 |
+| G | repo rules with no other home (dependencies, environment variables, commit and branch shape, build steps) | guidelines agent |
+| D | documentation | docs agent |
+| T | types and reuse | reuse agent |
+| A | architecture and size | architecture agent |
+| C | comments | comments agent |
+| B | behaviour and tests | behaviour agent |
 
-The root CLAUDE.md states the PR-readiness bar for specs. Read it during the review rather than working from this table alone: the table names the shapes, that file sets the requirement.
+Number every item inside its group and tag its source, so a finding can point at one line:
 
-**Test the PR description the same way.** Does it describe the diff in front of you, or an earlier version of it? A stale description is cheap to fix and misleads every reviewer, so it is worth reporting.
+```
+D4  [global]                                  Plain language, what it does for the reader
+D9  [repo: container/website/CLAUDE.md]       Titles are Title Case and name the job
+G2  [repo: CLAUDE.md]                         Every new env var is registered and MION_ prefixed
+```
 
-**Check what the script flags.** It lists new lines outside `docs/` that name a `docs/todos/` or `docs/done/` file. The root CLAUDE.md has a rule about that; read it and judge the hits against it.
+A repo rule about documentation goes in group D, not G, so the agent who reads the docs is the one who checks it.
 
-What comes out of this step is the **intent**: one short paragraph saying what this change is meant to do. Every pass agent gets it, because a reviewer who does not know the goal reports noise.
+## Step 4 - Get the list approved
 
-## Step 3 - Fan out the five passes
+Show the whole list with the intent above it, plus the groups you dropped and why ("no C group, the diff adds no comments"). Then ask, with AskUserQuestion: run it as is, add items, or drop a group. Fold in what they say and re-show only if they changed something structural.
 
-| Pass | The question it answers |
-| --- | --- |
-| guidelines | Does every changed file obey the CLAUDE.md files above it? |
-| docs | Does the changed documentation say it plainly, in this repo's voice? |
-| reuse | Can a new type or function be derived from, or replaced by, one that already exists? |
-| architecture | Is there a simpler obvious shape, with fewer new files and fewer committed lines? |
-| comments | Does each comment earn its line? |
+This is the moment the user steers the review. Take an added item seriously even when it is not in any rulebook: their attention is a signal about where this change is risky.
 
-Spawn all five in **one message** so they run at once, with `subagent_type: general-purpose`. The full brief for each one is in [passes.md](passes.md): read it and paste the brief verbatim into the agent prompt, filled in with the merge-base sha, the intent from step 2, the governing CLAUDE.md list, and the paths that pass should look at.
+## Step 5 - Fan out
 
-**No brief restates a repo rule, and neither should you when you write the prompts.** Each pass is told which files to read and asked to build its own checklist from them, then report that checklist with the findings. Rules change; a copy pasted into a prompt goes stale silently, and the checklist is also how you see what a pass actually covered.
+One agent per group that survived, all spawned in **one message** so they run at once, `subagent_type: general-purpose`. Briefs are in [passes.md](passes.md): paste the brief and fill in the merge-base sha, the intent, that group's approved items, and the paths.
 
-Tell every agent plainly: read only, no edits, no commits.
+Each agent gets **its items and nothing else**, checks them in order, and answers per item: pass, fail, or not applicable. Tell it to read the source file named on any repo item so it quotes the current text rather than your paraphrase. Tell it plainly: read only, no edits, no commits.
 
-Skip a pass only when the diff genuinely has nothing for it (no documentation changed, so no docs pass) and say in the report that you skipped it and why.
+## Step 6 - Verify before you report
 
-## Step 4 - Verify before you report
+You check the `S` items yourself here, against the diff you read in step 1.
 
-Agents over-report. They cite lines that moved, quote rules that do not exist, and call a rewrite "simpler" when it is only different. Nothing reaches the user unverified:
+For everything the agents send back, nothing reaches the user unverified:
 
 - **The citation is real.** Open the file at the cited line and check the code says what the finding claims.
-- **The rule is real.** A rule finding must quote the CLAUDE.md line it breaks, and you check that line exists. If it does not, either drop the finding or label it as taste.
-- **The simpler option is really simpler.** Count it: does the suggestion remove more lines than it adds, and does it keep the behaviour? If you cannot show that, drop it.
-- **It is in scope.** The change under review is the diff. A problem in untouched code is not this PR's finding; route it per step 5.
-- **Merge duplicates.** The reuse and architecture passes overlap by design, so the same finding often arrives twice. One entry, best evidence.
+- **The rule is real.** A repo-rule finding must quote the line it breaks, and you confirm that line exists. If it does not, drop it or relabel it as taste.
+- **The simpler option is really simpler.** Does it remove more lines than it adds, and keep the behaviour? If you cannot show that, drop it.
+- **It is in scope.** The change under review is the diff. A problem in untouched code is not this PR's finding; route it in step 7.
+- **Merge duplicates.** The T and A groups overlap by design, so one finding often arrives twice. One entry, best evidence.
+- **An off-list finding is welcome but marked.** An agent that spots something serious outside its items reports it flagged as off-list; keep it, and say it was not on the approved list.
 
-## Step 5 - Report, then ask
+## Step 7 - Report, then ask
 
-Keep the report short enough to act on. Order matters more than volume: a long list nobody reads is worse than the five findings that matter.
+Answer the list. Order by severity, not by group.
 
 ```markdown
 ## Review: <branch> vs <base>   (N files, +X / -Y lines)
 
 **Verdict:** ready to open | fix these first (K blocking)
-
-**Spec:** <spec file, and which case from step 2>
-**Description:** matches the diff | stale, says "<quote>" but the diff does <what>
+**List:** 34 items checked, 27 pass, 5 fail, 2 not applicable
 
 ### Blocking
-1. **<one line claim>** `path/file.ts:42`
-   Rule: <quoted CLAUDE.md line, with the file it comes from>
+1. **<one line claim>**  `path/file.ts:42`  [D9]
+   Rule: <quoted line, with the file it came from>
    Fix: <the concrete, small change>
 
 ### Worth fixing
 ### Nits
-
-### Passes skipped
-<pass, and why nothing applied>
+### Off-list
+### Checked clean
+<ids only, one line>
 ```
 
 Severity:
@@ -123,16 +141,17 @@ Severity:
 - **Worth fixing**: reuse, simplification, wordy or internals-heavy docs, a comment that no longer matches the code.
 - **Nit**: naming and phrasing where both readings are fine.
 
-Then ask what to do. The root CLAUDE.md sets the rule for where a finding goes: related ones are fixed in this change, unrelated ones go to a parallel background agent through the [delegate-finding skill](../delegate-finding/), and nothing is left as a note. Follow it rather than inventing a third lane. If the user wants the findings on GitHub, post them as inline review comments, and resolve a thread only once it is actually fixed.
+Then ask what to do. The root CLAUDE.md sets where a finding goes: related ones are fixed in this change, unrelated ones go to a parallel background agent through the [delegate-finding skill](../delegate-finding/), and nothing is left as a note. Follow it rather than inventing a third lane. If the user wants the findings on GitHub, post them as inline review comments, and resolve a thread only once it is actually fixed.
 
 ## What NOT to do
 
+- **Do not start reviewing before the list is approved.** Steps 1 to 3 are reading and listing.
 - **Do not edit code.** This skill reviews. Fixes happen after the user picks them, as their own step.
 - **Do not run tests, builds or lint, and never report a test result you did not produce.** This review reads. The host is often not bootstrapped, and "tests pass" from an unbuilt host is a false claim. Reporting that a behaviour has no test is fine and expected.
-- **Do not copy rules out of a CLAUDE.md into a prompt or a report as if they were fixed.** Point the pass at the file, let it read the current text, and quote what it found.
+- **Do not copy rules out of a CLAUDE.md into this skill.** They are read per review, quoted from the file, and cited by file name.
+- **Do not run a whole group the diff does not trigger.** An item that cannot apply produces noise and hides the ones that can.
 - **Do not report a rule you cannot quote.** Cite the line or call it taste.
 - **Do not review untouched code.** Being next to the diff is not being in it.
-- **Do not pad the report.** Ten nits hide one blocking finding.
 - **Do not rewrite the author's approach** when it works and breaks no rule. "I would have done it differently" is not a finding.
 - **Do not trust the spec or the PR description** as a description of the change. They are the thing being checked.
 
@@ -140,6 +159,7 @@ Then ask what to do. The root CLAUDE.md sets the rule for where a finding goes: 
 
 - **`origin/main..HEAD` is not the change.** Use the merge-base range from the script, or upstream commits show up as the author's work.
 - **A spec that reads perfectly can still be stalled.** It was written before the code. Check it against the diff, not against itself.
-- **The docs pass finds the most, and gets argued with the most.** Quote the guideline and show the rewritten sentence. A concrete shorter sentence wins an argument that adjectives do not.
-- **The docs style rules are written down and they move.** Read `container/website/CLAUDE.md` during the review, including the pages it says to read first, and check the diff against what it says today. The same file also says which tools may touch that tree, which decides what a valid fix looks like.
+- **The list is the deliverable of the first half.** If it is vague ("check the docs are good"), the pass will be vague too. Each item should be checkable against a line of the diff.
+- **The docs group finds the most and gets argued with the most.** Quote the guideline and show the rewritten sentence. A concrete shorter sentence wins an argument that adjectives do not.
+- **The docs style rules are written down and they move.** Read `container/website/CLAUDE.md` during the review, including the pages it says to read first. It also says which tools may touch that tree, which decides what a valid fix looks like.
 - **New file, low bar to question it.** Ask what it would cost to put the code in the file that already owns that job. Often nothing.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: review-pr
+description: Review a pull request or a feature branch against this repo's own bar before it lands. Use whenever the user says review this PR, review my branch, review my changes, review the diff, look over what I changed, is this ready to open, pre-PR check, or names a PR number or branch to review, even if they do not use the word review. It diffs against the target branch, finds the todo spec behind the change and checks whether the spec and the PR description still match what shipped, reads every CLAUDE.md governing the changed files and verifies each rule, checks the website docs for plain language, hunts for new types and functions that could reuse something existing, looks for a simpler shape with fewer committed lines, and prunes comments that repeat the code. It reports findings and asks what to do next; it never edits code on its own.
+---
+
+# review-pr
+
+Judge a change the way this repo judges one. You produce a **findings report**, never edits. The user decides afterwards what gets fixed, delegated, posted or dropped.
+
+Two things make this different from a generic code review, and they are where the real findings live:
+
+- **Written rules beat taste.** Every changed file is governed by the CLAUDE.md files above it: root, package, sometimes a subdirectory. Those carry hard rules (exact pinned deps, `MION_` env prefixes, test obligations, build discipline, no spec-doc references). A broken rule is a blocking finding with a citation, not an opinion.
+- **Docs drift hardest.** The website content tree has a strict plain-language style and it is the part that most often lands wordy, full of internals, or written in long chained clauses. Read it with the guidelines open, every time.
+
+The bias throughout: **fewer committed lines**. A new type that could be derived, a new file that could be three lines in an existing one, a comment that repeats the line under it. Each of those is a finding.
+
+## The arc
+
+1. **Scope** the change: base ref, diff, governing CLAUDE.md files. One script does this.
+2. **Frame** it: the spec doc and the PR description against what the diff actually does.
+3. **Fan out** five review passes as parallel agents.
+4. **Verify** every reported finding against the diff. Drop what does not hold, merge duplicates.
+5. **Report**, then ask what to do.
+
+## Step 1 - Scope
+
+```bash
+bash .claude/skills/review-pr/scope.sh [base-ref]
+```
+
+It prints the base ref and merge-base sha, the commits, the diff stat, the biggest added files, renames, the CLAUDE.md files governing each changed path, any spec doc in the diff, the website pages touched, and which source areas changed with no test change.
+
+**Pin the merge-base sha it prints.** Every pass diffs `<merge-base>..HEAD` so all five see one identical change set. Comparing against a moving `origin/main` makes upstream commits look like the author's work.
+
+Picking the target:
+
+- Nothing named: current branch against `origin/main`.
+- A branch named: check it out or diff it, base still `origin/main`.
+- A PR number named: read it with `mcp__github__pull_request_read` for the description, the base branch and the open review threads, fetch the head branch, then diff locally against that PR's own base.
+
+Then **read the whole diff yourself**: `git diff <merge-base>..HEAD`. On a large change read it area by area. You cannot verify an agent's finding about a change you have not seen.
+
+## Step 2 - Frame: the spec and the description
+
+Both of these are written before the code and often never updated. Treat them as claims to test, not as context to trust.
+
+**Find the spec.** A `docs/todos/x.md -> docs/done/x.md` rename in the diff is this PR's spec. No rename means either the spec is still in `docs/todos/` (the PR forgot to move it, which the repo's PR-readiness gate requires) or there is no spec. Read the whole file, including its metadata header, `Done when` and `Out of scope`.
+
+Then compare it to the diff and name which case you have:
+
+| Case | What you should see | The finding |
+| --- | --- | --- |
+| Matches | Spec describes what shipped | None |
+| Stalled | Spec plans approach A, diff does B | Spec must be rewritten to what shipped before it moves to `docs/done/` |
+| Part shipped | Spec promises more than the diff does | Split it: the moved doc records what landed, the rest becomes a new `docs/todos/` spec. There is no half-done lane |
+| Not moved | Spec still sits in `docs/todos/` | Blocking, the gate requires the `git mv` |
+| Superseded | An old spec was cross-referenced instead of rewritten | Rewrite from scratch, no "supersedes" note, no link |
+| Missing | Feature or fix with no spec | Not always wrong, but say so |
+
+**Test the PR description the same way.** Does it describe the diff in front of you, or an earlier version of it? A stale description is cheap to fix and misleads every reviewer, so it is worth reporting.
+
+**Check the reference ban.** The script lists new lines outside `docs/` that name a `docs/todos/` or `docs/done/` file. Root CLAUDE.md forbids those anywhere: doc, skill, workflow, test or code comment. Every hit is a finding.
+
+What comes out of this step is the **intent**: one short paragraph saying what this change is meant to do. Every pass agent gets it, because a reviewer who does not know the goal reports noise.
+
+## Step 3 - Fan out the five passes
+
+| Pass | The question it answers |
+| --- | --- |
+| guidelines | Does every changed file obey the CLAUDE.md files above it? |
+| docs | Does the changed documentation say it plainly, in this repo's voice? |
+| reuse | Can a new type or function be derived from, or replaced by, one that already exists? |
+| architecture | Is there a simpler obvious shape, with fewer new files and fewer committed lines? |
+| comments | Does each comment earn its line? |
+
+Spawn all five in **one message** so they run at once, with `subagent_type: general-purpose`. The full brief for each one is in [passes.md](passes.md): read it and paste the brief verbatim into the agent prompt, filled in with the merge-base sha, the intent from step 2, the governing CLAUDE.md list, and the paths that pass should look at.
+
+Tell every agent plainly: read only, no edits, no commits.
+
+Skip a pass only when the diff genuinely has nothing for it (no documentation changed, so no docs pass) and say in the report that you skipped it and why.
+
+## Step 4 - Verify before you report
+
+Agents over-report. They cite lines that moved, quote rules that do not exist, and call a rewrite "simpler" when it is only different. Nothing reaches the user unverified:
+
+- **The citation is real.** Open the file at the cited line and check the code says what the finding claims.
+- **The rule is real.** A rule finding must quote the CLAUDE.md line it breaks. If you cannot find that line, it is your opinion, so either drop it or label it as taste.
+- **The simpler option is really simpler.** Count it: does the suggestion remove more lines than it adds, and does it keep the behaviour? If you cannot show that, drop it.
+- **It is in scope.** The change under review is the diff. A problem in untouched code is not this PR's finding; route it per step 5.
+- **Merge duplicates.** The reuse and architecture passes overlap by design, so the same finding often arrives twice. One entry, best evidence.
+
+## Step 5 - Report, then ask
+
+Keep the report short enough to act on. Order matters more than volume: a long list nobody reads is worse than the five findings that matter.
+
+```markdown
+## Review: <branch> vs <base>   (N files, +X / -Y lines)
+
+**Verdict:** ready to open | fix these first (K blocking)
+
+**Spec:** <spec file, and which case from step 2>
+**Description:** matches the diff | stale, says "<quote>" but the diff does <what>
+
+### Blocking
+1. **<one line claim>** `path/file.ts:42`
+   Rule: <quoted CLAUDE.md line, with the file it comes from>
+   Fix: <the concrete, small change>
+
+### Worth fixing
+### Nits
+
+### Passes skipped
+<pass, and why nothing applied>
+```
+
+Severity:
+
+- **Blocking**: breaks a written rule, breaks behaviour, a fix or feature with no test, spec or docs contradicting the code, docs missing for a user-visible change.
+- **Worth fixing**: reuse, simplification, wordy or internals-heavy docs, a comment that no longer matches the code.
+- **Nit**: naming and phrasing where both readings are fine.
+
+Then ask what to do, and follow the repo's own finding rule when they answer:
+
+- **Related to this change**: fix it here, in this PR, with its own commit and test. Size buys no exemption.
+- **Unrelated**: hand it to a parallel background agent with the [delegate-finding skill](../delegate-finding/). Never a backlog entry.
+- **Post to GitHub**: inline review comments on the PR. Resolve a thread only once it is actually fixed; push-backs and explanations stay open for the reviewer to close.
+
+## What NOT to do
+
+- **Do not edit code.** This skill reviews. Fixes happen after the user picks them, as their own step.
+- **Do not run tests, builds or lint, and never report a test result you did not produce.** This review reads. The host is often not bootstrapped, and "tests pass" from an unbuilt host is a false claim. Reporting that a behaviour has no test is fine and expected.
+- **Do not report a rule you cannot quote.** Cite the CLAUDE.md line or call it taste.
+- **Do not review untouched code.** Being next to the diff is not being in it.
+- **Do not pad the report.** Ten nits hide one blocking finding.
+- **Do not rewrite the author's approach** when it works and breaks no rule. "I would have done it differently" is not a finding.
+- **Do not trust the spec or the PR description** as a description of the change. They are the thing being checked.
+
+## Gotchas
+
+- **`origin/main..HEAD` is not the change.** Use the merge-base range from the script, or upstream commits show up as the author's work.
+- **A spec that reads perfectly can still be stalled.** It was written before the code. Check it against the diff, not against itself.
+- **The docs pass finds the most, and gets argued with the most.** Quote the guideline and show the rewritten sentence. A concrete shorter sentence wins an argument that adjectives do not.
+- **Dashes are a docs rule, not a style preference.** No em dash, en dash, `--` or a spaced `-` chaining clauses in `container/website/content/`. Hyphenated words and dashes inside code or flags are fine.
+- **New file, low bar to question it.** Ask what it would cost to put the code in the file that already owns that job. Often nothing.
+- **`pnpm run format` never touches the website tree.** If a docs finding is about formatting, the fix is by hand in prose, never a formatter run.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -58,15 +58,34 @@ Do not judge the spec yet. It becomes items `S1` to `S4` on the list, and you ch
 
 ## Step 3 - Build the review list
 
-Two sources, both filtered by what the diff actually contains.
+The list is built fresh every review, from the files in front of you. Nothing is
+carried over from a previous review or from memory.
 
-**Repo rules.** Read, in full, every CLAUDE.md the script named, most specific last since it wins on conflict. Where one points at another document for an area this diff touches, follow the pointer. Then pull out the rules that could apply to these changed files, one line each, quoting or closely paraphrasing the rule and naming the file it came from. Drop rules for areas the diff does not touch.
+**Start with the CLAUDE.md files. They are the guidelines.** Read every one the
+script named, in full, for every review, most specific last since it wins on
+conflict. They evolve, so a rule you remember is a rule you are getting wrong.
+Where one points at another document for an area this diff touches, follow the
+pointer and read that too.
 
-Read the files each review. They change, and a remembered rule is a wrong rule.
+Turn them into items: the rules that could apply to these changed files, one line
+each, quoting or closely paraphrasing the rule and naming the file it came from.
+Drop rules for areas the diff does not touch, and say which areas you dropped.
+Show the count per file so the coverage is visible:
 
-**General checks.** [global-checks.md](global-checks.md) is the catalog of what no CLAUDE.md covers: ordinary engineering review, grouped and triggered. Take the groups whose trigger the diff meets.
+```
+CLAUDE.md                        14 rules apply
+packages/router/CLAUDE.md         4 rules apply
+container/website/CLAUDE.md       9 rules apply   (docs changed)
+```
 
-Then merge both into one list, grouped by the pass that will check it:
+**Then top up from the catalog.** [global-checks.md](global-checks.md) holds the
+ordinary engineering checks that no CLAUDE.md covers, grouped and triggered. Add
+the groups whose trigger the diff meets. It is the smaller half and it never
+substitutes for reading the CLAUDE.md files: where a catalog item and a repo rule
+say the same thing, keep the repo rule and drop the catalog item, because the
+repo rule is quotable and current.
+
+Merge both into one list, grouped by the pass that will check it:
 
 | Group | Covers | Pass owner |
 | --- | --- | --- |
@@ -78,7 +97,8 @@ Then merge both into one list, grouped by the pass that will check it:
 | C | comments | comments agent |
 | B | behaviour and tests | behaviour agent |
 
-Number every item inside its group and tag its source, so a finding can point at one line:
+Number every item inside its group and tag its source, so a finding can point at
+one line:
 
 ```
 D4  [global]                                  Plain language, what it does for the reader
@@ -86,7 +106,8 @@ D9  [repo: container/website/CLAUDE.md]       Titles are Title Case and name the
 G2  [repo: CLAUDE.md]                         Every new env var is registered and MION_ prefixed
 ```
 
-A repo rule about documentation goes in group D, not G, so the agent who reads the docs is the one who checks it.
+A repo rule about documentation goes in group D, not G, so the agent who reads
+the docs is the one who checks it.
 
 ## Step 4 - Get the list approved
 
@@ -148,6 +169,8 @@ Then ask what to do. The root CLAUDE.md sets where a finding goes: related ones 
 - **Do not start reviewing before the list is approved.** Steps 1 to 3 are reading and listing.
 - **Do not edit code.** This skill reviews. Fixes happen after the user picks them, as their own step.
 - **Do not run tests, builds or lint, and never report a test result you did not produce.** This review reads. The host is often not bootstrapped, and "tests pass" from an unbuilt host is a false claim. Reporting that a behaviour has no test is fine and expected.
+- **Do not build the list from the catalog alone.** The CLAUDE.md files are the guidelines; the catalog only covers what they do not.
+- **Do not skip re-reading a CLAUDE.md** because you read it earlier in this session or in a previous review. They change, and the list is only as current as the read behind it.
 - **Do not copy rules out of a CLAUDE.md into this skill.** They are read per review, quoted from the file, and cited by file name.
 - **Do not run a whole group the diff does not trigger.** An item that cannot apply produces noise and hides the ones that can.
 - **Do not report a rule you cannot quote.** Cite the line or call it taste.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -9,8 +9,8 @@ Judge a change the way this repo judges one. You produce a **findings report**, 
 
 Two things make this different from a generic code review, and they are where the real findings live:
 
-- **Written rules beat taste.** Every changed file is governed by the CLAUDE.md files above it: root, package, sometimes a subdirectory. Those carry hard rules (exact pinned deps, `MION_` env prefixes, test obligations, build discipline, no spec-doc references). A broken rule is a blocking finding with a citation, not an opinion.
-- **Docs drift hardest.** The website content tree has a strict plain-language style and it is the part that most often lands wordy, full of internals, or written in long chained clauses. Read it with the guidelines open, every time.
+- **Written rules beat taste.** Every changed file is governed by the CLAUDE.md files above it: root, package, sometimes a subdirectory. You read those files during the review and check the diff against what they say. They are the rulebook, so a finding that quotes one is blocking, and a finding that cannot is an opinion.
+- **Docs drift hardest.** The website content tree has its own written style rules, and it is the part that most often lands wordy, full of internals, or written in long chained clauses. Read the rules with the pages open, every time.
 
 The bias throughout: **fewer committed lines**. A new type that could be derived, a new file that could be three lines in an existing one, a comment that repeats the line under it. Each of those is a finding.
 
@@ -44,22 +44,24 @@ Then **read the whole diff yourself**: `git diff <merge-base>..HEAD`. On a large
 
 Both of these are written before the code and often never updated. Treat them as claims to test, not as context to trust.
 
-**Find the spec.** A `docs/todos/x.md -> docs/done/x.md` rename in the diff is this PR's spec. No rename means either the spec is still in `docs/todos/` (the PR forgot to move it, which the repo's PR-readiness gate requires) or there is no spec. Read the whole file, including its metadata header, `Done when` and `Out of scope`.
+**Find the spec.** A `docs/todos/x.md -> docs/done/x.md` rename in the diff is this PR's spec. No rename means either the spec is still in `docs/todos/` or there is no spec. Read the whole file, including its metadata header, `Done when` and `Out of scope`.
 
 Then compare it to the diff and name which case you have:
 
-| Case | What you should see | The finding |
+| Case | What you should see | What to report |
 | --- | --- | --- |
-| Matches | Spec describes what shipped | None |
-| Stalled | Spec plans approach A, diff does B | Spec must be rewritten to what shipped before it moves to `docs/done/` |
-| Part shipped | Spec promises more than the diff does | Split it: the moved doc records what landed, the rest becomes a new `docs/todos/` spec. There is no half-done lane |
-| Not moved | Spec still sits in `docs/todos/` | Blocking, the gate requires the `git mv` |
-| Superseded | An old spec was cross-referenced instead of rewritten | Rewrite from scratch, no "supersedes" note, no link |
+| Matches | Spec describes what shipped | Nothing |
+| Stalled | Spec plans approach A, diff does B | The spec has to describe what shipped before it moves |
+| Part shipped | Spec promises more than the diff does | Split it: the moved doc records what landed, the rest becomes a new spec |
+| Not moved | Spec still sits in `docs/todos/` | Check the repo's PR-readiness rules on this, then report against them |
+| Superseded | An old spec was linked instead of rewritten | Check the same rules, they cover this case |
 | Missing | Feature or fix with no spec | Not always wrong, but say so |
+
+The root CLAUDE.md states the PR-readiness bar for specs. Read it during the review rather than working from this table alone: the table names the shapes, that file sets the requirement.
 
 **Test the PR description the same way.** Does it describe the diff in front of you, or an earlier version of it? A stale description is cheap to fix and misleads every reviewer, so it is worth reporting.
 
-**Check the reference ban.** The script lists new lines outside `docs/` that name a `docs/todos/` or `docs/done/` file. Root CLAUDE.md forbids those anywhere: doc, skill, workflow, test or code comment. Every hit is a finding.
+**Check what the script flags.** It lists new lines outside `docs/` that name a `docs/todos/` or `docs/done/` file. The root CLAUDE.md has a rule about that; read it and judge the hits against it.
 
 What comes out of this step is the **intent**: one short paragraph saying what this change is meant to do. Every pass agent gets it, because a reviewer who does not know the goal reports noise.
 
@@ -75,6 +77,8 @@ What comes out of this step is the **intent**: one short paragraph saying what t
 
 Spawn all five in **one message** so they run at once, with `subagent_type: general-purpose`. The full brief for each one is in [passes.md](passes.md): read it and paste the brief verbatim into the agent prompt, filled in with the merge-base sha, the intent from step 2, the governing CLAUDE.md list, and the paths that pass should look at.
 
+**No brief restates a repo rule, and neither should you when you write the prompts.** Each pass is told which files to read and asked to build its own checklist from them, then report that checklist with the findings. Rules change; a copy pasted into a prompt goes stale silently, and the checklist is also how you see what a pass actually covered.
+
 Tell every agent plainly: read only, no edits, no commits.
 
 Skip a pass only when the diff genuinely has nothing for it (no documentation changed, so no docs pass) and say in the report that you skipped it and why.
@@ -84,7 +88,7 @@ Skip a pass only when the diff genuinely has nothing for it (no documentation ch
 Agents over-report. They cite lines that moved, quote rules that do not exist, and call a rewrite "simpler" when it is only different. Nothing reaches the user unverified:
 
 - **The citation is real.** Open the file at the cited line and check the code says what the finding claims.
-- **The rule is real.** A rule finding must quote the CLAUDE.md line it breaks. If you cannot find that line, it is your opinion, so either drop it or label it as taste.
+- **The rule is real.** A rule finding must quote the CLAUDE.md line it breaks, and you check that line exists. If it does not, either drop the finding or label it as taste.
 - **The simpler option is really simpler.** Count it: does the suggestion remove more lines than it adds, and does it keep the behaviour? If you cannot show that, drop it.
 - **It is in scope.** The change under review is the diff. A problem in untouched code is not this PR's finding; route it per step 5.
 - **Merge duplicates.** The reuse and architecture passes overlap by design, so the same finding often arrives twice. One entry, best evidence.
@@ -119,17 +123,14 @@ Severity:
 - **Worth fixing**: reuse, simplification, wordy or internals-heavy docs, a comment that no longer matches the code.
 - **Nit**: naming and phrasing where both readings are fine.
 
-Then ask what to do, and follow the repo's own finding rule when they answer:
-
-- **Related to this change**: fix it here, in this PR, with its own commit and test. Size buys no exemption.
-- **Unrelated**: hand it to a parallel background agent with the [delegate-finding skill](../delegate-finding/). Never a backlog entry.
-- **Post to GitHub**: inline review comments on the PR. Resolve a thread only once it is actually fixed; push-backs and explanations stay open for the reviewer to close.
+Then ask what to do. The root CLAUDE.md sets the rule for where a finding goes: related ones are fixed in this change, unrelated ones go to a parallel background agent through the [delegate-finding skill](../delegate-finding/), and nothing is left as a note. Follow it rather than inventing a third lane. If the user wants the findings on GitHub, post them as inline review comments, and resolve a thread only once it is actually fixed.
 
 ## What NOT to do
 
 - **Do not edit code.** This skill reviews. Fixes happen after the user picks them, as their own step.
 - **Do not run tests, builds or lint, and never report a test result you did not produce.** This review reads. The host is often not bootstrapped, and "tests pass" from an unbuilt host is a false claim. Reporting that a behaviour has no test is fine and expected.
-- **Do not report a rule you cannot quote.** Cite the CLAUDE.md line or call it taste.
+- **Do not copy rules out of a CLAUDE.md into a prompt or a report as if they were fixed.** Point the pass at the file, let it read the current text, and quote what it found.
+- **Do not report a rule you cannot quote.** Cite the line or call it taste.
 - **Do not review untouched code.** Being next to the diff is not being in it.
 - **Do not pad the report.** Ten nits hide one blocking finding.
 - **Do not rewrite the author's approach** when it works and breaks no rule. "I would have done it differently" is not a finding.
@@ -140,6 +141,5 @@ Then ask what to do, and follow the repo's own finding rule when they answer:
 - **`origin/main..HEAD` is not the change.** Use the merge-base range from the script, or upstream commits show up as the author's work.
 - **A spec that reads perfectly can still be stalled.** It was written before the code. Check it against the diff, not against itself.
 - **The docs pass finds the most, and gets argued with the most.** Quote the guideline and show the rewritten sentence. A concrete shorter sentence wins an argument that adjectives do not.
-- **Dashes are a docs rule, not a style preference.** No em dash, en dash, `--` or a spaced `-` chaining clauses in `container/website/content/`. Hyphenated words and dashes inside code or flags are fine.
+- **The docs style rules are written down and they move.** Read `container/website/CLAUDE.md` during the review, including the pages it says to read first, and check the diff against what it says today. The same file also says which tools may touch that tree, which decides what a valid fix looks like.
 - **New file, low bar to question it.** Ask what it would cost to put the code in the file that already owns that job. Often nothing.
-- **`pnpm run format` never touches the website tree.** If a docs finding is about formatting, the fix is by hand in prose, never a formatter run.

--- a/.claude/skills/review-pr/global-checks.md
+++ b/.claude/skills/review-pr/global-checks.md
@@ -1,0 +1,69 @@
+# Global review checks
+
+The criteria that are not written in any CLAUDE.md: ordinary good-engineering
+review. The repo rules come from the CLAUDE.md files at review time; this file is
+the other half, and it is a **catalog to filter**, never a list to run whole.
+
+Each item has an id, so the review list, the pass briefs and the final report can
+all point at the same thing. Include an item only when its trigger is in the
+diff, and say in the review list which groups you dropped and why.
+
+## S - spec and description (include always)
+
+- S1 The spec describes what shipped, not an earlier plan.
+- S2 Everything the spec promised shipped, or the split is explicit.
+- S3 The PR description matches the diff in front of you.
+- S4 The change has a spec at all, or a stated reason it does not need one.
+
+## D - documentation (include when docs, public behaviour or public API changed)
+
+- D1 A user-visible change is documented on the page a reader would look at.
+- D2 The docs describe what the code now does, not what it used to do.
+- D3 Examples in the docs would actually run and typecheck.
+- D4 Plain language: a reader learns what it does for them, not how it is built.
+- D5 Says it once. No sentence repeats the one above it in other words.
+- D6 Short sentences over long chained clauses.
+- D7 No internals a user cannot act on.
+- D8 The page still reads in order after the edit, no orphan paragraph or dead link.
+
+## T - types and reuse (include when types or exported functions were added)
+
+- T1 The new type does not already exist somewhere under another name.
+- T2 A type that restates part of another is derived from it instead (Pick, Omit,
+    Partial, Extract, ReturnType, a generic parameter, extending it).
+- T3 Two near-identical new types share a base instead of drifting apart.
+- T4 A new function is not a rename of an existing helper.
+- T5 The type is as narrow as the values it really holds, no wider.
+- T6 A type is exported only if something outside needs it.
+- T7 Generic parameters earn their place, one caller shape means no generic.
+
+## A - architecture and size (include when files were added, moved or restructured)
+
+- A1 A new file holds a separate concern, or the file that owns the job was full.
+- A2 There is no simpler obvious shape that does the same thing in fewer lines.
+- A3 No abstraction with one caller, no options object with one option, no
+    interface implemented once, no layer that only forwards.
+- A4 The change extends the existing hook or table rather than adding a parallel path.
+- A5 No copy-paste between the new files, or from the file they were modelled on.
+- A6 Placement respects the package boundaries the packages themselves state.
+- A7 Nothing left dead: the code this change replaces is gone, not orphaned.
+- A8 The committed line count is close to the smallest that does the job.
+
+## C - comments (include when comments were added or changed)
+
+- C1 Each comment says something the code cannot say by itself.
+- C2 One line where one line does the job.
+- C3 No comment describes behaviour the diff just changed.
+- C4 No commented-out code, no ownerless TODO, no leftover debug note.
+- C5 A comment that carries a real reason, constraint or invariant stays.
+
+## B - behaviour and tests (include when code changed)
+
+- B1 New branches handle their boundary cases (empty, zero, one, maximum, missing).
+- B2 Errors are handled or propagated, never swallowed.
+- B3 Async work is awaited, nothing is left floating.
+- B4 Input crossing a boundary is validated before it is used.
+- B5 A public signature change is either backwards compatible or called out.
+- B6 Every changed behaviour has a test that would fail without the change.
+- B7 No test was weakened, skipped or deleted to make the change pass.
+- B8 Nothing added to a hot path that runs per request without a reason.

--- a/.claude/skills/review-pr/global-checks.md
+++ b/.claude/skills/review-pr/global-checks.md
@@ -55,11 +55,9 @@ diff, and say in the review list which groups you dropped and why.
 
 ## C - comments (include when comments were added or changed)
 
-- C1 Each comment says something the code cannot say by itself.
-- C2 One line where one line does the job.
-- C3 No comment describes behaviour the diff just changed.
-- C4 No commented-out code, no ownerless TODO, no leftover debug note.
-- C5 A comment that carries a real reason, constraint or invariant stays.
+No items here. The comment rules live in the code style section of the root
+CLAUDE.md, so this group is sourced entirely from that file. Keep the group and
+its pass, read the items out of the file.
 
 ## B - behaviour and tests (include when code changed)
 

--- a/.claude/skills/review-pr/global-checks.md
+++ b/.claude/skills/review-pr/global-checks.md
@@ -1,8 +1,12 @@
 # Global review checks
 
 The criteria that are not written in any CLAUDE.md: ordinary good-engineering
-review. The repo rules come from the CLAUDE.md files at review time; this file is
-the other half, and it is a **catalog to filter**, never a list to run whole.
+review. This file is the **second** source and the smaller one. The guidelines
+themselves live in the CLAUDE.md files above each changed directory, they are
+read in full at review time, and they win wherever the two overlap.
+
+It is a **catalog to filter**, never a list to run whole, and never a substitute
+for reading those files.
 
 Each item has an id, so the review list, the pass briefs and the final report can
 all point at the same thing. Include an item only when its trigger is in the

--- a/.claude/skills/review-pr/passes.md
+++ b/.claude/skills/review-pr/passes.md
@@ -1,0 +1,205 @@
+# The five review passes
+
+One brief per pass. Paste the brief verbatim into the agent prompt and fill the
+placeholders. Spawn all five in one message so they run at once.
+
+## Shared header (prepend to every brief)
+
+```
+You are reviewing a change in the mion monorepo. Read only: do not edit, write,
+format, commit or run tests. Your output is a findings list.
+
+Diff range (use exactly this, nothing else):  git diff <MERGE_BASE>..HEAD
+Intent of the change: <INTENT from step 2>
+Changed files: <PATHS relevant to this pass>
+
+Report every finding in this shape, most important first:
+
+- claim:    one line, what is wrong
+  where:    path/to/file.ts:LINE
+  evidence: the exact line(s) from the diff
+  reason:   the quoted rule it breaks, or why it costs the reader
+  fix:      the concrete smaller change, with the replacement text where short
+  severity: blocking | worth-fixing | nit
+  confidence: high | medium | low
+
+Rules: cite only lines that exist in this diff. Quote a rule only if you read it
+in a real file, with the file name. If you find nothing, say "no findings" and
+stop. A short list of real findings beats a long list of maybes.
+```
+
+## Pass 1: guidelines
+
+```
+Check every changed file against the CLAUDE.md files that govern it.
+
+Governing files, most specific wins on conflict:
+<LIST from scope.sh, e.g. CLAUDE.md, packages/router/CLAUDE.md>
+
+Method:
+1. Read each governing CLAUDE.md in full. They are short.
+2. Write down the rules that could touch these changed files. Ignore the rest.
+3. Check each rule against the diff, one by one. Quote the rule line you checked.
+
+Rules broken most often here, worth checking explicitly:
+- Dependencies: exact pinned versions, cross-package deps use workspace:*,
+  devDependencies live at the repo root, not per package.
+- Environment variables: every new var must be added to the REGISTRY in
+  scripts/lib/env.mjs, be prefixed MION_, and appear in .env.sample only when it
+  is user-settable (secret or dev scope, never internal).
+- Tests: a fix or a feature without a test is blocking. Anything touching the
+  marker API needs BOTH getRunTypeId call shapes as paired tests
+  (see ts-go-runtypes/CLAUDE.md).
+- Code style: no I prefix on interfaces, no T prefix on type parameters, prefer
+  type casting over assertions, no @param or @returns in JSDoc, meaningful names
+  rather than one-letter ones (loop indices and err are fine).
+- Spec docs: no file outside docs/ may name a docs/todos/ or docs/done/ document.
+- Git shape: commits are a single Conventional Commits subject line, history is
+  linear, no merge commits from main.
+- Build discipline: an edit under packages/devtools/src needs its dist rebuilt,
+  since consumers and the linter read the built dist.
+
+Report a finding only where the diff actually breaks a rule you can quote. If a
+rule is ambiguous about this case, say so and mark confidence medium.
+```
+
+## Pass 2: docs
+
+```
+Review the changed documentation for plain language and this repo's voice. This
+is the pass that finds the most, because docs land wordy and full of internals.
+
+Read first, in full:
+- container/website/CLAUDE.md, the Writing guidelines section
+- container/website/content/01.rpc/02.server/01.routes.md, the model page
+Then read the root CLAUDE.md section on website documentation.
+
+Changed pages: <PATHS>
+
+Check each changed page and each changed paragraph:
+1. Plain, user-focused. Says what the feature does for the reader and why it
+   helps. No internals (hashing, byte offsets, side-channel, fixpoint, cache
+   mechanics). A knob only a contributor would set does not belong on the site
+   at all, however well written.
+2. No dashes chaining clauses: no em dash, en dash, --, or a spaced - as
+   punctuation. Hyphenated words and dashes in code, flags and URLs are fine.
+   Grep the changed pages for them and list every hit with its line.
+3. One section, one job: how, what, or why. Two jobs means two sections.
+4. Titles: plain Title Case, name the job, stand alone without the page title,
+   no code names, no questions, no slogans.
+5. One table per topic. Several small sections in a row with the same columns
+   are one table that got split.
+6. Frontmatter description: one simple sentence, aim under 100 characters.
+7. TypeScript examples use <code-import> from packages/examples/src, not a
+   hand-written fence. Fences are for bash, JSON, output and deliberately
+   partial fragments.
+8. index.md gets the simplest wording on the site.
+9. A renamed heading changes its URL anchor: check the content tree for links
+   to the old slug.
+
+For every wordy sentence you flag, write the shorter replacement in the fix
+field. A rewrite is the finding; "this is too complex" is not.
+
+Also check the other direction: does the diff change user-visible behaviour that
+the docs do not mention yet? Missing docs for a shipped feature is blocking.
+```
+
+## Pass 3: reuse
+
+```
+Find new types and new functionality that could come from something that already
+exists. Every redundant declaration is committed lines someone must maintain.
+
+Changed files: <PATHS>
+
+Method:
+1. List every type, interface, enum and exported function ADDED by the diff.
+2. For each one, search for a near-match before judging it: grep the same
+   package, then its siblings, then packages/run-types and packages/core for the
+   same field set, the same shape, or the same job under another name.
+3. Ask, in this order:
+   - Does this type already exist? Then import it.
+   - Can it be derived? Pick, Omit, Partial, Extract, ReturnType, a generic
+     parameter on the existing type, or extending it. Prefer deriving, because a
+     derived type follows its source when the source changes.
+   - Is it a near-copy of a neighbour that differs by one field? Then the two
+     should share a base.
+   - Same questions for functions: is there a helper doing this already, and
+     does this one just wrap it with a different name?
+4. Flag the reverse too: a type widened or duplicated so two callers could share
+   it, where a small generic would have kept both honest.
+
+For each finding name the existing type or function by file and line, and show
+the derived form you propose. A reuse claim without the existing declaration to
+point at is not a finding.
+
+Ignore: intentional duplication across package boundaries where importing would
+create a dependency the repo does not allow. Check that before you flag it.
+```
+
+## Pass 4: architecture
+
+```
+Judge the shape of the change. The goal is the simplest obvious version, and
+fewer committed lines.
+
+Diff stat: <STAT>
+New files: <ADDED FILES with line counts>
+
+Method:
+1. Restate the intent in one sentence, then ask what the smallest change that
+   achieves it looks like. Compare that to the diff.
+2. Every new file: does it earn its existence? What would it cost to put this in
+   the file that already owns this job? Name that file. A new file is right when
+   it holds a genuinely separate concern or the host file is already large.
+3. Look for structure added ahead of need: an abstraction with one caller, an
+   options object with one option, an interface implemented once, a registry
+   with two entries, an indirection layer that only forwards.
+4. Look for the missed extension point: did the author add a parallel path where
+   the codebase already had a hook, a strategy table, or an existing branch to
+   extend?
+5. Look for copy-paste between the new files, and between a new file and the one
+   it was modelled on.
+6. Is anything placed wrongly? Package boundaries here are strict: recorders do
+   not import drizzle, platform adapters wrap the router, devtools presets map
+   through shared options so they cannot drift. Check the package's own
+   CLAUDE.md for its boundary before flagging placement.
+
+Every architecture finding must carry a line count: roughly how many committed
+lines the simpler shape removes, and confirmation that behaviour is unchanged.
+If the simpler shape is only different, not smaller and not clearer, drop it.
+
+Do not propose refactoring code the diff does not touch.
+```
+
+## Pass 5: comments
+
+```
+Review only the comments added or changed by the diff, in code files.
+
+Changed files: <PATHS>
+
+The bar this repo sets: one-liners, and a comment stays only if it says
+something that cannot be read from the code.
+
+Delete or rewrite:
+- Restates the line below it ("// increment the counter").
+- Names the function again in prose above it.
+- JSDoc with @param or @returns tags: the repo bans both, the types already say it.
+- A multi-line block that says one thing: collapse it to one line.
+- Commented-out code, a TODO with no owner and no plan, a leftover debugging note.
+- Stale: describes behaviour the diff just changed. Quote both and mark it
+  blocking, because a wrong comment is worse than none.
+
+Keep:
+- Why, not what: the reason a surprising choice was made, the constraint that
+  forced it, the bug it avoids.
+- A load-bearing invariant, an ordering requirement, a link to the spec of a
+  format.
+- A warning that the obvious simplification here is wrong.
+
+For each finding give the replacement one-liner, or say "delete" outright. Be
+strict but do not strip a comment carrying real reasoning just because it is two
+lines. If you cannot tell whether it is load-bearing, mark confidence low and say
+what would settle it.
+```

--- a/.claude/skills/review-pr/passes.md
+++ b/.claude/skills/review-pr/passes.md
@@ -1,197 +1,157 @@
-# The five review passes
+# The passes
 
-One brief per pass. Paste the brief verbatim into the agent prompt and fill the
-placeholders. Spawn all five in one message so they run at once.
+One brief per group of the approved review list. Paste the brief into the agent
+prompt and fill the placeholders. Spawn every surviving group in one message so
+they run at once.
 
-**No pass restates a repo rule.** The rules live in the CLAUDE.md files and they
-change; a copy here would go stale and would be wrong in the worst way, quietly.
-Each pass reads the files that govern its area and builds its own checklist from
-them, then reports that checklist so the coverage is visible.
+**A brief never restates a repo rule.** The items carry what to check, and a
+repo item names the file it came from so the agent reads the current text. Rules
+change; anything copied in here would go stale silently.
 
 ## Shared header (prepend to every brief)
 
 ```
-You are reviewing a change in the mion monorepo. Read only: do not edit, write,
-format, commit or run tests. Your output is a findings list.
+You are reviewing a change in the mion monorepo, against a checklist the author
+already approved. Read only: do not edit, write, format, commit or run tests.
 
 Diff range (use exactly this, nothing else):  git diff <MERGE_BASE>..HEAD
-Intent of the change: <INTENT from step 2>
-Changed files: <PATHS relevant to this pass>
+Intent of the change: <INTENT>
+Files for this pass: <PATHS>
 
-Report every finding in this shape, most important first:
+Your items:
+<the approved items for this group, with their ids and sources>
 
-- claim:    one line, what is wrong
-  where:    path/to/file.ts:LINE
+Method: check your items, in order, and nothing else. For any item tagged
+[repo: <file>], open that file and read the rule in its current wording before
+judging, then quote what you read.
+
+Answer every item:
+
+- id:     D9
+  result: pass | fail | not-applicable
+  where:  path/to/file.ts:LINE        (for a fail, and for a pass you had to work for)
   evidence: the exact line(s) from the diff
-  reason:   the quoted rule it breaks, or why it costs the reader
-  fix:      the concrete smaller change, with the replacement text where short
+  reason: the quoted rule, or why it costs the reader
+  fix:    the concrete smaller change, with the replacement text where short
   severity: blocking | worth-fixing | nit
   confidence: high | medium | low
 
-Rules: cite only lines that exist in this diff. Quote a rule only if you read it
-in a real file, naming that file. If you find nothing, say "no findings" and
-stop. A short list of real findings beats a long list of maybes.
+Then, only if you saw something serious your items do not cover, add it under
+"off-list" in the same shape. Do not pad it: off-list is for real problems, not
+for things you would have written differently.
+
+Cite only lines that exist in this diff. Quote a rule only if you read it in a
+real file, naming that file.
 ```
 
-## Pass 1: guidelines
+## Group G: repo guidelines
 
 ```
-Build a rule checklist from the CLAUDE.md files themselves, then check the diff
-against it. Nothing is listed for you here on purpose: those files change, and
-anything copied into this brief would be out of date.
+These items come from the CLAUDE.md files that govern the changed paths:
+dependency shape, environment variables, file placement, build steps, commit and
+branch shape, and anything else with no other group.
 
-Governing files, most specific wins on conflict:
-<LIST from scope.sh>
+Read each named CLAUDE.md in full before checking its items. They are short.
+Where one points at another document for an area this diff touches, follow the
+pointer and read that too.
 
-Method:
-1. Read each governing CLAUDE.md in full. They are short. Where one points at
-   another document for the detail of an area this diff touches, follow the
-   pointer and read that too.
-2. Write a numbered checklist of every rule that could apply to these changed
-   files. One line per rule, each naming the file it came from. Drop rules about
-   areas the diff does not touch, and say which areas you dropped.
-3. Walk the checklist against the diff item by item. Mark each one pass, fail or
-   not applicable, with the file and line you checked.
-4. Report the checklist first so the reviewer sees the coverage, then a finding
-   for every fail.
-
-Treat every rule as binding, whether or not it is marked important, and whatever
-it covers: dependency shape, naming, file placement, tests owed, docs owed,
-environment registration, build steps, commit and branch shape.
-
-Report a finding only where you can quote both the rule line and the diff line
-that breaks it. A rule you cannot quote is your opinion, so leave it out.
+Judge against the wording you read, not against what the item paraphrases. If
+the rule turns out narrower than the item suggests, say so and mark the item
+pass with a note. If it is wider and the diff breaks the wider version, that is
+a fail with the real quote.
 ```
 
-## Pass 2: docs
+## Group D: documentation
 
 ```
-Review the changed documentation against the repo's own writing guidelines. Work
-from the guidelines as written, never from memory or general style sense. This is
-the pass that finds the most, because documentation lands wordy and full of
-internals more often than anything else.
+This is the group that finds the most, because documentation lands wordy and
+full of internals more often than anything else.
 
-Read first, in full:
-- container/website/CLAUDE.md, including the pages it tells you to read before
-  writing or restyling
-- the website documentation section of the root CLAUDE.md
-
-Changed pages: <PATHS>
-
-Method:
-1. Turn those guidelines into a numbered checklist, one line per rule.
-2. Check every changed page, and every changed paragraph, against each item.
-3. Report the checklist with pass or fail first, then the findings.
+Read first, in full: container/website/CLAUDE.md, including the pages it tells
+you to read before writing or restyling. Then check your items against every
+changed page and every changed paragraph.
 
 Run the mechanical items rather than eyeballing them: grep the changed pages for
 whatever the guidelines ban as punctuation, and measure anything they set a
 length bar for.
 
-Two judgements are yours beyond the checklist:
-- Wordy or internals-heavy prose. For every sentence you flag, write the shorter
-  replacement in the fix field. The rewrite is the finding; "too complex" is not.
-- Missing documentation. Does the diff change user-visible behaviour that no page
-  mentions yet? That is blocking.
+For every sentence you flag as wordy or internals-heavy, write the shorter
+replacement in the fix field. The rewrite is the finding; "too complex" is not.
+
+Missing documentation is a fail, not a gap: if the diff changes user-visible
+behaviour that no page mentions, name the page it belongs on.
 ```
 
-## Pass 3: reuse
+## Group T: types and reuse
 
 ```
-Find new types and new functionality that could come from something that already
-exists. Every redundant declaration is committed lines someone has to maintain.
+Work from the additions: list every type, interface, enum and exported function
+the diff ADDS, then check your items against that list.
 
-Changed files: <PATHS>
+Search before you judge. For each addition, grep the same package, then its
+siblings, then the shared packages, for the same field set, the same shape, or
+the same job under another name. A reuse claim with no existing declaration to
+point at is not a finding, so name the existing one by file and line and show
+the derived form you propose (Pick, Omit, Partial, Extract, ReturnType, a
+generic parameter, or extending it).
 
-Method:
-1. List every type, interface, enum and exported function ADDED by the diff.
-2. For each one, search for a near match before judging it: grep the same
-   package, then its siblings, then the shared packages, for the same field set,
-   the same shape, or the same job under another name.
-3. Ask, in this order:
-   - Does this type already exist? Then import it.
-   - Can it be derived? Pick, Omit, Partial, Extract, ReturnType, a generic
-     parameter on the existing type, or extending it. Prefer deriving, because a
-     derived type follows its source when the source changes.
-   - Is it a near copy of a neighbour that differs by one field? Then the two
-     should share a base.
-   - Same questions for functions: does a helper already do this, and does the
-     new one only wrap it under another name?
-4. Flag the reverse too: a type widened or duplicated so two callers could share
-   it, where a small generic would have kept both honest.
-
-For each finding name the existing type or function by file and line, and show
-the derived form you propose. A reuse claim with no existing declaration to point
-at is not a finding.
-
-Before flagging, check whether importing would cross a package boundary the repo
-does not allow. The package CLAUDE.md states its boundaries; read it rather than
-assuming. Deliberate duplication across such a boundary is correct.
+Before flagging, check whether the import would cross a package boundary the
+repo does not allow. The package CLAUDE.md states its boundaries; read it rather
+than assuming. Deliberate duplication across such a boundary is correct.
 ```
 
-## Pass 4: architecture
+## Group A: architecture and size
 
 ```
-Judge the shape of the change. The goal is the simplest obvious version, and
-fewer committed lines.
-
 Diff stat: <STAT>
 New files: <ADDED FILES with line counts>
 
-Method:
-1. Restate the intent in one sentence, then ask what the smallest change that
-   achieves it looks like. Compare that to the diff.
-2. Every new file: does it earn its existence? What would it cost to put this in
-   the file that already owns the job? Name that file. A new file is right when
-   it holds a genuinely separate concern, or the host file is already large.
-3. Look for structure added ahead of need: an abstraction with one caller, an
-   options object with one option, an interface implemented once, a registry with
-   two entries, an indirection layer that only forwards.
-4. Look for the missed extension point: did the author add a parallel path where
-   the codebase already had a hook, a strategy table, or a branch to extend?
-5. Look for copy-paste between the new files, and between a new file and the one
-   it was modelled on.
-6. Is anything placed wrongly? Package boundaries here are strict, so read the
-   CLAUDE.md of the packages involved and judge placement against what they
-   state, not against what looks tidy.
+Start by restating the intent in one sentence and describing the smallest change
+that would achieve it. Compare that to the diff, then check your items.
 
-Every architecture finding carries a line count: roughly how many committed lines
-the simpler shape removes, and confirmation that behaviour is unchanged. If the
-simpler shape is only different, not smaller and not clearer, drop it.
+Every architecture fail carries a number: roughly how many committed lines the
+simpler shape removes, and confirmation that behaviour is unchanged. If the
+simpler shape is only different, not smaller and not clearer, mark the item pass
+and move on.
+
+For placement, read the CLAUDE.md of the packages involved and judge against
+what they state, not against what looks tidy.
 
 Do not propose refactoring code the diff does not touch.
 ```
 
-## Pass 5: comments
+## Group C: comments
 
 ```
-Review only the comments added or changed by the diff, in code files.
+Look only at comments the diff adds or changes, in code files.
 
-Changed files: <PATHS>
-
-First read the code style rules in the root CLAUDE.md, plus any CLAUDE.md in the
+Read the code style rules in the root CLAUDE.md, plus any CLAUDE.md in the
 directories these files live in, and take the comment and doc-block rules from
-there. Then apply the general bar: a comment stays only if it says something that
-cannot be read from the code, and it says it in as few lines as possible.
+there before judging.
 
-Delete or rewrite:
-- Restates the line below it ("// increment the counter").
-- Names the function again in prose above it.
-- A doc block using tags the repo's style rules ban, where the types already
-  carry the information.
-- A multi-line block that says one thing: collapse it to one line.
-- Commented-out code, a TODO with no owner and no plan, a leftover debug note.
-- Stale: describes behaviour the diff just changed. Quote both and mark it
-  blocking, because a wrong comment is worse than no comment.
+For each fail give the replacement one-liner, or say "delete" outright. Be
+strict, but do not strip a comment carrying a real reason, constraint or
+invariant just because it runs to two lines. A comment describing behaviour the
+diff just changed is blocking: a wrong comment is worse than no comment.
 
-Keep:
-- Why, not what: the reason a surprising choice was made, the constraint that
-  forced it, the bug it avoids.
-- A load-bearing invariant, an ordering requirement, a pointer to the spec of a
-  format.
-- A warning that the obvious simplification here is wrong.
+If you cannot tell whether a comment is load-bearing, mark confidence low and
+say what would settle it.
+```
 
-For each finding give the replacement one-liner, or say "delete" outright. Be
-strict, but do not strip a comment carrying real reasoning just because it runs
-to two lines. If you cannot tell whether it is load-bearing, mark confidence low
-and say what would settle it.
+## Group B: behaviour and tests
+
+```
+Read the changed code closely enough to say what it does now versus before, then
+check your items.
+
+For a behaviour item, a fail needs the input or state that reaches it: "empty
+array reaches line 42 and it indexes [0]". A worry with no path to it is not a
+finding.
+
+For a coverage item, name the test that should exist and what it would pin.
+Check whether an existing test already covers it before calling it missing, and
+check whether any test was weakened, skipped or deleted in this diff.
+
+Do not run anything. You are reading tests, not executing them, and reporting a
+result you did not produce would be a false claim.
 ```

--- a/.claude/skills/review-pr/passes.md
+++ b/.claude/skills/review-pr/passes.md
@@ -3,6 +3,11 @@
 One brief per pass. Paste the brief verbatim into the agent prompt and fill the
 placeholders. Spawn all five in one message so they run at once.
 
+**No pass restates a repo rule.** The rules live in the CLAUDE.md files and they
+change; a copy here would go stale and would be wrong in the worst way, quietly.
+Each pass reads the files that govern its area and builds its own checklist from
+them, then reports that checklist so the coverage is visible.
+
 ## Shared header (prepend to every brief)
 
 ```
@@ -24,117 +29,103 @@ Report every finding in this shape, most important first:
   confidence: high | medium | low
 
 Rules: cite only lines that exist in this diff. Quote a rule only if you read it
-in a real file, with the file name. If you find nothing, say "no findings" and
+in a real file, naming that file. If you find nothing, say "no findings" and
 stop. A short list of real findings beats a long list of maybes.
 ```
 
 ## Pass 1: guidelines
 
 ```
-Check every changed file against the CLAUDE.md files that govern it.
+Build a rule checklist from the CLAUDE.md files themselves, then check the diff
+against it. Nothing is listed for you here on purpose: those files change, and
+anything copied into this brief would be out of date.
 
 Governing files, most specific wins on conflict:
-<LIST from scope.sh, e.g. CLAUDE.md, packages/router/CLAUDE.md>
+<LIST from scope.sh>
 
 Method:
-1. Read each governing CLAUDE.md in full. They are short.
-2. Write down the rules that could touch these changed files. Ignore the rest.
-3. Check each rule against the diff, one by one. Quote the rule line you checked.
+1. Read each governing CLAUDE.md in full. They are short. Where one points at
+   another document for the detail of an area this diff touches, follow the
+   pointer and read that too.
+2. Write a numbered checklist of every rule that could apply to these changed
+   files. One line per rule, each naming the file it came from. Drop rules about
+   areas the diff does not touch, and say which areas you dropped.
+3. Walk the checklist against the diff item by item. Mark each one pass, fail or
+   not applicable, with the file and line you checked.
+4. Report the checklist first so the reviewer sees the coverage, then a finding
+   for every fail.
 
-Rules broken most often here, worth checking explicitly:
-- Dependencies: exact pinned versions, cross-package deps use workspace:*,
-  devDependencies live at the repo root, not per package.
-- Environment variables: every new var must be added to the REGISTRY in
-  scripts/lib/env.mjs, be prefixed MION_, and appear in .env.sample only when it
-  is user-settable (secret or dev scope, never internal).
-- Tests: a fix or a feature without a test is blocking. Anything touching the
-  marker API needs BOTH getRunTypeId call shapes as paired tests
-  (see ts-go-runtypes/CLAUDE.md).
-- Code style: no I prefix on interfaces, no T prefix on type parameters, prefer
-  type casting over assertions, no @param or @returns in JSDoc, meaningful names
-  rather than one-letter ones (loop indices and err are fine).
-- Spec docs: no file outside docs/ may name a docs/todos/ or docs/done/ document.
-- Git shape: commits are a single Conventional Commits subject line, history is
-  linear, no merge commits from main.
-- Build discipline: an edit under packages/devtools/src needs its dist rebuilt,
-  since consumers and the linter read the built dist.
+Treat every rule as binding, whether or not it is marked important, and whatever
+it covers: dependency shape, naming, file placement, tests owed, docs owed,
+environment registration, build steps, commit and branch shape.
 
-Report a finding only where the diff actually breaks a rule you can quote. If a
-rule is ambiguous about this case, say so and mark confidence medium.
+Report a finding only where you can quote both the rule line and the diff line
+that breaks it. A rule you cannot quote is your opinion, so leave it out.
 ```
 
 ## Pass 2: docs
 
 ```
-Review the changed documentation for plain language and this repo's voice. This
-is the pass that finds the most, because docs land wordy and full of internals.
+Review the changed documentation against the repo's own writing guidelines. Work
+from the guidelines as written, never from memory or general style sense. This is
+the pass that finds the most, because documentation lands wordy and full of
+internals more often than anything else.
 
 Read first, in full:
-- container/website/CLAUDE.md, the Writing guidelines section
-- container/website/content/01.rpc/02.server/01.routes.md, the model page
-Then read the root CLAUDE.md section on website documentation.
+- container/website/CLAUDE.md, including the pages it tells you to read before
+  writing or restyling
+- the website documentation section of the root CLAUDE.md
 
 Changed pages: <PATHS>
 
-Check each changed page and each changed paragraph:
-1. Plain, user-focused. Says what the feature does for the reader and why it
-   helps. No internals (hashing, byte offsets, side-channel, fixpoint, cache
-   mechanics). A knob only a contributor would set does not belong on the site
-   at all, however well written.
-2. No dashes chaining clauses: no em dash, en dash, --, or a spaced - as
-   punctuation. Hyphenated words and dashes in code, flags and URLs are fine.
-   Grep the changed pages for them and list every hit with its line.
-3. One section, one job: how, what, or why. Two jobs means two sections.
-4. Titles: plain Title Case, name the job, stand alone without the page title,
-   no code names, no questions, no slogans.
-5. One table per topic. Several small sections in a row with the same columns
-   are one table that got split.
-6. Frontmatter description: one simple sentence, aim under 100 characters.
-7. TypeScript examples use <code-import> from packages/examples/src, not a
-   hand-written fence. Fences are for bash, JSON, output and deliberately
-   partial fragments.
-8. index.md gets the simplest wording on the site.
-9. A renamed heading changes its URL anchor: check the content tree for links
-   to the old slug.
+Method:
+1. Turn those guidelines into a numbered checklist, one line per rule.
+2. Check every changed page, and every changed paragraph, against each item.
+3. Report the checklist with pass or fail first, then the findings.
 
-For every wordy sentence you flag, write the shorter replacement in the fix
-field. A rewrite is the finding; "this is too complex" is not.
+Run the mechanical items rather than eyeballing them: grep the changed pages for
+whatever the guidelines ban as punctuation, and measure anything they set a
+length bar for.
 
-Also check the other direction: does the diff change user-visible behaviour that
-the docs do not mention yet? Missing docs for a shipped feature is blocking.
+Two judgements are yours beyond the checklist:
+- Wordy or internals-heavy prose. For every sentence you flag, write the shorter
+  replacement in the fix field. The rewrite is the finding; "too complex" is not.
+- Missing documentation. Does the diff change user-visible behaviour that no page
+  mentions yet? That is blocking.
 ```
 
 ## Pass 3: reuse
 
 ```
 Find new types and new functionality that could come from something that already
-exists. Every redundant declaration is committed lines someone must maintain.
+exists. Every redundant declaration is committed lines someone has to maintain.
 
 Changed files: <PATHS>
 
 Method:
 1. List every type, interface, enum and exported function ADDED by the diff.
-2. For each one, search for a near-match before judging it: grep the same
-   package, then its siblings, then packages/run-types and packages/core for the
-   same field set, the same shape, or the same job under another name.
+2. For each one, search for a near match before judging it: grep the same
+   package, then its siblings, then the shared packages, for the same field set,
+   the same shape, or the same job under another name.
 3. Ask, in this order:
    - Does this type already exist? Then import it.
    - Can it be derived? Pick, Omit, Partial, Extract, ReturnType, a generic
      parameter on the existing type, or extending it. Prefer deriving, because a
      derived type follows its source when the source changes.
-   - Is it a near-copy of a neighbour that differs by one field? Then the two
+   - Is it a near copy of a neighbour that differs by one field? Then the two
      should share a base.
-   - Same questions for functions: is there a helper doing this already, and
-     does this one just wrap it with a different name?
+   - Same questions for functions: does a helper already do this, and does the
+     new one only wrap it under another name?
 4. Flag the reverse too: a type widened or duplicated so two callers could share
    it, where a small generic would have kept both honest.
 
 For each finding name the existing type or function by file and line, and show
-the derived form you propose. A reuse claim without the existing declaration to
-point at is not a finding.
+the derived form you propose. A reuse claim with no existing declaration to point
+at is not a finding.
 
-Ignore: intentional duplication across package boundaries where importing would
-create a dependency the repo does not allow. Check that before you flag it.
+Before flagging, check whether importing would cross a package boundary the repo
+does not allow. The package CLAUDE.md states its boundaries; read it rather than
+assuming. Deliberate duplication across such a boundary is correct.
 ```
 
 ## Pass 4: architecture
@@ -150,24 +141,22 @@ Method:
 1. Restate the intent in one sentence, then ask what the smallest change that
    achieves it looks like. Compare that to the diff.
 2. Every new file: does it earn its existence? What would it cost to put this in
-   the file that already owns this job? Name that file. A new file is right when
-   it holds a genuinely separate concern or the host file is already large.
+   the file that already owns the job? Name that file. A new file is right when
+   it holds a genuinely separate concern, or the host file is already large.
 3. Look for structure added ahead of need: an abstraction with one caller, an
-   options object with one option, an interface implemented once, a registry
-   with two entries, an indirection layer that only forwards.
+   options object with one option, an interface implemented once, a registry with
+   two entries, an indirection layer that only forwards.
 4. Look for the missed extension point: did the author add a parallel path where
-   the codebase already had a hook, a strategy table, or an existing branch to
-   extend?
+   the codebase already had a hook, a strategy table, or a branch to extend?
 5. Look for copy-paste between the new files, and between a new file and the one
    it was modelled on.
-6. Is anything placed wrongly? Package boundaries here are strict: recorders do
-   not import drizzle, platform adapters wrap the router, devtools presets map
-   through shared options so they cannot drift. Check the package's own
-   CLAUDE.md for its boundary before flagging placement.
+6. Is anything placed wrongly? Package boundaries here are strict, so read the
+   CLAUDE.md of the packages involved and judge placement against what they
+   state, not against what looks tidy.
 
-Every architecture finding must carry a line count: roughly how many committed
-lines the simpler shape removes, and confirmation that behaviour is unchanged.
-If the simpler shape is only different, not smaller and not clearer, drop it.
+Every architecture finding carries a line count: roughly how many committed lines
+the simpler shape removes, and confirmation that behaviour is unchanged. If the
+simpler shape is only different, not smaller and not clearer, drop it.
 
 Do not propose refactoring code the diff does not touch.
 ```
@@ -179,27 +168,30 @@ Review only the comments added or changed by the diff, in code files.
 
 Changed files: <PATHS>
 
-The bar this repo sets: one-liners, and a comment stays only if it says
-something that cannot be read from the code.
+First read the code style rules in the root CLAUDE.md, plus any CLAUDE.md in the
+directories these files live in, and take the comment and doc-block rules from
+there. Then apply the general bar: a comment stays only if it says something that
+cannot be read from the code, and it says it in as few lines as possible.
 
 Delete or rewrite:
 - Restates the line below it ("// increment the counter").
 - Names the function again in prose above it.
-- JSDoc with @param or @returns tags: the repo bans both, the types already say it.
+- A doc block using tags the repo's style rules ban, where the types already
+  carry the information.
 - A multi-line block that says one thing: collapse it to one line.
-- Commented-out code, a TODO with no owner and no plan, a leftover debugging note.
+- Commented-out code, a TODO with no owner and no plan, a leftover debug note.
 - Stale: describes behaviour the diff just changed. Quote both and mark it
-  blocking, because a wrong comment is worse than none.
+  blocking, because a wrong comment is worse than no comment.
 
 Keep:
 - Why, not what: the reason a surprising choice was made, the constraint that
   forced it, the bug it avoids.
-- A load-bearing invariant, an ordering requirement, a link to the spec of a
+- A load-bearing invariant, an ordering requirement, a pointer to the spec of a
   format.
 - A warning that the obvious simplification here is wrong.
 
 For each finding give the replacement one-liner, or say "delete" outright. Be
-strict but do not strip a comment carrying real reasoning just because it is two
-lines. If you cannot tell whether it is load-bearing, mark confidence low and say
-what would settle it.
+strict, but do not strip a comment carrying real reasoning just because it runs
+to two lines. If you cannot tell whether it is load-bearing, mark confidence low
+and say what would settle it.
 ```

--- a/.claude/skills/review-pr/scope.sh
+++ b/.claude/skills/review-pr/scope.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Scope a branch for review: base ref, diff stat, new files, spec docs, website
+# pages, test coverage signal, and the CLAUDE.md files governing each change.
+# Usage: bash .claude/skills/review-pr/scope.sh [base-ref]
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "not a git repo" >&2; exit 1; }
+
+base_ref=${1:-}
+if [ -z "$base_ref" ]; then
+  git fetch --quiet origin main 2>/dev/null || true
+  if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    base_ref=origin/main
+  else
+    base_ref=main
+  fi
+fi
+
+merge_base=$(git merge-base "$base_ref" HEAD 2>/dev/null) || {
+  echo "no merge base between $base_ref and HEAD" >&2; exit 1; }
+range="$merge_base..HEAD"
+
+section() { printf '\n## %s\n' "$1"; }
+indent()  { local out; out=$(cat); if [ -z "$out" ]; then echo "  (none)"; else printf '%s\n' "$out" | sed 's/^/  /'; fi; }
+area()    { awk -F/ '{ if ($1=="packages" && NF>1) print $1"/"$2; else print $1 }'; }
+
+printf '## Target\n'
+printf 'branch:     %s\n' "$(git rev-parse --abbrev-ref HEAD)"
+printf 'base ref:   %s\n' "$base_ref"
+printf 'merge base: %s\n' "$merge_base"
+printf 'diff range: %s   <- every pass must use this exact range\n' "$range"
+
+section "Commits"
+git log --oneline "$range" | indent
+
+changed=$(git diff --name-only -M "$range")
+if [ -z "$changed" ]; then printf '\nNo changes against %s.\n' "$base_ref"; exit 0; fi
+
+section "Diff stat"
+git diff --stat=160 "$range" | indent
+
+section "Added files, biggest first (added removed path)"
+git diff --numstat -M "$range" --diff-filter=A | sort -rn | head -20 | indent
+
+section "Deleted and renamed files"
+git diff --name-status -M "$range" --diff-filter=DR | indent
+
+section "Governing CLAUDE.md (count = changed files it covers)"
+printf '%s\n' "$changed" | while IFS= read -r f; do
+  d=$(dirname "$f")
+  while :; do
+    if [ "$d" = "." ]; then [ -f CLAUDE.md ] && echo CLAUDE.md; break; fi
+    [ -f "$d/CLAUDE.md" ] && echo "$d/CLAUDE.md"
+    d=$(dirname "$d")
+  done
+done | sort | uniq -c | sort -rn | indent
+
+section "Spec docs in the diff (a todos -> done rename is this PR's spec)"
+git diff --name-status -M "$range" -- docs/todos docs/done | indent
+
+section "New references to a spec doc outside docs/ (banned by root CLAUDE.md)"
+git diff -M "$range" -- . ':(exclude)docs' 2>/dev/null | grep -E '^\+.*docs/(todos|done)/' | head -20 | indent
+
+section "Website pages changed"
+git diff --name-only -M "$range" -- container/website/content | indent
+
+tests=$(printf '%s\n' "$changed" | grep -E '\.(spec|test)\.ts$|_test\.go$' || true)
+section "Test files changed"
+printf '%s\n' "$tests" | grep -v '^$' | indent
+
+section "Source areas changed with no test change"
+src_areas=$(printf '%s\n' "$changed" | grep -vE '\.(spec|test)\.ts$|_test\.go$' | grep -E '^(packages|ts-go-runtypes)/' | area | sort -u)
+test_areas=$(printf '%s\n' "$tests" | grep -v '^$' | area | sort -u)
+comm -23 <(printf '%s\n' "$src_areas" | grep -v '^$') <(printf '%s\n' "$test_areas" | grep -v '^$') | indent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ See [SETUP.md → Containerized apps](SETUP.md#containerized-apps-docs-website--
 - `InjectRunTypeId` (capital T mid-word) — same casing as `RunType`.
 - Prefer type casting over assertions.
 - No `@param` / `@returns` in JSDoc; prefer one-liner comments and one-line `if`s.
+- **A comment earns its line or it goes.** Keep it only if it says something the code cannot: the reason behind a surprising choice, the constraint that forced it, an ordering requirement or invariant. One line where one line does the job. Delete anything that restates the code below it, and never leave commented-out code, an ownerless TODO, or a comment describing behaviour the change just made stale.
 - Use meaningful names in Go + TS; avoid one-letter abbreviations like `p`, `c`, `t`; when a struct field has a JSON tag, reuse that name for the local variable. Loop indices (`i`, `k`, `v`) and `err` are fine.
 
 ## Environment variables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,13 @@ Before opening a PR, confirm the change is **PR ready** — never open one other
   Shipped only PART of it? **SPLIT it, never park it**: the moved doc records what actually landed, the remainder becomes a NEW [docs/todos/](docs/todos/) spec that stands on its own. There is no half-done lane.
 - **A superseded spec is rewritten from scratch**, never cross-referenced. Delete the old one (or `git mv` it to [docs/done/](docs/done/) if part genuinely shipped). Never leave a link, a "supersedes" note, or a summary of the previous version.
 - **No other file ever names a `docs/todos/` or `docs/done/` document.** Not a doc, a skill, a workflow, a test, or a code comment: those specs get deleted eventually, so every such reference rots. Put the reasoning in the file that needs it. A spec may list the documents that could go stale once it merges, but that list lives inside the spec.
+- **Label the PR so the CI lanes it needs actually run.** The heavy lanes are opt-in per PR ([pr-heavy.yml](.github/workflows/pr-heavy.yml), [drizzle-e2e.yml](.github/workflows/drizzle-e2e.yml)). With no label they never run and GitHub still shows the PR green, so an unlabelled PR can merge untested:
+  - `website`: builds the docs site. Add it for [container/website/](container/website/) and for [packages/examples/](packages/examples/), whose files the pages import.
+  - `bench`: runs the validation benchmarks. Add it for [container/benchmarks/](container/benchmarks/) or their deps.
+  - `pre-publish-e2e`: packs every package, publishes to a throwaway registry and runs the consumer lanes. Add it for package exports, `package.json` changes, public API renames, anything a consumer installs.
+  - `drizzle-e2e`: runs drizzle's own suites against real databases. Add it for [packages/drizzle-orm/](packages/drizzle-orm/) and its dialect packages, or [container/drizzle-e2e/](container/drizzle-e2e/).
+  - `skip-defaults` does the opposite, it opts OUT of the default lint / typecheck / test lanes. Only for a PR that cannot affect them.
+  Adding a label re-triggers its lane, and it keeps running on every later commit, so label at open time rather than at the end.
 
 ## Git workflow
 


### PR DESCRIPTION
Adds a new `review-pr` skill that implements structured pull request review against repo guidelines before a change lands.

## What it does

The skill reviews a PR or branch in two halves:

1. **Agree what to check** — builds a filtered checklist from CLAUDE.md rules that govern the changed files, plus general engineering checks those files don't cover. Shows it to the user and gets approval before reviewing.

2. **Check it** — runs the approved list as parallel passes (one agent per group: guidelines, docs, types/reuse, architecture, comments, behaviour/tests), verifies findings against the diff, and reports them with severity and next steps.

The review produces a findings report, never edits. The user decides what gets fixed, delegated, or dropped.

## Files added

- **SKILL.md** — full skill documentation covering the arc (scope → frame → build list → approve → fan out → verify → report), what to do and what not to do, and gotchas.
- **passes.md** — one brief per review group (G, D, T, A, C, B), with the shared header and group-specific guidance for each agent.
- **scope.sh** — bash script that scopes a branch: prints base ref, merge-base sha, commits, diff stat, new files, renames, governing CLAUDE.md files, spec docs, website pages, and test coverage signal. Pins the merge-base so all passes see one identical change set.
- **global-checks.md** — catalog of ordinary engineering checks (spec, docs, types, architecture, comments, behaviour/tests) that no CLAUDE.md covers. Filtered per review, never run whole.

## Key design

- **List first, review second** — an approved checklist makes the review auditable and lets the user steer before work happens.
- **Fewer committed lines** — the bias throughout. New types that could be derived, new files that could be three lines in an existing one, comments that repeat the line under them are all findings.
- **Read the guidelines fresh** — CLAUDE.md files are read in full at review time, quoted in findings, and cited by file name. Rules change; anything copied into the skill would go stale silently.
- **Verify before reporting** — every finding is checked against the diff: the citation is real, the rule is real, the simpler option is actually simpler, it's in scope.
- **No edits, no test runs** — the skill reads only. Tests and builds are the host's job; reporting a result you didn't produce is a false claim.

https://claude.ai/code/session_01R1kkaruZ54Xr7H6GWKfdBD