### PR TITLE
fix(jsonsize): the jsonMaxBytes bound covers the wire, not raw JSON.stringify

### DIFF
--- a/container/website/content/01.rpc/02.server/09.security.md
+++ b/container/website/content/01.rpc/02.server/09.security.md
@@ -50,7 +50,7 @@ Every route has its own request limit. The router settles it once, when the rout
 <code-import path="packages/examples/src/router/security-max-body-size.ts" lang="ts" />
 
 ::note
-The derived limit measures the body the client actually sends. A parameter that never reaches the wire, a function, a symbol or a binary value such as `Uint8Array`, costs nothing toward it.
+The derived limit measures the body the client actually sends. Members that never reach the wire (a function, a symbol, or a binary value such as `Uint8Array`) cost nothing toward it.
 ::
 
 The platform adapter reads the body against that number and stops a body that passes it as early as the platform allows: node, uws and Cloudflare stop the read mid-stream, Bun buffers the body natively before your code runs (its server-wide read limit is set to the largest route limit, and a smaller route limit refuses the buffered body). The router checks it again before parsing, so the limit holds everywhere. The resolved number is published in the route metadata as `maxBodySize`.

--- a/container/website/content/01.rpc/02.server/09.security.md
+++ b/container/website/content/01.rpc/02.server/09.security.md
@@ -49,6 +49,10 @@ Every route has its own request limit. The router settles it once, when the rout
 
 <code-import path="packages/examples/src/router/security-max-body-size.ts" lang="ts" />
 
+::note
+The derived limit measures the body the client actually sends. A parameter that never reaches the wire, a function, a symbol or a binary value such as `Uint8Array`, costs nothing toward it.
+::
+
 The platform adapter reads the body against that number and stops a body that passes it as early as the platform allows: node, uws and Cloudflare stop the read mid-stream, Bun buffers the body natively before your code runs (its server-wide read limit is set to the largest route limit, and a smaller route limit refuses the buffered body). The router checks it again before parsing, so the limit holds everywhere. The resolved number is published in the route metadata as `maxBodySize`.
 
 To turn type-derived limits off, set `derivedPayloadLimits: false` in the `runTypes` block of the Vite plugin or `withMion`. Every route then takes its own option or the adapter's number.

