### PR TITLE
fix(jsonsize): charge the flat-union merged-property envelope

### DIFF
--- a/docs/done/json-size-bound-underestimates-a-bounded-set.md
+++ b/docs/done/json-size-bound-underestimates-a-bounded-set.md
@@ -1,0 +1,82 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-12
+---
+
+# jsonMaxBytes underestimates a union of object members
+
+## Intent
+
+`jsonMaxBytes` is supposed to be a true upper bound on what the compiled JSON encoder emits for a
+type, so a consumer deriving a request size limit from it never rejects a payload the encoder
+itself produced. For a union of two or more object members it was not, and the `jsonsize` fuzz
+lane's soak caught it on a bounded `Set`.
+
+## What failed
+
+The soak reported three violations on CI run 34719842695 (job 103623691959), all the same type and
+the same per-type seed (2646330014), differing only in the Date the mock drew:
+
+```
+[jsonsize-fuzz][JS-MAX-ENCODER] [1d] Set<({2}|{3}|{3}|{1})>≤1 (seed=2646330014):
+the compiled JSON encoder emits 70 bytes, over the type's jsonMaxBytes 68
+    [[-1,{"kind":"t2","f0":[2,null],"f1":[1,"1995-03-12T13:06:34.149Z"]}]]
+```
+
+## The cause
+
+Not the Set, and not the union's own `[-1, …]` envelope: both were already budgeted. The flat-union
+encoder merges a union's OBJECT members into one wire shape whose every property is the union of
+that name across the arms (`ts-go-runtypes/internal/cachegen/typefunctions/union_flat_layout.go`).
+A property two arms declare with different types therefore rides as `[<candidateIndex>,value]`.
+
+In the reported type, `f0` is declared by three arms and `f1` by two, so the encoder wrote
+`"f0":[2,null]` and `"f1":[1,"…"]` where the walk had sized a bare `null` and a bare Date. The
+`jsonsize` walk sizes each union member on its own and knew nothing about that merge, so it lost
+4 bytes per merged property.
+
+Nothing about this is specific to a sized container. With the fix reverted, the same undercount
+fires for a `Set` item, a `Map` key, an array element and a bare union root; a `Map` value only
+escaped because a generous key bound absorbed the gap.
+
+## What shipped
+
+`ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go` — `unionBytes` now counts the union's
+mergeable members (object literals and intersections; every other member keeps its own
+`[index,value]` arm, and a bounded class member like Date / Map / Set is always atomic). When two
+or more merge, each member's size gains one sub-envelope per direct data property:
+
+```go
+size := result.Bytes
+if mergeable > 1 {
+    size += w.mergedPropCount(w.deref(member)) * subEnvelopeBytes(mergeable)
+}
+```
+
+`subEnvelopeBytes(candidates)` is `[` + the widest candidate index + `,` + `]`. A merged property
+holds at most one candidate per object member, and the sub-wrap index is always a plain 0-based
+one (`emitMergedPropStringify`), never the object branch's `-1`.
+
+Charging every property of every mergeable member, rather than only the ones the emitter really
+wraps, is the same worst case the outer envelope already takes: the walk cannot see the emitter's
+layout decision, and the number is a bound, not a size. The reported type's bound goes from 68 to
+80 against the encoder's 70.
+
+## Tests
+
+- `ts-go-runtypes/internal/cachegen/jsonsize/jsonsize_test.go` —
+  `TestMaxBytes_UnionMergedProps` pins the arithmetic for a two-object union, for a union with a
+  single object member (no sub-envelope, the arm size stands) and for a `Set` of the merged union.
+- `packages/run-types/test/fuzz/type/unionMergedPropJsonSize.smoke.test.ts` — compiles the reported
+  four-arm shape as a `Set` item, a `Map` value, a `Map` key, an array element and a bare root, and
+  checks the real encoder's UTF-8 output against the bound the build wrote. Each case carries its
+  own literal tags: identical shapes share a node id, and a nested union's row has no bound.
+
+Both fail with the surcharge removed.
+
+## Not changed
+
+The fuzz lane's own shape. It did its job: it found a real undercount and printed a replayable
+per-type seed. Making the soak's exploration deterministic across machines is a separate concern.