--- a/docs/done/jsonsize-bound-ignores-binary-view-stringify.md
+++ b/docs/done/jsonsize-bound-ignores-binary-view-stringify.md
@@ -1,0 +1,125 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-12
+---
+
+# jsonMaxBytes and the jsonsize lane disagree about a binary view
+
+## Intent
+
+The `jsonsize` fuzz lane holds `jsonMaxBytes` to TWO oracles: `JS-MAX-ENCODER` (the compiled JSON
+encoder's real output) and `JS-MAX-STRINGIFY` (`JSON.stringify` of the raw value). A type carrying
+a typed array, an `ArrayBuffer`, a `SharedArrayBuffer` or a `DataView` satisfies the first and
+fails the second, and it has no length bound to fall back on. Decide which value the bound is
+promising to cover and make the two agree.
+
+## What fails
+
+A 7 minute soak (`MION_FUZZ_JSONSIZE_SOAK_MS=420000 pnpm miondevx core fuzz jsonsize`) over 3700
+types reported 22 violations, all `JS-MAX-STRINGIFY`, none `JS-MAX-ENCODER`:
+
+```
+[jsonsize-fuzz][JS-MAX-STRINGIFY] [1d] N0 (seed=2010557748): JSON.stringify is 44 bytes, over the type's jsonMaxBytes 31
+    {"p0":{"0":1,"1":2,"2":3},"p1":null,"p2":{}}
+[jsonsize-fuzz][JS-MAX-STRINGIFY] ({3}&{1}) (seed=1115569936): JSON.stringify is 85 bytes, over the type's jsonMaxBytes 78
+    {"m0_0":"1975-06-09T10:20:04.238Z","m0_1":{"0":1,"1":2,"2":3},"m0_2":true,"m1_0":{}}
+```
+
+`{"0":1,"1":2,"2":3}` is `JSON.stringify(new Uint8Array([1,2,3]))`, and `{}` is a raw buffer or a
+`DataView`.
+
+This predates the merged-property fix that found it: that change only ever ADDS bytes to a bound,
+and none of the reported types is a union of object members.
+
+## The disagreement, minimised
+
+```
+=== {p0:Uint8Array} bound 11 | stringify {"p0":{"0":1,"1":2,"2":3}} | encoder {}
+=== {p0:ArrayBuffer} bound 11 | stringify {"p0":{}}                 | encoder {}
+=== {p0:DataView}   bound 11 | stringify {"p0":{}}                  | encoder {}
+```
+
+The encoder DROPS the member (DataOnly strips every binary view), so the wire carries nothing for
+it and the bound's 4 bytes cover it with room to spare. `JSON.stringify` of the raw JS value keeps
+it, and a typed array stringifies to one `"<index>":<number>` pair per element with no maximum the
+type declares.
+
+The walk's arm is in `ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go`:
+
+```go
+case reflection.SubKindNonSerializable:
+	return bounded(nullBytes)
+```
+
+Its neighbours (`KindFunction`, `KindSymbol`, `KindPromise`) carry the comment "JSON.stringify
+drops these: absent in an object, `null` in an array", which is true for those kinds and false for
+a binary view. So the two oracles were only ever in agreement by accident.
+
+## The call to make
+
+Both directions are defensible and the decision belongs to whoever owns the bound's contract:
+
+- **The bound covers the WIRE.** Then it is already right, and `JS-MAX-STRINGIFY` is measuring a
+  value the wire never carries. The lane would stop generating binary views into the bounded
+  presets, the way `BOUNDED_PRESETS` in
+  [jsonSizeFuzzRunner.ts](../../packages/run-types/test/fuzz/type/jsonSizeFuzzRunner.ts) already
+  sets `classes: false`, or the stringify oracle would measure the DataOnly projection instead of
+  the raw value.
+- **The bound covers ANY JSON body that could arrive.** Then a type containing a binary view is
+  unbounded and loses its derived limit.
+
+Worth weighing before choosing: mion turns this number into a per-route request size limit. Making
+such a type unbounded drops it to the platform default (128 KB), which is LOOSER than the derived
+limit it has today, so that direction costs real protection on exactly the routes that carry bulk
+data.
+
+## Done when
+
+- The two oracles agree on a type carrying a typed array, an `ArrayBuffer`, a `SharedArrayBuffer`
+  and a `DataView`, with a non-fuzz test pinning whichever answer is chosen.
+- The chosen contract is written down on the `SubKindNonSerializable` arm, so the next reader does
+  not have to re-derive it from the function-kind comment next to it.
+- A soak of at least 7 minutes reports zero violations on both oracles.
+
+## Plan — the bound covers the wire (2026-09-12)
+
+**The call: the bound covers the WIRE.** `jsonMaxBytes` is the largest body the compiled JSON
+encoder writes, which is the body a mion client actually sends. It is NOT a bound on
+`JSON.stringify` of an arbitrary raw JS value, and it never was: the two only agreed by accident.
+
+Why this way rather than making such a type unbounded:
+
+- The router turns the number into a per-route request limit. Making a binary-carrying type
+  unbounded drops it to the platform default (128 KB), LOOSER than the derived limit it has today,
+  so the "safer" direction is the one that removes protection.
+- Nothing the type declares bounds a typed array's stringified form (one `"<index>":<number>` pair
+  per element), so "any JSON body that could arrive" makes every binary-carrying route unbounded
+  by construction. That is not a bound, it is an opt-out.
+- The wire reading is what the walk already implements everywhere else, and what the encoder,
+  DataOnly and the build-time drop warning all agree on.
+
+Only a TYPED ARRAY actually broke the stringify oracle. `ArrayBuffer`, `SharedArrayBuffer` and
+`DataView` stringify to `{}` (2 bytes), which the arm's `nullBytes` (4) already covers; they show
+up in the soak output only as bystanders next to a typed array.
+
+### What shipped
+
+- `ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go` — the contract is written on the
+  `SubKindNonSerializable` arm and in the package doc. No behaviour change: the arm's
+  `bounded(nullBytes)` was already right under this contract.
+- `packages/run-types/test/fuzz/type/jsonSizeFuzzRunner.ts` — `JS-MAX-STRINGIFY` now measures
+  `stringifyWire(value)`: `JSON.stringify` with a replacer that drops binary views. The replacer
+  returning `undefined` leaves an object key absent and an array slot `null`, which is exactly the
+  walk's own rule for a dropped member, so the oracle stays independent of the compiled encoder.
+- `ts-go-runtypes/internal/cachegen/jsonsize/jsonsize_test.go` — `TestMaxBytes_NonSerializableIsWireBound`
+  pins `bounded(nullBytes)` at the root and in an object, array and tuple slot.
+- `packages/run-types/test/fuzz/type/binaryViewJsonSize.smoke.test.ts` — a non-fuzz test over
+  `{p0: Uint8Array; p1: ArrayBuffer; p2: SharedArrayBuffer; p3: DataView}` and `[Uint8Array, boolean]`:
+  the encoder emits `{}`, the wire-shaped stringify is within the bound, the raw one is not.
+- `container/website/content/01.rpc/02.server/09.security.md` — a note on Body Size Limits saying
+  the derived limit measures the body the client sends, so a member that never reaches the wire
+  costs nothing toward it.
+
+A 7 minute soak reports zero violations on both oracles.

--- a/docs/done/jsonsize-bound-ignores-binary-view-stringify.md
+++ b/docs/done/jsonsize-bound-ignores-binary-view-stringify.md
@@ -122,4 +122,9 @@ up in the soak output only as bystanders next to a typed array.
   the derived limit measures the body the client sends, so a member that never reaches the wire
   costs nothing toward it.
 
-A 7 minute soak reports zero violations on both oracles.
+An 8 minute soak over 3700+ types reports zero violations on both oracles.
+
+The first soak of this change still showed a few `JS-MAX-ENCODER` violations on flat unions. They
+were the separate flat-union merged-property bug, not this one: seed 4070727106 bounded
+`({1}&{1})[]` at 70 while the encoder emitted 73, and the merged-property fix raises that bound to
+78. That fix is in `main`, and the clean soak ran on top of it.

--- a/packages/run-types/test/fuzz/type/binaryViewJsonSize.smoke.test.ts
+++ b/packages/run-types/test/fuzz/type/binaryViewJsonSize.smoke.test.ts
@@ -1,0 +1,79 @@
+// `jsonMaxBytes` bounds the WIRE, so a binary view costs a dropped member and
+// nothing more: DataOnly strips typed arrays, ArrayBuffer, SharedArrayBuffer
+// and DataView, and the compiled encoder writes nothing for them. Raw
+// `JSON.stringify` keeps a typed array as one `"<index>":<number>` pair per
+// element, which no bound the type declares could cover, so the json-size fuzz
+// lane's stringify oracle drops binary views before measuring (`stringifyWire`).
+import {describe, it, expect} from 'vitest';
+import {getRunType} from '@mionjs/run-types';
+import {openClient, compileType, hasBinary} from './typeFuzzHarness.ts';
+import {stringifyWire} from './jsonSizeFuzzRunner.ts';
+import {typecheckGeneratedType} from './tsValidate.ts';
+import type {GeneratedType, TypeShape, PropShape} from '../core/typeGen.ts';
+
+function prop(name: string, shape: TypeShape): PropShape {
+  return {name, optional: false, readonly: false, method: false, shape};
+}
+const typedArray: TypeShape = {kind: 'typedarray', name: 'Uint8Array'};
+
+/** `{p0: Uint8Array; p1: ArrayBuffer; p2: SharedArrayBuffer; p3: DataView}` **/
+const allFour: GeneratedType = {
+  decls: [],
+  root: {
+    kind: 'object',
+    props: [
+      prop('p0', typedArray),
+      prop('p1', {kind: 'arraybuffer'}),
+      prop('p2', {kind: 'sharedarraybuffer'}),
+      prop('p3', {kind: 'dataview'}),
+    ],
+  },
+};
+/** `[Uint8Array, boolean]` — a dropped tuple slot is `null`, the walk's `nullBytes`. **/
+const inTuple: GeneratedType = {decls: [], root: {kind: 'tuple', elems: [typedArray, {kind: 'boolean'}]}};
+
+function utf8(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
+}
+
+describe('jsonMaxBytes of a type carrying a binary view', () => {
+  (hasBinary() ? it : it.skip)(
+    'bounds the wire, and the stringify oracle agrees',
+    async () => {
+      expect(typecheckGeneratedType(allFour), 'must be valid TypeScript').toEqual([]);
+      expect(typecheckGeneratedType(inTuple), 'must be valid TypeScript').toEqual([]);
+      const client = openClient();
+      try {
+        const compiled = await compileType(client, allFour);
+        expect(compiled.resolverError, compiled.resolverError).toBeUndefined();
+        expect(compiled.evalError, compiled.evalError).toBeUndefined();
+        const bound = getRunType(undefined, compiled.sites.find((site) => !site.fnId)!.id as never).jsonMaxBytes!;
+        expect(bound).toBeGreaterThan(0);
+
+        const value = {
+          p0: new Uint8Array([1, 2, 3]),
+          p1: new ArrayBuffer(8),
+          p2: new SharedArrayBuffer(8),
+          p3: new DataView(new ArrayBuffer(8)),
+        };
+        // the encoder drops all four: an empty object on the wire, well under the bound
+        expect(compiled.wired.jsonEncode!(value)).toBe('{}');
+        // the wire-shaped stringify agrees; the raw one does not, which is the whole point
+        expect(utf8(stringifyWire(value))).toBeLessThanOrEqual(bound);
+        expect(utf8(JSON.stringify(value))).toBeGreaterThan(bound);
+        expect(JSON.stringify(value)).toContain('"0":1');
+
+        const tuple = await compileType(client, inTuple);
+        expect(tuple.resolverError, tuple.resolverError).toBeUndefined();
+        const tupleBound = getRunType(undefined, tuple.sites.find((site) => !site.fnId)!.id as never).jsonMaxBytes!;
+        // `[` + `null` + `,` + `false` + `]`, the walk's own arithmetic
+        expect(tupleBound).toBe(2 + 4 + 1 + 5);
+        expect(stringifyWire([new Uint8Array([1, 2, 3]), true])).toBe('[null,true]');
+        expect(utf8(stringifyWire([new Uint8Array([1, 2, 3]), true]))).toBeLessThanOrEqual(tupleBound);
+      } finally {
+        client.close();
+      }
+    },
+    180000
+  );
+});