--- a/packages/run-types/test/fuzz/type/unionMergedPropJsonSize.smoke.test.ts
+++ b/packages/run-types/test/fuzz/type/unionMergedPropJsonSize.smoke.test.ts
@@ -1,0 +1,105 @@
+// jsonsize regression: a union of object members rides the wire as ONE merged
+// shape, so a property two members declare with different types is wrapped as
+// `[<candidateIndex>,value]`. The `jsonMaxBytes` walk sized each member on its
+// own and never charged those wrappers, so a bounded `Set` of such a union
+// claimed 68 bytes while the encoder emitted 70:
+//   [[-1,{"kind":"t2","f0":[2,null],"f1":[1,"1995-03-12T13:06:34.149Z"]}]]
+// The same merge happens wherever the union sits, so a `Map` value, a `Map`
+// key and a bare root are all checked here.
+import {describe, it, expect} from 'vitest';
+import {getRunType} from '@mionjs/run-types';
+import {openClient, compileType, hasBinary} from './typeFuzzHarness.ts';
+import {typecheckGeneratedType} from './tsValidate.ts';
+import type {GeneratedType, PropShape, TypeShape} from '../core/typeGen.ts';
+
+function prop(name: string, shape: TypeShape): PropShape {
+  return {name, optional: false, readonly: false, method: false, shape};
+}
+
+/** The four arms the soak reported: `f0` is declared by three of them with a
+ *  different type each, `f1` by two, so both gain a sub-envelope. `tag` keeps
+ *  every case's union a DISTINCT type: identical shapes share a node id, and
+ *  the same id read back from an earlier case's build carries that build's row
+ *  (a nested union has no bound, only a root does). **/
+const union4 = (tag: string): TypeShape => ({
+  kind: 'union',
+  members: [
+    {
+      kind: 'object',
+      props: [
+        prop('kind', {kind: 'literal', value: `t0-${tag}`}),
+        prop('f0', {kind: 'object', props: [prop('p0', {kind: 'number'})]}),
+      ],
+    },
+    {
+      kind: 'object',
+      props: [
+        prop('kind', {kind: 'literal', value: `t1-${tag}`}),
+        prop('f0', {kind: 'undefined'}),
+        prop('f1', {kind: 'set', elem: {kind: 'null'}, structural: {maxItems: 3}}),
+      ],
+    },
+    {
+      kind: 'object',
+      props: [prop('kind', {kind: 'literal', value: `t2-${tag}`}), prop('f0', {kind: 'null'}), prop('f1', {kind: 'date'})],
+    },
+    {kind: 'object', props: [prop('kind', {kind: 'literal', value: `t3-${tag}`})]},
+  ],
+});
+
+/** The widest arm: three properties, two of them sub-wrapped, one a Date. **/
+const widestArm = (tag: string) => ({kind: `t2-${tag}`, f0: null, f1: new Date('2018-03-26T05:49:26.862Z')});
+
+const cases: {title: string; root: TypeShape; values: () => unknown[]}[] = [
+  {
+    title: 'Set<union of objects> (the reported shape)',
+    root: {kind: 'set', elem: union4('set'), structural: {maxItems: 1}},
+    values: () => [new Set([widestArm('set')]), new Set([{kind: 't1-set', f0: undefined, f1: new Set([null, null, null])}])],
+  },
+  {
+    title: 'Map<string, union of objects>',
+    root: {kind: 'map', key: {kind: 'format', name: 'maxLen8'}, value: union4('mapvalue'), structural: {maxItems: 1}},
+    values: () => [new Map([['abcdefgh', widestArm('mapvalue')]])],
+  },
+  {
+    title: 'Map<union of objects, number>',
+    root: {kind: 'map', key: union4('mapkey'), value: {kind: 'number'}, structural: {maxItems: 1}},
+    values: () => [new Map([[widestArm('mapkey'), -1.7976931348623157e308]])],
+  },
+  {
+    title: 'a bare union of objects, no sized container',
+    root: union4('bare'),
+    values: () => [widestArm('bare')],
+  },
+  {
+    title: 'array of a union of objects',
+    root: {kind: 'array', elem: union4('array'), structural: {maxItems: 2}},
+    values: () => [[widestArm('array'), widestArm('array')]],
+  },
+];
+
+describe('jsonMaxBytes covers the flat-union merged-property envelope', () => {
+  for (const {title, root, values} of cases) {
+    (hasBinary() ? it : it.skip)(`the encoder never passes the bound: ${title}`, () => {
+      const gen: GeneratedType = {decls: [], root};
+      expect(typecheckGeneratedType(gen), `${title} must be valid TypeScript`).toEqual([]);
+      const client = openClient();
+      return compileType(client, gen)
+        .then((compiled) => {
+          expect(compiled.resolverError, compiled.resolverError).toBeUndefined();
+          expect(compiled.evalError, compiled.evalError).toBeUndefined();
+          const reflectionId = compiled.sites.find((site) => !site.fnId)?.id;
+          expect(reflectionId, 'the type compiled no reflection root').toBeDefined();
+          const bound = getRunType(undefined, reflectionId as never).jsonMaxBytes;
+          expect(bound, 'the type must be fully bounded').toBeTypeOf('number');
+          for (const value of values()) {
+            const encoded = compiled.wired.jsonEncode!(value);
+            expect(typeof encoded).toBe('string');
+            const emitted = Buffer.byteLength(encoded as string, 'utf8');
+            expect(emitted, `${encoded} is ${emitted} bytes, over the bound ${bound}`).toBeLessThanOrEqual(bound!);
+          }
+        })
+        .finally(() => client.close());
+    });
+  }
+});