--- a/packages/run-types/test/fuzz/type/jsonSizeFuzzRunner.ts
+++ b/packages/run-types/test/fuzz/type/jsonSizeFuzzRunner.ts
@@ -4,7 +4,9 @@
 // BOUNDED type (typeGen with `boundedSizes`), compiles it, reads the bound off
 // the reflection root, then draws values from the product `createMockDataFn`
 // and measures them two ways:
-//   - JS-MAX-STRINGIFY: `JSON.stringify(value)` in UTF-8 bytes (the raw value)
+//   - JS-MAX-STRINGIFY: `JSON.stringify(value)` in UTF-8 bytes, binary views
+//                       dropped (an independent measure that never reads the
+//                       compiled encoder; see `stringifyWire`)
 //   - JS-MAX-ENCODER:   the compiled JSON encoder's output in UTF-8 bytes (what
 //                       the router / client really put on the wire)
 // Both must be <= jsonMaxBytes. Two generator presets run: the serialisable
@@ -146,18 +148,36 @@ function boundOf(compiled: CompiledType): number | undefined {
   return getRunType(undefined, reflectionId as never).jsonMaxBytes;
 }
 
+/** The bound covers the WIRE, so this oracle must measure a wire-shaped value.
+ *  DataOnly strips every binary view, and a typed array would otherwise
+ *  stringify to one `"<index>":<number>` pair per element, which no bound the
+ *  type declares could cover. Dropping them here costs nothing: a replacer
+ *  returning undefined leaves an object key absent and an array slot `null`,
+ *  the walk's own rule for a non-serialisable member. */
+export function stringifyWire(value: unknown): string {
+  return (
+    JSON.stringify(value, (_key, member: unknown) =>
+      ArrayBuffer.isView(member) || member instanceof ArrayBuffer || isSharedArrayBuffer(member) ? undefined : member
+    ) ?? ''
+  );
+}
+
+function isSharedArrayBuffer(member: unknown): boolean {
+  return typeof SharedArrayBuffer !== 'undefined' && member instanceof SharedArrayBuffer;
+}
+
 function measure(compiled: CompiledType, bound: number, value: unknown, seed: number): JsonSizeViolation[] {
   const out: JsonSizeViolation[] = [];
   // a root that stringifies to nothing (undefined, a function) puts no bytes on the wire
-  const raw = JSON.stringify(value) ?? '';
-  const rawBytes = utf8Bytes(raw);
-  if (rawBytes > bound) {
+  const wire = stringifyWire(value);
+  const wireBytes = utf8Bytes(wire);
+  if (wireBytes > bound) {
     out.push({
       oracle: 'JS-MAX-STRINGIFY',
       type: compiled.title,
       seed,
-      message: `JSON.stringify is ${rawBytes} bytes, over the type's jsonMaxBytes ${bound}`,
-      value: raw.slice(0, 300),
+      message: `JSON.stringify is ${wireBytes} bytes, over the type's jsonMaxBytes ${bound}`,
+      value: wire.slice(0, 300),
     });
   }
   const encoded = compiled.wired.jsonEncode?.(value);

--- a/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go
+++ b/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go
@@ -11,7 +11,9 @@
 // The walk is a sibling of the binary cold-start estimator
 // (cachegen/typefunctions/binary_size_estimate.go) but answers a different
 // question: not "how many bytes will a typical binary encoding take" but "how
-// many bytes can a compact JSON body of this type reach, at most". So every
+// many bytes can a compact JSON body of this type reach, at most". The body it
+// bounds is the one the compiled encoder writes, not `JSON.stringify` of a raw
+// JS value: the two part ways wherever DataOnly drops a member. So every
 // arm is a worst case: 6 bytes per UTF-16 unit for a string (the `\uXXXX`
 // escape form), 24 for a number (the longest `JSON.stringify` double), every
 // optional member present, the largest union member. The `compact` encoder
@@ -540,6 +542,13 @@ func (w *walker) classBytes(rt *reflection.RunType, path string, depth int) Resu
 	case reflection.SubKindTemporalDuration:
 		return unbounded(path, "Duration digits have no bound")
 	case reflection.SubKindNonSerializable:
+		// The bound covers the WIRE, not `JSON.stringify` of the raw value.
+		// DataOnly strips every non-serialisable class, so the encoder writes
+		// nothing for it (a `null` in a tuple slot), and `nullBytes` is that
+		// worst case. `JSON.stringify` disagrees for a typed array, which it
+		// keeps as one `"<index>":<number>` pair per element with no maximum
+		// the type declares; the json-size fuzz lane's stringify oracle drops
+		// binary views for that reason.
 		return bounded(nullBytes)
 	case reflection.SubKindNone:
 		// A user class takes the registered-serializer road when one exists

--- a/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize_test.go
+++ b/ts-go-runtypes/internal/cachegen/jsonsize/jsonsize_test.go
@@ -303,3 +303,23 @@ func TestMaxBytes_VisitsEveryWireSlot(t *testing.T) {
 		return reflection.WalkContinue
 	})
 }
+
+// A binary view (typed array, ArrayBuffer, SharedArrayBuffer, DataView) is a
+// non-serialisable class: DataOnly strips it, so the encoder writes nothing for
+// it in an object and a `null` in a tuple slot. `JSON.stringify` of the raw
+// value disagrees for a typed array, which is why the bound is a wire bound.
+func TestMaxBytes_NonSerializableIsWireBound(t *testing.T) {
+	binaryView := func() *reflection.RunType {
+		return &reflection.RunType{Kind: reflection.KindClass, SubKind: reflection.SubKindNonSerializable}
+	}
+	expectBounded(t, "root", MaxBytes(binaryView(), noRefs), 4)
+	// `{` + `"p0":` + 4 + `}`
+	expectBounded(t, "object member", MaxBytes(object(prop("p0", binaryView(), false)), noRefs), 1+5+4+1)
+	// `[` + 4 + `,` + 4 + `]`
+	expectBounded(t, "array element", MaxBytes(arrayFmt(binaryView(), map[string]any{"maxItems": 2.0}), noRefs), 2+4+1+4)
+	tuple := &reflection.RunType{Kind: reflection.KindTuple, Children: []*reflection.RunType{
+		{Kind: reflection.KindTupleMember, Child: binaryView()}, {Kind: reflection.KindTupleMember, Child: boolean},
+	}}
+	// `[` + `null` + `,` + `false` + `]`
+	expectBounded(t, "tuple member", MaxBytes(tuple, noRefs), 2+4+1+5)
+}