--- a/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go
+++ b/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go
@@ -422,25 +422,83 @@ func (w *walker) objectBytes(rt *reflection.RunType, path string, depth int) Res
 // `[-1,value]`) whenever the union carries a transform or an object member;
 // the walk cannot see the emitter's layout decision, so it always budgets the
 // widest envelope the member count allows.
+//
+// A union of two or more OBJECT members costs a second envelope the arm sizes
+// know nothing about: the flat layout merges those members into one shape
+// whose every property is the union of that name across the arms
+// (union_flat_layout.go), so a property two arms declare with different types
+// rides as `[<candidateIndex>,value]`. The arm walk sizes `f1: Date` as a bare
+// date, while the wire carries `"f1":[1,"…"]`. Charging every property of every
+// mergeable member is the same worst case the envelope above takes: a bound,
+// not the emitter's real layout.
 func (w *walker) unionBytes(rt *reflection.RunType, path string, depth int) Result {
 	if len(rt.Children) == 0 {
 		return bounded(nullBytes)
 	}
+	mergeable := w.mergeableMembers(rt)
 	largest := 0
 	for i, member := range rt.Children {
 		result := w.walk(member, path+"|"+strconv.Itoa(i), depth+1)
 		if !result.Bounded {
 			return result
 		}
-		largest = max(largest, result.Bytes)
+		size := result.Bytes
+		if mergeable > 1 {
+			size += w.mergedPropCount(w.deref(member)) * subEnvelopeBytes(mergeable)
+		}
+		largest = max(largest, size)
 	}
 	return bounded(largest + unionEnvelopeBytes(len(rt.Children)))
+}
+
+// mergeableMembers counts the members the flat layout merges into one object
+// shape: object literals and intersections. Every other member keeps its own
+// `[index,value]` arm, a bounded class member (Date / Map / Set) included.
+func (w *walker) mergeableMembers(rt *reflection.RunType) int {
+	count := 0
+	for _, child := range rt.Children {
+		if member := w.deref(child); member != nil && isMergeableKind(member.Kind) {
+			count++
+		}
+	}
+	return count
+}
+
+func isMergeableKind(kind reflection.ReflectionKind) bool {
+	return kind == reflection.KindObjectLiteral || kind == reflection.KindIntersection
+}
+
+// mergedPropCount counts the direct data properties of a mergeable member, the
+// slots that gain a sub-envelope. Mirrors the filter objectBytes sizes with.
+func (w *walker) mergedPropCount(rt *reflection.RunType) int {
+	if rt == nil || !isMergeableKind(rt.Kind) {
+		return 0
+	}
+	count := 0
+	for _, child := range rt.Children {
+		member := w.deref(child)
+		if member == nil || member.IsStatic || member.Child == nil {
+			continue
+		}
+		if member.Kind == reflection.KindProperty || member.Kind == reflection.KindPropertySignature {
+			count++
+		}
+	}
+	return count
 }
 
 // unionEnvelopeBytes: `[` + the widest member index (`-1`, or the last index)
 // + `,` + `]`.
 func unionEnvelopeBytes(members int) int {
 	return 1 + max(len("-1"), len(strconv.Itoa(members-1))) + 1 + 1
+}
+
+// subEnvelopeBytes: `[` + the widest candidate index + `,` + `]`. A merged
+// property holds at most one candidate per object member, and its index is
+// always a plain 0-based one (emitMergedPropStringify), never the object
+// branch's `-1`.
+func subEnvelopeBytes(candidates int) int {
+	return 1 + len(strconv.Itoa(candidates-1)) + 1 + 1
 }
 
 // classBytes: the builtins with a fixed JSON spelling are constants; a Map is