### PR DESCRIPTION
## What was wrong

The `jsonsize` fuzz lane holds `jsonMaxBytes` to two oracles. They disagreed for any type carrying a typed array, an `ArrayBuffer`, a `SharedArrayBuffer` or a `DataView`:

- `JS-MAX-ENCODER` passed: the compiled encoder drops every binary view, so the wire carries nothing for it.
- `JS-MAX-STRINGIFY` failed: `JSON.stringify` of the raw JS value keeps it, and a typed array stringifies to one `"<index>":<number>` pair per element, with no maximum the type declares.

A 7 minute soak over 3700 types reported 22 `JS-MAX-STRINGIFY` violations, none on the encoder.

```
=== {p0:Uint8Array} bound 11 | stringify {"p0":{"0":1,"1":2,"2":3}} | encoder {}
```

## The call: the bound covers the wire

`jsonMaxBytes` is the largest body the compiled encoder writes, which is the body a mion client actually sends. It is not a bound on `JSON.stringify` of an arbitrary raw JS value, and it never was. The two only agreed by accident, because the neighbouring arms (function, symbol, Promise) happen to stringify away.

Why this reading rather than making such a type unbounded:

- The router turns the number into a per-route request limit. Making a binary-carrying type unbounded drops it to the platform default of 128 KB, **looser** than the derived limit it has today, so the apparently safer direction is the one that removes protection.
- Nothing the type declares bounds a typed array's stringified form, so "any JSON body that could arrive" makes every binary-carrying route unbounded by construction. That is an opt-out, not a bound.
- The wire reading is what the encoder, DataOnly and the build-time drop warning already agree on.

Only a typed array actually broke the oracle. `ArrayBuffer`, `SharedArrayBuffer` and `DataView` stringify to `{}` (2 bytes), which the arm's `nullBytes` (4) already covers. They appear in the soak output only as bystanders next to a typed array.

## Changes

No behaviour change: the Go walk was already right under this contract.

- `ts-go-runtypes/internal/cachegen/jsonsize/jsonsize.go` — the contract is written down on the `SubKindNonSerializable` arm and in the package doc, so the next reader does not re-derive it from the function-kind comment next to it.
- `packages/run-types/test/fuzz/type/jsonSizeFuzzRunner.ts` — `JS-MAX-STRINGIFY` now measures `stringifyWire(value)`, `JSON.stringify` with a replacer that drops binary views. The replacer returning `undefined` leaves an object key absent and an array slot `null`, which is exactly the walk's own rule for a dropped member, so the oracle stays independent of the compiled encoder and keeps checking binary-carrying types instead of excluding them from the presets.
- `ts-go-runtypes/internal/cachegen/jsonsize/jsonsize_test.go` — `TestMaxBytes_NonSerializableIsWireBound` pins `bounded(nullBytes)` at the root and in an object, array and tuple slot.
- `packages/run-types/test/fuzz/type/binaryViewJsonSize.smoke.test.ts` — a non-fuzz test over `{p0: Uint8Array; p1: ArrayBuffer; p2: SharedArrayBuffer; p3: DataView}` and `[Uint8Array, boolean]`: the encoder emits `{}`, the wire-shaped stringify fits the bound, the raw one does not.
- `container/website/content/01.rpc/02.server/09.security.md` — a note on Body Size Limits saying the derived limit measures the body the client sends, so a member that never reaches the wire costs nothing toward it.
- The spec moves into `docs/done/` with the decision and its reasoning recorded.

## Verification

- `go -C ts-go-runtypes test ./internal/... ./cmd/...` green.
- `pnpm run test:ci` green, all 7 batches.
- `pnpm run lint` and `pnpm run check-format` clean.
- An 8 minute soak (`MION_FUZZ_JSONSIZE_SOAK_MS=480000 pnpm miondevx core fuzz jsonsize`) on this branch reports zero violations on both oracles.

The first soak of this change still showed a few `JS-MAX-ENCODER` violations on flat unions. Those were the separate merged-property bug, not this one: seed 4070727106 bounded `({1}&{1})[]` at 70 while the encoder emitted 73, and #273 raises that bound to 78. That fix is now in `main`, this branch is rebased on it, and the clean soak ran on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWEdJXt6MEfrKy7poZ6Df7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWEdJXt6MEfrKy7poZ6Df7)_