--- a/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize_test.go
+++ b/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize_test.go
@@ -173,6 +173,30 @@ func TestMaxBytes_Union(t *testing.T) {
 	expectUnbounded(t, "unbounded member", MaxBytes(mixed, noRefs), "|1: string without maxLength")
 }
 
+func TestMaxBytes_UnionMergedProps(t *testing.T) {
+	lit := func(value string) *reflection.RunType {
+		return &reflection.RunType{Kind: reflection.KindLiteral, Literal: value}
+	}
+	armA := object(prop("kind", lit("a"), false), prop("f", num, false))
+	armB := object(prop("kind", lit("b"), false), prop("f", boolean, false))
+	// Two object members merge into ONE wire shape, so `f` rides as
+	// `[<candidateIndex>,value]`: every property of every arm is charged that
+	// sub-envelope on top of the arm's own size.
+	// armA = `{` + `"kind":"a"` + `,` + `"f":<24>` + `}` = 41, + 2 × `[1,` … `]`
+	sub := subEnvelopeBytes(2)
+	merged := &reflection.RunType{Kind: reflection.KindUnion, Children: []*reflection.RunType{armA, armB}}
+	expectBounded(t, "merged props", MaxBytes(merged, noRefs), 41+2*sub+unionEnvelopeBytes(2))
+	// A single object member has a single candidate per property, so the flat
+	// layout writes no sub-envelope and the arm size stands.
+	lone := &reflection.RunType{Kind: reflection.KindUnion, Children: []*reflection.RunType{armA, num}}
+	expectBounded(t, "one object member", MaxBytes(lone, noRefs), 41+unionEnvelopeBytes(2))
+	// The surcharge reaches the union wherever it sits: `Set<armA|armB>` of 1.
+	item := &reflection.RunType{ID: "u", Kind: reflection.KindParameter, SubKind: reflection.SubKindSetItem, Child: merged}
+	setRT := &reflection.RunType{Kind: reflection.KindClass, SubKind: reflection.SubKindSet, Arguments: []*reflection.RunType{reflection.NewRef("u")},
+		FormatAnnotation: &reflection.FormatAnnotation{Name: "formattedSet", Params: map[string]any{"maxItems": 1.0}}}
+	expectBounded(t, "set of merged union", MaxBytes(setRT, map[string]*reflection.RunType{"u": item}), 2+41+2*sub+unionEnvelopeBytes(2))
+}
+
 func TestMaxBytes_MapAndSet(t *testing.T) {
 	param := func(id string, sub reflection.ReflectionSubKind, child *reflection.RunType) *reflection.RunType {
 		return &reflection.RunType{ID: id, Kind: reflection.KindParameter, SubKind: sub, Child: child}


### PR DESCRIPTION
`jsonMaxBytes` is meant to be a true upper bound on what the compiled JSON encoder emits, so a consumer deriving a request size limit from it never rejects a payload the encoder itself produced. For a union of two or more object members it was not.

The `jsonsize` fuzz soak caught it on a bounded `Set` (CI run 34719842695, job 103623691959, per-type seed 2646330014):

```
[jsonsize-fuzz][JS-MAX-ENCODER] [1d] Set<({2}|{3}|{3}|{1})>≤1 (seed=2646330014):
the compiled JSON encoder emits 70 bytes, over the type's jsonMaxBytes 68
    [[-1,{"kind":"t2","f0":[2,null],"f1":[1,"1995-03-12T13:06:34.149Z"]}]]
```

## The cause

Not the `Set`, and not the union's own `[-1, …]` envelope: both were already budgeted. The flat-union encoder merges a union's **object** members into one wire shape whose every property is the union of that name across the arms (`union_flat_layout.go`), so a property two arms declare with different types rides as `[<candidateIndex>,value]`.

In the reported type `f0` is declared by three arms and `f1` by two, so the encoder wrote `"f0":[2,null]` and `"f1":[1,"…"]` where the walk had sized a bare `null` and a bare `Date`. The walk sizes each member on its own and knew nothing about the merge, losing 4 bytes per merged property.

Nothing about this is specific to a sized container. With the fix reverted, the same undercount fires for a `Set` item, a `Map` key, an array element and a bare union root; a `Map` value only escaped because a generous key bound absorbed the gap.

## The change

`unionBytes` now counts the union's mergeable members (object literals and intersections; every other member keeps its own `[index,value]` arm, and a bounded class member like `Date` / `Map` / `Set` is always atomic). When two or more merge, each member's size gains one sub-envelope per direct data property:

```go
size := result.Bytes
if mergeable > 1 {
    size += w.mergedPropCount(w.deref(member)) * subEnvelopeBytes(mergeable)
}
```

Charging every property of every mergeable member, rather than only the ones the emitter really wraps, is the same worst case the outer envelope already takes: the walk cannot see the emitter's layout decision, and the number is a bound, not a size. The reported type's bound goes from 68 to 80 against the encoder's 70.

## Tests

- `TestMaxBytes_UnionMergedProps` pins the arithmetic for a two-object union, for a union with a single object member (no sub-envelope, the arm size stands) and for a `Set` of the merged union.
- `unionMergedPropJsonSize.smoke.test.ts` compiles the reported four-arm shape as a `Set` item, a `Map` value, a `Map` key, an array element and a bare root, and checks the real encoder's UTF-8 output against the bound the build wrote.

Both fail with the surcharge removed.

Ran green: the full JS suite (all 21 projects), `go -C ts-go-runtypes test ./internal/... ./cmd/...`, `pnpm run lint`, `pnpm run format`, and `pnpm miondevx core fuzz jsonsize`.

## A separate finding, delegated

A 7 minute soak over 3700 types reported **zero** `JS-MAX-ENCODER` violations, confirming this fix, but 22 on the other oracle, `JS-MAX-STRINGIFY`. They are a different, pre-existing defect: the encoder DROPS a typed array / `ArrayBuffer` / `DataView` member, so the bound's 4 bytes cover the wire, while `JSON.stringify` of the raw value keeps it with no length the type declares.

```
=== {p0:Uint8Array} bound 11 | stringify {"p0":{"0":1,"1":2,"2":3}} | encoder {}
```

This predates the change here (the surcharge only ever ADDS bytes, and none of the reported types is a union of object members) and needs a design call about which value the bound promises to cover, so it is filed and handed to a parallel session rather than widened into this PR. That fix lands in its own PR.

No CI labels: this touches neither package exports, the website, the benchmarks, nor the drizzle packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012c4wr4Zpet4m8JRgPqzQ9t

---
_Generated by [Claude Code](https://claude.ai/code/session_012c4wr4Zpet4m8JRgPqzQ9t)_