### PR TITLE
Replace path-based CI gates with content-based lane hashing

### DIFF
--- a/.github/actions/ci-lanes/action.yml
+++ b/.github/actions/ci-lanes/action.yml
@@ -35,6 +35,10 @@ runs:
     - uses: actions/setup-node@v5
       with:
         node-version: 26
+        # setup-node defaults this to true, sees pnpm-lock.yaml and runs `pnpm` to
+        # locate the store, which fails the whole step here: this job installs
+        # nothing, so pnpm is not on PATH and there is no install to cache.
+        package-manager-cache: false
 
     # Dependency-free node, run BEFORE any bootstrap so a skipped lane costs a
     # checkout, not an install.

--- a/.github/actions/ci-lanes/action.yml
+++ b/.github/actions/ci-lanes/action.yml
@@ -1,0 +1,58 @@
+name: Decide which CI lanes to run
+description: >
+  Hash each lane's inputs in the tree being tested, then look up whether that exact
+  content already passed. Emits ONE `lanes` output, a JSON map of
+  {lane: {run, hash, reason}}, read with fromJSON() in a job `if:`.
+
+  A lane runs unless a green marker exists under its hash, so every unknown is a
+  run: an unreadable marker list, a new unclassified path, a lane whose job failed
+  (a failed job never saves a marker). scripts/ci/lanes.mjs owns the lane table and
+  the verdict; run it locally with `pnpm miondevx core lanes`.
+
+  On a pull request the checked-out tree is the MERGE ref, so a lane's hash covers
+  the base branch too: main moving re-runs the lane, which is exactly what a "diff
+  against the last green commit" rule would have got wrong.
+
+  Needs `permissions: actions: read` on the calling job to list the markers. The
+  job that RUNS a lane must save its marker on success with ./.github/actions/save-lane-green.
+
+inputs:
+  lanes:
+    description: Space-separated lane names to decide (see scripts/ci/lanes.mjs)
+    required: true
+
+outputs:
+  lanes:
+    description: 'JSON map of {lane: {run, hash, reason}}'
+    value: ${{ steps.decide.outputs.lanes }}
+
+runs:
+  using: composite
+  steps:
+    # The gate job runs no bootstrap and no install, so it brings its own node. The
+    # runner image ships an older one and the scripts use `import.meta.main`, which
+    # needs the version the workspace targets.
+    - uses: actions/setup-node@v5
+      with:
+        node-version: 26
+
+    # Dependency-free node, run BEFORE any bootstrap so a skipped lane costs a
+    # checkout, not an install.
+    #
+    # A marker is a claim about CONTENT, so one proven on any branch counts: the
+    # list is read with `gh cache list` rather than a ref-scoped cache restore,
+    # which would miss a lane another branch already proved at the same hash.
+    # Failing to read it writes an empty list, and an empty list runs everything.
+    - name: Decide the lanes from their input hashes
+      id: decide
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        LANES: ${{ inputs.lanes }}
+      run: |
+        # --key filters server-side so only our markers count against the limit, and
+        # the limit is generous because a marker missed off the end just re-runs a
+        # lane: wasteful, never wrong.
+        gh cache list --key mion-lane-green- --limit 200 --json key --jq '.[].key' > lane-green-keys.txt || : > lane-green-keys.txt
+        node scripts/ci/lanes.mjs --decide $LANES --green-keys lane-green-keys.txt --github
+        rm -f lane-green-keys.txt

--- a/.github/actions/save-lane-green/action.yml
+++ b/.github/actions/save-lane-green/action.yml
@@ -1,0 +1,26 @@
+name: Record a lane as green
+description: >
+  Write the marker that lets a later run skip this lane. The key IS the claim
+  ("these exact inputs passed"); the payload is a throwaway file, never read back.
+
+  Call this as the LAST step of a lane's job, and leave the default `if: success()`
+  in place: a marker written by a job that failed, or that was cancelled part-way,
+  would skip a lane that never proved anything.
+
+inputs:
+  lane:
+    description: Lane name, as passed to ./.github/actions/ci-lanes
+    required: true
+  hash:
+    description: That lane's hash from the ci-lanes output
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo "${{ inputs.lane }} ${{ inputs.hash }} passed in run ${{ github.run_id }}" > lane-green-marker.txt
+    - uses: actions/cache/save@v4
+      with:
+        path: lane-green-marker.txt
+        key: mion-lane-green-${{ inputs.lane }}-${{ inputs.hash }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,19 @@ name: ci
 #   js-lint — check-format + lint/typecheck + the code-import and examples gates
 #             + the rest of the JS suite + platform-bun's bun:test suites + the
 #             ten time-boxed fuzz lanes, soaked sequentially
-# Both are PATH-GATED via the `changes` job (dorny/paths-filter), same mechanism
-# as `smoke`: they run only when Go (ts-go-runtypes/**) or JS (packages/** + root
-# JS config + scripts) files change, so a docs-only PR skips both. Inside go-fuzz
-# the gofmt/vet/go-test steps are additionally gated on the Go filter, so a
-# packages-only change runs the fuzz half without re-running the Go suite. (A Go
-# change still runs js-lint too: typecheck compiles the ts-go-runtypes testfixtures.)
+# Both are CONTENT-GATED via the `lanes` job, same mechanism as `smoke`. Each lane
+# declares the paths that feed it (scripts/ci/lanes.mjs), hashes exactly those paths
+# in the tree under test, and runs unless a marker says that hash already passed. So
+# a docs-only commit skips every lane, and a commit that only touches the Go tree
+# skips the JS half without touching the other's marker.
+# This replaced a DIFF gate (dorny/paths-filter against the pull request's base),
+# whose flaw was that one touched file under packages/ pinned the filter true for the
+# life of the branch: a later docs-only commit re-ran ~33 runner minutes for nothing.
+# Inside go-fuzz the two halves answer to their own lanes, so a packages-only change
+# runs the fuzz half without re-running the Go suite. The reverse does NOT hold: the
+# Go tree feeds EVERY lane, because the binary built from it is the engine they all
+# run on (the plugin tests spawn it, the container lanes mount it), so a Go change
+# still runs js-lint and the rest.
 #
 # FUZZ BUDGETS: every lane runs on every PR at its QUICK tier — roughly 2x the
 # near-decorative defaults; see the FUZZ registry in scripts/miondevx.mjs — so
@@ -42,8 +49,8 @@ name: ci
 # cache hit and the per-job resolver build is fast, not minutes.
 #
 # A FOURTH job, `smoke`, runs the website serves-a-page + benchmark
-# competitor-build checks. It is path-gated (only when container inputs change,
-# decided by the tiny `changes` job) and runs in PARALLEL with the verify jobs
+# competitor-build checks. It is content-gated (only when container inputs change,
+# decided by the tiny `lanes` job) and runs in PARALLEL with the verify jobs
 # instead of tailing them. It NEVER builds the shared image: it PULLS the
 # prebuilt one (competitor node_modules baked in) and mounts our freshly built
 # binary; if the image can't be pulled the job fails (rebuild + push it from
@@ -80,14 +87,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides WHICH heavy jobs run, by CONTENT. Kept as its own tiny job so the gated
+  # jobs can `needs:` it without a bootstrap, and so a docs-only commit never spins
+  # up a heavy runner at all. The lane table, the hashing and the verdict all live in
+  # scripts/ci/lanes.mjs, so a maintainer can ask the same question locally with
+  # `pnpm miondevx core lanes`.
+  lanes:
+    name: decide lanes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # listing the green markers is an Actions cache read
+      actions: read
+    outputs:
+      lanes: ${{ steps.decide.outputs.lanes }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: decide
+        uses: ./.github/actions/ci-lanes
+        with:
+          lanes: go js-fuzz js smoke
+      # The whole-tree hygiene sweeps live HERE, in the one job nothing can skip,
+      # because they read docs/, .claude/ and the root prose files — exactly the
+      # paths every lane deliberately ignores. Gated on a lane they would miss the
+      # edits they exist to catch.
+      # Plain node, not `pnpm run check:tree`: this job installs nothing, so pnpm is
+      # not on PATH. The script only needs git and node, which is the point of it.
+      - name: Whole-tree sweeps (spec references, old repo URL, NUL bytes)
+        run: node scripts/ci/check-tree.mjs
+
   # ── go-fuzz: Go suite + the count-based JS fuzz lanes ─────────────────────
   # The Go suite (vet + test) is the wall floor here; the count-based JS fuzz
   # lanes (the JS heavyweight) ride along on this otherwise-Go-bound runner to
   # balance it against js-lint, at their quick budgets.
   go-fuzz:
     name: go tests + fuzz
-    needs: changes
-    if: (needs.changes.outputs.go == 'true' || needs.changes.outputs.pkg == 'true') && !contains(github.event.pull_request.labels.*.name, 'skip-defaults')
+    needs: lanes
+    if: (fromJSON(needs.lanes.outputs.lanes).go.run || fromJSON(needs.lanes.outputs.lanes)['js-fuzz'].run) && !contains(github.event.pull_request.labels.*.name, 'skip-defaults')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -99,7 +135,7 @@ jobs:
       # Go-specific steps run only when the Go tree changed; a packages-only
       # change still runs the fuzz half below (which spawns the binary).
       - name: Go formatting (our code only; never third_party)
-        if: needs.changes.outputs.go == 'true'
+        if: fromJSON(needs.lanes.outputs.lanes).go.run
         working-directory: ts-go-runtypes
         run: |
           unformatted="$(gofmt -l cmd internal)"
@@ -109,7 +145,7 @@ jobs:
             exit 1
           fi
       - name: Go vet (our code only; never third_party)
-        if: needs.changes.outputs.go == 'true'
+        if: fromJSON(needs.lanes.outputs.lanes).go.run
         working-directory: ts-go-runtypes
         run: go vet ./cmd/... ./internal/...
       # Build BEFORE the Go suite: since the real-package migration the Go
@@ -126,7 +162,7 @@ jobs:
       # codes among them) live there and once rotted unnoticed when only
       # ./internal/... ran.
       - name: Go test suite (fuzz sweeps at quick budgets)
-        if: needs.changes.outputs.go == 'true'
+        if: fromJSON(needs.lanes.outputs.lanes).go.run
         working-directory: ts-go-runtypes
         env:
           MION_FUZZ_ITER: '30'
@@ -140,6 +176,7 @@ jobs:
       # fuzz-lane-contracts test out of this slice) are pinned by that same test.
       # Local replay: `pnpm miondevx core fuzz <enrich|i18n|typemod|convertcli|apiids> --quick`.
       - name: JS fuzz sweep (count-based lanes at quick budgets)
+        if: fromJSON(needs.lanes.outputs.lanes)['js-fuzz'].run
         env:
           MION_FUZZ_ENRICH_SEQUENCES: '12'
           MION_FUZZ_I18N_SEQUENCES: '12'
@@ -152,7 +189,24 @@ jobs:
       # sweep above never sets it, so the concurrency coverage rides here at the
       # race lane's quick budget (miondevx sets MION_FUZZ_RACE=1 itself).
       - name: Concurrent CLI race fuzz (MION_FUZZ_RACE gate)
+        if: fromJSON(needs.lanes.outputs.lanes)['js-fuzz'].run
         run: pnpm miondevx core fuzz race --quick
+
+      # One marker per HALF, each written only when that half actually ran and
+      # passed. A half that was skipped proved nothing, so it must not claim a
+      # marker that would skip it again next time.
+      - name: Record the Go suite as green
+        if: success() && fromJSON(needs.lanes.outputs.lanes).go.run
+        uses: ./.github/actions/save-lane-green
+        with:
+          lane: go
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes).go.hash }}
+      - name: Record the JS fuzz sweep as green
+        if: success() && fromJSON(needs.lanes.outputs.lanes)['js-fuzz'].run
+        uses: ./.github/actions/save-lane-green
+        with:
+          lane: js-fuzz
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes)['js-fuzz'].hash }}
 
   # ── js-lint: the rest of the JS suite + lint/typecheck/format ─────────────
   # Everything except the fuzz tree runs here, plus the static checks and the
@@ -160,8 +214,8 @@ jobs:
   # go-fuzz this is a complete, disjoint partition of the JS suite.
   js-lint:
     name: js tests + lint
-    needs: changes
-    if: (needs.changes.outputs.go == 'true' || needs.changes.outputs.pkg == 'true') && !contains(github.event.pull_request.labels.*.name, 'skip-defaults')
+    needs: lanes
+    if: fromJSON(needs.lanes.outputs.lanes).js.run && !contains(github.event.pull_request.labels.*.name, 'skip-defaults')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -251,6 +305,11 @@ jobs:
       # lane replays locally with this exact command.
       - name: Time-boxed fuzz lanes at quick budgets
         run: pnpm miondevx core fuzz cloning elision jsonsize nondata roundtrip secbinary secformat secgen sechttp secjson size types value --quick
+      - name: Record js tests + lint as green
+        uses: ./.github/actions/save-lane-green
+        with:
+          lane: js
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes).js.hash }}
 
   # ── commitlint: Conventional Commits gate on the PR's commits ──────────────
   # Validates every commit in the PR range against commitlint.config.js. PR-only
@@ -284,55 +343,13 @@ jobs:
             git log -1 --format=%B "$sha" | pnpm exec commitlint --verbose
           done
 
-  # Decides WHICH heavy jobs run, by path: `smoke` (the website/benchmarks apps +
-  # their drivers), `go` (the Go tree), and `pkg` (JS packages + root JS config +
-  # scripts). Kept as its own tiny job so the gated jobs can `needs:` it without a
-  # bootstrap, and so a docs-only PR never spins up a heavy runner at all.
-  changes:
-    name: detect changes
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      smoke: ${{ steps.filter.outputs.smoke }}
-      go: ${{ steps.filter.outputs.go }}
-      pkg: ${{ steps.filter.outputs.pkg }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v4
-        id: filter
-        with:
-          filters: |
-            smoke:
-              # Only the two apps the smoke actually builds — NOT the pre-publish-e2e
-              # fixture (that is exercised by release-gate, not ci).
-              - 'container/website/**'
-              - 'container/benchmarks/**'
-              - 'scripts/core/build.mjs'
-              - 'scripts/website/**'
-              - 'scripts/container/**'
-              - 'scripts/lib/**'
-            go:
-              - 'ts-go-runtypes/**'
-              - '.github/actions/bootstrap/**'
-            pkg:
-              - 'packages/**'
-              - 'scripts/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-              - 'tsconfig.json'
-              - 'vitest.config.ts'
-              - '.github/actions/bootstrap/**'
-
-  # Path-gated container smoke, parallel with the verify jobs. Self-contained: it
+  # Content-gated container smoke, parallel with the verify jobs. Self-contained: it
   # builds its own resolver + linux binaries for the container mounts, then pulls
   # the prebuilt shared image (CI never builds it).
   smoke:
     name: container smoke
-    needs: changes
-    if: needs.changes.outputs.smoke == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-defaults')
+    needs: lanes
+    if: fromJSON(needs.lanes.outputs.lanes).smoke.run && !contains(github.event.pull_request.labels.*.name, 'skip-defaults')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -367,3 +384,8 @@ jobs:
       # build is an esbuild pass like the others.
       - name: Benchmark competitor-build smoke
         run: pnpm miondevx bench smoke
+      - name: Record the container smoke as green
+        uses: ./.github/actions/save-lane-green
+        with:
+          lane: smoke
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes).smoke.hash }}

--- a/.github/workflows/drizzle-e2e.yml
+++ b/.github/workflows/drizzle-e2e.yml
@@ -14,6 +14,11 @@ name: drizzle · translated suites against real databases
 #   2. any PR carrying the `drizzle-e2e` label, so whoever touches those packages
 #      can ask for it on demand
 #
+# Either trigger is then gated on CONTENT by the `lanes` job: the lane hashes the
+# paths that feed it (scripts/ci/lanes.mjs) and runs only when that hash has not
+# already passed. Before that, a label meant five database lanes on every commit
+# for the life of the pull request, docs commits included.
+#
 # It cannot live inside release-gate.yml: that gate is also called by the publish
 # path, and a job there cannot be depended on from here.
 on:
@@ -32,6 +37,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The content gate, shared with ci.yml and pr-heavy.yml. It answers "have these
+  # exact inputs already passed", which is a different question from `decide`'s
+  # "is this pull request about drizzle at all"; both must say yes.
+  lanes:
+    name: decide lanes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      lanes: ${{ steps.decide.outputs.lanes }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: decide
+        uses: ./.github/actions/ci-lanes
+        with:
+          lanes: drizzle
+
   # ── decide: is this run worth its cost? ─────────────────────────────────────
   # A prod PR runs it only when the drizzle packages changed since their release
   # point; a labelled PR always runs. `unreleasedChanges()` returning {known:
@@ -41,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.check.outputs.run }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -66,8 +91,8 @@ jobs:
   # a host-only set, so this shortcut can never reach npm.
   build:
     name: build + pack
-    needs: decide
-    if: needs.decide.outputs.run == 'true'
+    needs: [lanes, decide]
+    if: needs.decide.outputs.run == 'true' && fromJSON(needs.lanes.outputs.lanes).drizzle.run
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,7 +123,7 @@ jobs:
 
   drizzle-e2e:
     name: ${{ matrix.dialect }}
-    needs: build
+    needs: [lanes, build]
     strategy:
       fail-fast: false
       matrix:
@@ -151,3 +176,20 @@ jobs:
           name: drizzle-e2e-${{ matrix.dialect }}
           path: logs/drizzle-e2e/
           if-no-files-found: ignore
+
+  # ONE marker for the whole matrix, so it is written only once ALL FIVE dialects
+  # have passed. Writing it per dialect would let one green lane stand in for the
+  # four that were still running, or that failed.
+  record-green:
+    name: record drizzle as green
+    needs: [lanes, drizzle-e2e]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/save-lane-green
+        with:
+          lane: drizzle
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes).drizzle.hash }}

--- a/.github/workflows/pr-heavy.yml
+++ b/.github/workflows/pr-heavy.yml
@@ -19,6 +19,13 @@ name: pr · website + benchmarks + pre-publish e2e (label-gated)
 #                    run the consumer lanes (the multi-bundler matrix and the
 #                    mion consumers) against that install, like the release gate
 #
+# A LABEL IS NOT ENOUGH on its own. These lanes used to run on every commit for the
+# life of a labelled pull request, so a docs commit re-paid a ten minute site build
+# or a two hour benchmark run. The `lanes` job now decides by CONTENT as well: each
+# lane hashes the paths that feed it (scripts/ci/lanes.mjs) and runs only when that
+# hash has not already passed. Label AND content, so `synchronize` keeps a labelled
+# pull request honest without re-running work that is already proven.
+#
 # Deliberately NOT pull_request_target: that would hand secrets and write
 # permissions to fork code. And deliberately no deploy step — this proves the
 # build, website-deploy.yml remains the only thing that ships a site.
@@ -37,9 +44,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The content gate, shared with ci.yml and drizzle-e2e.yml. Tiny and unlabelled:
+  # it has to answer before the labelled jobs can ask.
+  lanes:
+    name: decide lanes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      lanes: ${{ steps.decide.outputs.lanes }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: decide
+        uses: ./.github/actions/ci-lanes
+        with:
+          lanes: website bench e2e
+
   website:
     name: build the docs site
-    if: contains(github.event.pull_request.labels.*.name, 'website')
+    needs: lanes
+    if: contains(github.event.pull_request.labels.*.name, 'website') && fromJSON(needs.lanes.outputs.lanes).website.run
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -74,10 +99,16 @@ jobs:
       # first (a whole-workspace build this lane does not run).
       - name: Build the docs site
         run: pnpm miondevx website container-build
+      - name: Record the docs site build as green
+        uses: ./.github/actions/save-lane-green
+        with:
+          lane: website
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes).website.hash }}
 
   bench:
     name: validation benchmarks
-    if: contains(github.event.pull_request.labels.*.name, 'bench')
+    needs: lanes
+    if: contains(github.event.pull_request.labels.*.name, 'bench') && fromJSON(needs.lanes.outputs.lanes).bench.run
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -101,6 +132,11 @@ jobs:
       # its lane builds in seconds like the others.
       - name: Run the benchmarks
         run: pnpm miondevx bench --quick
+      - name: Record the benchmarks as green
+        uses: ./.github/actions/save-lane-green
+        with:
+          lane: bench
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes).bench.hash }}
 
   # ── pre-publish e2e: the release gate's consumer lanes, on a PR ─────────────
   # Two jobs like drizzle-e2e.yml: ONE build that packs the tarballs, then the e2e
@@ -114,7 +150,8 @@ jobs:
   # OS-agnostic and the release gate keeps running them.
   pre-publish-build:
     name: pre-publish e2e · build + pack
-    if: contains(github.event.pull_request.labels.*.name, 'pre-publish-e2e')
+    needs: lanes
+    if: contains(github.event.pull_request.labels.*.name, 'pre-publish-e2e') && fromJSON(needs.lanes.outputs.lanes).e2e.run
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -143,7 +180,7 @@ jobs:
 
   pre-publish-e2e:
     name: pre-publish e2e · consumer lanes
-    needs: pre-publish-build
+    needs: [lanes, pre-publish-build]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     # packages:read lets the job pull the prebuilt e2e image.
@@ -178,3 +215,9 @@ jobs:
       # The ONE front door, the same script as the release gate and a local run.
       - name: Pre-publish e2e (container backend)
         run: pnpm miondevx release e2e --backend container
+      # The marker rides the job that PROVES the lane, not the one that packs for it.
+      - name: Record the pre-publish e2e as green
+        uses: ./.github/actions/save-lane-green
+        with:
+          lane: e2e
+          hash: ${{ fromJSON(needs.lanes.outputs.lanes).e2e.hash }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,9 @@ Before opening a PR, confirm the change is **PR ready** — never open one other
   - `pre-publish-e2e`: packs every package, publishes to a throwaway registry and runs the consumer lanes. Add it for package exports, `package.json` changes, public API renames, anything a consumer installs.
   - `drizzle-e2e`: runs drizzle's own suites against real databases. Add it for [packages/drizzle-orm/](packages/drizzle-orm/) and its dialect packages, or [container/drizzle-e2e/](container/drizzle-e2e/).
   - `skip-defaults` does the opposite, it opts OUT of the default lint / typecheck / test lanes. Only for a PR that cannot affect them.
-  Adding a label re-triggers its lane, and it keeps running on every later commit, so label at open time rather than at the end.
+  Adding a label re-triggers its lane, so label at open time rather than at the end.
+  A label is necessary but NOT sufficient: every lane is also gated on CONTENT ([scripts/ci/lanes.mjs](scripts/ci/lanes.mjs)). Each lane declares the paths that feed it, hashes exactly those paths, and runs unless a marker says that hash already passed. So a labelled lane re-runs on a commit that changes its inputs and skips one that does not, and a docs-only commit skips every lane. Ask what this tree needs with `pnpm miondevx core lanes`.
+  Adding a top-level directory means classifying it there: an unclassified path joins EVERY lane's hash, so everything re-runs until someone says what reads it.
 
 ## Git workflow
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -92,6 +92,15 @@ pnpm --filter @mionjs/run-types test      # the other
 
 JS plugin tests in [packages/devtools/test/](packages/devtools/test/) spawn the Go binary — `pretest` rebuilds it. For the edit/see-tests loop, `pnpm run check:builds` then `pnpm exec vitest` (watch mode) keeps the binary fresh; `pnpm test` is the one-shot pass.
 
+To see which CI lanes the current tree needs, and why:
+
+```bash
+pnpm miondevx core lanes                        # one hash per lane, over the paths that feed it
+pnpm run check:tree                             # the whole-tree hygiene sweeps CI runs ungated
+```
+
+A lane runs unless a marker says its exact inputs already passed, so a commit that changes nothing a lane reads skips it. The lane table is [scripts/ci/lanes.mjs](scripts/ci/lanes.mjs).
+
 ---
 
 ## Containerized apps (docs website + benchmarks)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "format": "oxfmt --write 'packages/**/*.ts' && prettier --write 'packages/**/*.md' && gofmt -w ts-go-runtypes/cmd ts-go-runtypes/internal",
         "check-format": "oxfmt --check 'packages/**/*.ts' && prettier --check 'packages/**/*.md' && gofmt -l ts-go-runtypes/cmd ts-go-runtypes/internal && test -z \"$(gofmt -l ts-go-runtypes/cmd ts-go-runtypes/internal)\"",
         "check-code-imports": "node scripts/check-code-imports.mjs",
+        "check:tree": "node scripts/ci/check-tree.mjs",
         "precheck-types-examples": "pnpm run check:builds",
         "check-types-examples": "pnpm --filter @mionjs/examples run check-types",
         "prelint": "pnpm run check:builds",

--- a/packages/devtools/test/ci-lane-contracts.test.ts
+++ b/packages/devtools/test/ci-lane-contracts.test.ts
@@ -1,0 +1,218 @@
+// Contract tests for the CONTENT gate that decides which CI lanes run.
+//
+// The gate is easy to half-wire, and every half-wiring fails SILENTLY in the
+// direction that costs coverage rather than time: a lane whose job never saves a
+// green marker just re-runs forever (merely wasteful), but a lane gated on a
+// marker some OTHER job writes, or saved by a job that was skipped, reports green
+// having proved nothing. GitHub counts a skipped check as success, so nothing
+// downstream would notice.
+//
+// These pin the three halves to each other: the lane table in scripts/ci/lanes.mjs,
+// the `if:` that consults it, and the save step that writes the marker.
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, it} from 'vitest';
+// @ts-expect-error — a plain .mjs repo script, no types.
+import {LANES, FEEDS_NOTHING, decide, greenKey, laneHashes, unclassified} from '../../../scripts/ci/lanes.mjs';
+// @ts-expect-error — a plain .mjs repo script, no types.
+import {SWEEPS} from '../../../scripts/ci/check-tree.mjs';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const read = (rel: string): string => readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+const WORKFLOWS = {
+  'ci.yml': ['go', 'js-fuzz', 'js', 'smoke'],
+  'pr-heavy.yml': ['website', 'bench', 'e2e'],
+  'drizzle-e2e.yml': ['drizzle'],
+} as const;
+
+describe('the lane table', () => {
+  it('classifies every tracked path, so nothing silently buys a skip', () => {
+    const tracked = laneHashes('HEAD');
+    expect(tracked.unknown, `classify these in scripts/ci/lanes.mjs: ${tracked.unknown.join(', ')}`).toEqual([]);
+  });
+
+  it('leaves the docs and agent trees feeding nothing, which is the whole point', () => {
+    for (const dir of ['docs/', '.claude/', 'CLAUDE.md']) expect(FEEDS_NOTHING).toContain(dir);
+    for (const lane of Object.values(LANES) as {paths: string[]}[]) {
+      for (const ignored of FEEDS_NOTHING) expect(lane.paths, `${ignored} must feed no lane`).not.toContain(ignored);
+    }
+  });
+
+  // The old dorny/paths-filter gate listed neither, so a pull request that only
+  // touched the docs content skipped js-lint and with it check-code-imports, the
+  // one gate that turns a dangling <code-import> into a failure instead of an
+  // error placeholder rendered into the page.
+  it('feeds the docs content and the examples into the js lane that checks them', () => {
+    for (const fed of ['container/', 'packages/']) expect(LANES.js.paths).toContain(fed);
+  });
+
+  // The two trees read into each other, and the old path gate got BOTH wrong: it
+  // ran js-lint on any Go change (right, but for no stated reason) and never fed
+  // the marker sources into the Go lane at all. Derive each direction from the
+  // thing that does the reading, so neither can rot into a silent skip.
+  it('feeds every tsconfig the root typecheck compiles into the js lane', () => {
+    const typecheck = JSON.parse(read('package.json')).scripts.typecheck as string;
+    const projects = [...typecheck.matchAll(/tsc -p (\S+)/g)].map((match) => match[1]);
+    expect(projects.length).toBeGreaterThan(2);
+    for (const project of projects) {
+      const dir = project.slice(0, project.lastIndexOf('/') + 1);
+      expect(
+        LANES.js.paths.some((fed: string) => dir.startsWith(fed)),
+        `${project} is typechecked by js-lint but feeds no js lane path`
+      ).toBe(true);
+    }
+  });
+
+  it('feeds the packages the Go suites mount as node_modules into the go lane', () => {
+    const fixtures =
+      read('ts-go-runtypes/internal/testfixtures/realmarker.go') + read('ts-go-runtypes/internal/testfixtures/realdrizzle.go');
+    const mounted = [...fixtures.matchAll(/filepath\.Join\(repoRoot, "packages", "([\w-]+)"\)/g)].map(
+      (match) => `packages/${match[1]}/`
+    );
+    expect(mounted.length).toBeGreaterThan(2);
+    for (const pkg of new Set(mounted)) {
+      expect(
+        LANES.go.paths.some((fed: string) => pkg.startsWith(fed)),
+        `${pkg} is compiled by the Go suites but feeds no go lane path`
+      ).toBe(true);
+    }
+  });
+
+  it('gives each lane its own hash unless the two read the same inputs', () => {
+    const {hashes} = laneHashes('HEAD');
+    // js and js-fuzz are the two halves of one input set, split so each job half
+    // owns its own marker; everything else must be distinguishable.
+    expect(hashes.js).toBe(hashes['js-fuzz']);
+    const distinct = new Set(
+      Object.entries(hashes)
+        .filter(([name]) => name !== 'js-fuzz')
+        .map(([, hash]) => hash)
+    );
+    expect(distinct.size).toBe(Object.keys(LANES).length - 1);
+  });
+
+  it('is fail-safe: an unclassified path joins every lane, and an unknown marker list runs everything', () => {
+    expect(unclassified(['brand-new-dir/thing.ts'])).toEqual(['brand-new-dir/thing.ts']);
+    const hashes = {js: 'abc'};
+    expect(decide(['js'], {hashes, greenKeys: []}).js.run).toBe(true);
+    expect(decide(['js'], {hashes, greenKeys: [greenKey('js', 'abc')]}).js.run).toBe(false);
+    // a marker for a DIFFERENT hash never counts
+    expect(decide(['js'], {hashes, greenKeys: [greenKey('js', 'def')]}).js.run).toBe(true);
+  });
+});
+
+// The ignore list is only safe because nothing gated reads those paths. The three
+// whole-tree sweeps DO read every tracked file, so if one ever moves back into the
+// vitest suite, a .claude/ or CLAUDE.md edit would skip the very check meant to
+// catch it. Pin them to the one job no lane can skip.
+describe('the whole-tree sweeps run ungated', () => {
+  const ci = read('.github/workflows/ci.yml');
+  const gate = ci.slice(ci.indexOf('\n  lanes:'), ci.indexOf('\n  go-fuzz:'));
+
+  it('runs check-tree in the gate job, which has no `if:` of its own', () => {
+    expect(gate).toContain('run: node scripts/ci/check-tree.mjs');
+    expect(gate, 'the gate job must never be conditional').not.toMatch(/^    if:/m);
+  });
+
+  it('carries every sweep, so adding one to the script reaches CI for free', () => {
+    expect((SWEEPS as {name: string}[]).length).toBeGreaterThanOrEqual(3);
+    for (const sweep of SWEEPS as {name: string; run: () => string[]}[]) expect(typeof sweep.run).toBe('function');
+  });
+
+  it('keeps the sweeps out of the vitest suite they used to gate on', () => {
+    const contracts = read('packages/devtools/test/repo-contracts.test.ts');
+    expect(contracts, 'a whole-tree git grep is back in the js lane').not.toContain("spawnSync('git', ['grep'");
+    expect(contracts).not.toContain("['ls-files', '-z'");
+  });
+});
+
+describe('every workflow gates on the lanes it declares', () => {
+  for (const [file, lanes] of Object.entries(WORKFLOWS)) {
+    const workflow = read(`.github/workflows/${file}`);
+    const declared = /uses: \.\/\.github\/actions\/ci-lanes\n\s+with:\n\s+lanes: (.+)/.exec(workflow)?.[1].trim().split(/\s+/);
+
+    it(`${file} asks the gate for exactly the lanes it uses`, () => {
+      expect(declared).toEqual([...lanes]);
+      for (const lane of lanes) expect(Object.keys(LANES)).toContain(lane);
+    });
+
+    it(`${file} reads each lane's verdict in a job or step condition`, () => {
+      for (const lane of lanes) {
+        const reference = lane.includes('-')
+          ? `fromJSON(needs.lanes.outputs.lanes)['${lane}'].run`
+          : `fromJSON(needs.lanes.outputs.lanes).${lane}.run`;
+        expect(workflow, `${file} never gates on ${lane}`).toContain(reference);
+      }
+    });
+
+    // The save is what makes the NEXT run cheap; without it the lane re-runs
+    // forever and the gate is dead weight nobody notices.
+    it(`${file} records each lane green with that lane's own hash`, () => {
+      for (const lane of lanes) {
+        const hash = lane.includes('-')
+          ? `fromJSON(needs.lanes.outputs.lanes)['${lane}'].hash`
+          : `fromJSON(needs.lanes.outputs.lanes).${lane}.hash`;
+        expect(workflow).toMatch(
+          new RegExp(
+            `save-lane-green\\n\\s+with:\\n\\s+lane: ${lane}\\n\\s+hash: \\$\\{\\{ ${hash.replace(/[.()[\]$]/g, '\\$&')} \\}\\}`
+          )
+        );
+      }
+    });
+
+    it(`${file} grants the gate job the actions:read it needs to list the markers`, () => {
+      const job = workflow.slice(
+        workflow.indexOf('\n  lanes:'),
+        workflow.indexOf('\n    steps:', workflow.indexOf('\n  lanes:'))
+      );
+      expect(job, `${file}'s lanes job cannot list caches without actions: read`).toContain('actions: read');
+    });
+  }
+});
+
+describe('a marker is only ever written by work that actually ran and passed', () => {
+  const ci = read('.github/workflows/ci.yml');
+
+  // go-fuzz runs when EITHER half is due, so each half's save must re-check its
+  // own lane. Without the guard, a run triggered by the Go half alone would mark
+  // the JS fuzz sweep green having never executed it.
+  it('guards the two go-fuzz halves on their own lane, not on the job', () => {
+    for (const lane of ['go', "['js-fuzz']"]) {
+      const reference = lane.startsWith('[')
+        ? `fromJSON(needs.lanes.outputs.lanes)${lane}.run`
+        : `fromJSON(needs.lanes.outputs.lanes).${lane}.run`;
+      expect(ci).toContain(`if: success() && ${reference}`);
+    }
+  });
+
+  // Five dialects share one marker, so it cannot ride any single dialect's job.
+  it('records drizzle green only after all five dialect lanes pass', () => {
+    const drizzle = read('.github/workflows/drizzle-e2e.yml');
+    const record = drizzle.slice(drizzle.indexOf('\n  record-green:'));
+    expect(record).toContain('needs: [lanes, drizzle-e2e]');
+    expect(record).toContain('if: success()');
+    expect(drizzle.indexOf('save-lane-green')).toBe(drizzle.lastIndexOf('save-lane-green'));
+  });
+
+  // A save placed mid-job would claim the lane green while the steps after it are
+  // still unproven, and those steps are exactly the slow ones worth skipping.
+  it('puts every save after the last step that does work', () => {
+    let checked = 0;
+    for (const file of Object.keys(WORKFLOWS)) {
+      const workflow = read(`.github/workflows/${file}`);
+      for (const job of workflow.split(/\n  (?=[\w-]+:\n)/)) {
+        const firstSave = job.indexOf('save-lane-green');
+        if (firstSave === -1) continue;
+        checked += 1;
+        // drizzle's record-green job runs nothing itself (it waits on the five
+        // dialect jobs), so "no work at all" is fine; work AFTER the save is not.
+        expect(firstSave, `${file}: a run step follows a save-lane-green step`).toBeGreaterThan(
+          job.lastIndexOf('\n        run: ')
+        );
+      }
+    }
+    // go-fuzz, js-lint, smoke, website, bench, pre-publish-e2e, record-green.
+    // The count catches a save step lost to an edit, which the loop above cannot.
+    expect(checked).toBe(7);
+  });
+});

--- a/packages/devtools/test/ci-lane-contracts.test.ts
+++ b/packages/devtools/test/ci-lane-contracts.test.ts
@@ -105,6 +105,30 @@ describe('the lane table', () => {
 // whole-tree sweeps DO read every tracked file, so if one ever moves back into the
 // vitest suite, a .claude/ or CLAUDE.md edit would skip the very check meant to
 // catch it. Pin them to the one job no lane can skip.
+// A gate job that FAILS takes every lane down with it, and GitHub reports a job
+// skipped for a failed dependency as neutral, so the pull request can look settled
+// while nothing ran. The job therefore installs nothing and must ask for nothing
+// that needs an install.
+describe('the gate job stands on its own', () => {
+  const action = read('.github/actions/ci-lanes/action.yml');
+
+  it('turns off the package-manager cache setup-node enables by default', () => {
+    // On by default, it finds pnpm-lock.yaml and shells out to `pnpm` to locate the
+    // store. pnpm is not on PATH here, and that failure fails the whole step.
+    expect(action).toContain('package-manager-cache: false');
+  });
+
+  it('never runs pnpm, which the job does not install', () => {
+    const steps = action.slice(action.indexOf('runs:'));
+    expect(steps, 'the gate job has no pnpm').not.toMatch(/run:.*\bpnpm\b/);
+    for (const file of Object.keys(WORKFLOWS)) {
+      const workflow = read(`.github/workflows/${file}`);
+      const gate = workflow.slice(workflow.indexOf('\n  lanes:'), workflow.indexOf('\n\n  ', workflow.indexOf('\n  lanes:')));
+      expect(gate, `${file}'s gate job has no pnpm`).not.toMatch(/run:.*\bpnpm\b/);
+    }
+  });
+});
+
 describe('the whole-tree sweeps run ungated', () => {
   const ci = read('.github/workflows/ci.yml');
   const gate = ci.slice(ci.indexOf('\n  lanes:'), ci.indexOf('\n  go-fuzz:'));

--- a/packages/devtools/test/ci-skip-defaults-contracts.test.ts
+++ b/packages/devtools/test/ci-skip-defaults-contracts.test.ts
@@ -4,7 +4,7 @@
 // smoke) on one PR. It only works if BOTH halves are in place: the trigger must
 // fire on label changes (or the label does nothing until the next push), and
 // every heavy job's `if:` must read it (or one job keeps running). The light
-// jobs (`changes`, `commitlint`) must NOT read it: they cost seconds and keep the
+// jobs (`lanes`, `commitlint`) must NOT read it: they cost seconds and keep the
 // PR's commit messages gated.
 import {readFileSync} from 'node:fs';
 import path from 'node:path';
@@ -39,15 +39,15 @@ describe('the skip-defaults label', () => {
   });
 
   it('never skips the light jobs', () => {
-    for (const job of ['changes', 'commitlint']) expect(jobCondition(job) ?? '', job).not.toContain(LABEL);
+    for (const job of ['lanes', 'commitlint']) expect(jobCondition(job) ?? '', job).not.toContain(LABEL);
   });
 
-  it('is a guard on the existing path gate, not a replacement for it', () => {
+  it('is a guard on the existing content gate, not a replacement for it', () => {
     // `(a || b) && !label`: the parentheses keep the label from binding to `b` alone.
-    for (const job of ['go-fuzz', 'js-lint'])
-      expect(jobCondition(job), job).toMatch(
-        /^\(needs\.changes\.outputs\.\w+ == 'true' \|\| needs\.changes\.outputs\.\w+ == 'true'\) && !contains/
-      );
-    expect(jobCondition('smoke')).toMatch(/^needs\.changes\.outputs\.smoke == 'true' && !contains/);
+    expect(jobCondition('go-fuzz')).toMatch(
+      /^\(fromJSON\(needs\.lanes\.outputs\.lanes\)[.[].+ \|\| fromJSON\(needs\.lanes\.outputs\.lanes\)[.[].+\) && !contains/
+    );
+    expect(jobCondition('js-lint')).toMatch(/^fromJSON\(needs\.lanes\.outputs\.lanes\)\.js\.run && !contains/);
+    expect(jobCondition('smoke')).toMatch(/^fromJSON\(needs\.lanes\.outputs\.lanes\)\.smoke\.run && !contains/);
   });
 });

--- a/packages/devtools/test/pr-heavy-lane-contracts.test.ts
+++ b/packages/devtools/test/pr-heavy-lane-contracts.test.ts
@@ -52,7 +52,9 @@ describe('the pre-publish-e2e lane mirrors the release gate', () => {
     const downloaded = /download-artifact@v\d+\n\s+with:\n\s+name: ([\w-]+)/.exec(lane)?.[1];
     expect(uploaded).toBe('pre-publish-e2e-tarballs');
     expect(downloaded).toBe(uploaded);
-    expect(lane).toContain('needs: pre-publish-build');
+    // `lanes` rides alongside so the e2e job can read its own lane's hash for the
+    // green marker; the pack dependency is what carries the tarballs.
+    expect(lane).toContain('needs: [lanes, pre-publish-build]');
   });
 
   it('pulls the same prebuilt e2e image the gate pulls, with the PAT', () => {

--- a/packages/devtools/test/repo-contracts.test.ts
+++ b/packages/devtools/test/repo-contracts.test.ts
@@ -31,6 +31,8 @@
 
 import {describe, it, expect} from 'vitest';
 import {spawnSync} from 'node:child_process';
+// @ts-expect-error — a plain .mjs repo script, no types.
+import {specReferenceOffenders} from '../../../scripts/ci/check-tree.mjs';
 import {readFileSync, existsSync, readdirSync, statSync, mkdirSync, mkdtempSync, writeFileSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import {resolve, dirname, join, posix} from 'node:path';
@@ -145,21 +147,6 @@ describe('published packages point at this repository', () => {
     });
   }
 
-  it(
-    'no tracked file outside docs/ names the old ts-run-types repository',
-    () => {
-      // -I skips binaries; the pathspecs exclude the history records + specs under docs/ and the
-      // vendored submodule. The needle is split so this file never matches itself.
-      const oldRepo = ['MionKit', 'ts-run-types'].join('/');
-      const res = spawnSync('git', ['grep', '-I', '-l', oldRepo, '--', '.', ':!docs', ':!ts-go-runtypes/third_party'], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-      });
-      expect(res.stdout.trim().split('\n').filter(Boolean)).toEqual([]);
-    },
-    WHOLE_TREE_TIMEOUT
-  );
-
   it("the client's undeclared slot is never called the fatal slot", () => {
     // `FatalError` is a typed, declared halt; the result tuple's slot 2 holds what NOBODY declared.
     // One word for two things reads wrong, so the slot is `undeclared` in code, examples and docs.
@@ -191,43 +178,17 @@ describe('published packages point at this repository', () => {
   });
 });
 
-// A path under docs/todos/ or docs/done/ ending in a spec filename. The sweep runs over
-// TRACKED files only (git grep), so ignored build output never trips it.
-const SPEC_REFERENCE = /docs\/(todos|done)\/[a-z0-9-]+\.md/;
-// Where naming a spec is legitimate: the two spec directories themselves, the changelog
-// (history), the vendored submodule and every isolated dependency tree.
-const SPEC_REFERENCE_EXEMPT = /^(docs\/(todos|done)\/|CHANGELOG\.md$|ts-go-runtypes\/third_party\/)|(^|\/)(_deps|node_modules)\//;
-
-// The files that name a spec and are not allowed to. Pure over (path, text) so the rule
-// itself is testable without a git checkout.
-function specReferenceOffenders(entries: {file: string; text: string}[]): string[] {
-  return entries
-    .filter(({file}) => !SPEC_REFERENCE_EXEMPT.test(file))
-    .filter(({text}) => SPEC_REFERENCE.test(text))
-    .map(({file}) => file);
-}
-
+// The three WHOLE-TREE sweeps (this rule, the old-repository one and the NUL-byte
+// one) run from scripts/ci/check-tree.mjs in the always-on `lanes` job, not here:
+// they read docs/, .claude/ and the root prose files, which the lane gate
+// deliberately excludes from the js lane, so a sweep gated on js inputs would miss
+// exactly the edits it exists to catch. What stays here is the RULE itself, over the
+// same implementation the sweep uses.
 describe('no file outside docs/todos and docs/done names a todo or done spec', () => {
   // Fixture paths are assembled so this file never names a spec itself.
   const spec = (dir: 'todos' | 'done', name: string): string => ['docs', dir, `${name}.md`].join('/');
   const doneRef = spec('done', 'some-finding');
   const todoRef = spec('todos', 'next-thing');
-
-  it(
-    'the tracked tree has no such reference',
-    () => {
-      // -I skips binaries; git grep only sees tracked files. The exemptions are applied
-      // in JS (one regex for both the real sweep and the rule tests below).
-      const res = spawnSync('git', ['grep', '-I', '-l', '-E', SPEC_REFERENCE.source, '--', '.'], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-      });
-      const candidates = res.stdout.trim().split('\n').filter(Boolean);
-      const entries = candidates.map((file) => ({file, text: readFileSync(join(REPO_ROOT, file), 'utf8')}));
-      expect(specReferenceOffenders(entries)).toEqual([]);
-    },
-    WHOLE_TREE_TIMEOUT
-  );
 
   it('fails on a reference in code, a workflow, a doc, a skill or a parked spec', () => {
     const text = `see ${doneRef} for why`;
@@ -889,33 +850,6 @@ describe('website-test-counts', () => {
     const numericLiterals = [...tiles.matchAll(/value: '([\d,]+)'/g)].map((match) => match[1]);
     expect(numericLiterals).toEqual([]);
   });
-});
-
-describe('tracked sources carry no raw NUL byte', () => {
-  // A literal NUL makes git classify the file as BINARY: no line diffs, no auto-merge.
-  // Two files carried one, and the rtUtils.ts one blocked a rebase.
-  const SCANNED = ['*.ts', '*.tsx', '*.js', '*.mjs', '*.cjs', '*.go', '*.json', '*.md'];
-
-  it(
-    'no tracked source file contains a literal NUL',
-    () => {
-      const listed = spawnSync('git', ['ls-files', '-z', '--', ...SCANNED], {
-        cwd: REPO_ROOT,
-        maxBuffer: 64 * 1024 * 1024,
-      });
-      expect(listed.status).toBe(0);
-      const files = listed.stdout
-        .toString('utf8')
-        .split('\u0000')
-        .filter(Boolean)
-        .filter((file) => !file.startsWith('ts-go-runtypes/third_party/') && !file.includes('/testdata/'));
-      expect(files.length).toBeGreaterThan(500);
-
-      const offenders = files.filter((file) => readFileSync(join(REPO_ROOT, file)).includes(0));
-      expect(offenders).toEqual([]);
-    },
-    WHOLE_TREE_TIMEOUT
-  );
 });
 
 // ── mion server benchmarks (container/mion-bench) ──────────────────────────────

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,7 +25,7 @@ Each area is a subdirectory under `scripts/` plus a dispatch case in [miondevx.m
 
 | Area        | Directory                  | Purpose                                                                  |
 | ----------- | -------------------------- | ------------------------------------------------------------------------ |
-| `core`      | [core/](core/)             | Go resolver + TS marker/plugin: build, smoke, fuzz, codegen, tsgolint    |
+| `core`      | [core/](core/), [ci/](ci/) | Go resolver + TS marker/plugin: build, smoke, fuzz, codegen, tsgolint, and the CI lane table |
 | `website`   | [website/](website/)       | Docs site (Nuxt + Docus): dev server, build, preview, container         |
 | `bench`     | [website/bench-data/](website/bench-data/) | Benchmarks (audit / typecost / compiletime / serialization / smoke)       |
 | `release`   | [release/](release/)       | npm publish pipeline (preflight → publish → website → CI deploy)         |

--- a/scripts/ci/check-tree.mjs
+++ b/scripts/ci/check-tree.mjs
@@ -1,0 +1,95 @@
+// check-tree.mjs — the repo hygiene sweeps that read EVERY tracked file.
+//
+// These three used to live only inside repo-contracts.test.ts, which runs in the
+// js-lint job. That was fine while js-lint ran on every commit, and became a hole
+// the moment lanes started skipping by content (scripts/ci/lanes.mjs): a sweep that
+// reads docs/, .claude/ and the root prose files cannot be gated on paths that
+// deliberately exclude them, or an offending edit lands unseen.
+//
+// So they run here instead, from the `lanes` job, which always runs and installs
+// nothing: git plus node, no workspace, no build. The rules themselves are still
+// unit-tested in repo-contracts.test.ts, which imports these same functions, so
+// there is exactly one implementation of each.
+//
+// Usage: `pnpm run check:tree`, or `node scripts/ci/check-tree.mjs`.
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {REPO_ROOT} from '../lib/env.mjs';
+import {capture, die, note, reportCliError, success} from '../lib/proc.mjs';
+
+// A path under docs/todos/ or docs/done/ ending in a spec filename. Specs get
+// deleted, so any reference to one rots; the rule is that nothing names them.
+export const SPEC_REFERENCE = /docs\/(todos|done)\/[a-z0-9-]+\.md/;
+// Where naming a spec is legitimate: the two spec directories themselves, the
+// changelog (history), the vendored submodule and every isolated dependency tree.
+export const SPEC_REFERENCE_EXEMPT = /^(docs\/(todos|done)\/|CHANGELOG\.md$|ts-go-runtypes\/third_party\/)|(^|\/)(_deps|node_modules)\//;
+
+// Pure over (path, text) so the rule is testable without a checkout.
+export const specReferenceOffenders = (entries) =>
+  entries
+    .filter(({file}) => !SPEC_REFERENCE_EXEMPT.test(file))
+    .filter(({text}) => SPEC_REFERENCE.test(text))
+    .map(({file}) => file);
+
+// -I skips binaries, and git grep only sees tracked files, so ignored build output
+// never trips any of this.
+const grepFiles = (args) =>
+  capture('git', ['grep', '-I', '-l', ...args], {cwd: REPO_ROOT})
+    .stdout.trim()
+    .split('\n')
+    .filter(Boolean);
+
+export function specReferences() {
+  const candidates = grepFiles(['-E', SPEC_REFERENCE.source, '--', '.']);
+  return specReferenceOffenders(candidates.map((file) => ({file, text: readFileSync(join(REPO_ROOT, file), 'utf8')})));
+}
+
+// The packages moved out of a separate repository and the old URL kept surviving in
+// package.json fields and READMEs. docs/ is exempt: it records history. The needle is
+// split so this file never matches itself.
+export function oldRepoReferences() {
+  return grepFiles([['MionKit', 'ts-run-types'].join('/'), '--', '.', ':!docs', ':!ts-go-runtypes/third_party']);
+}
+
+// A literal NUL makes git classify a file as BINARY: no line diffs, no auto-merge.
+// Two files carried one, and the rtUtils.ts one blocked a rebase.
+const NUL_SCANNED = ['*.ts', '*.tsx', '*.js', '*.mjs', '*.cjs', '*.go', '*.json', '*.md'];
+
+export function nulBytes() {
+  const listed = capture('git', ['ls-files', '-z', '--', ...NUL_SCANNED], {cwd: REPO_ROOT, maxBuffer: 64 * 1024 * 1024});
+  if (listed.status !== 0) die(`git ls-files failed: ${listed.stderr.trim()}`);
+  const files = listed.stdout
+    .split('\0')
+    .filter(Boolean)
+    .filter((file) => !file.startsWith('ts-go-runtypes/third_party/') && !file.includes('/testdata/'));
+  // A sweep that silently matched nothing would pass forever; the floor catches it.
+  if (files.length < 500) die(`the NUL sweep listed only ${files.length} files, so its pathspecs stopped matching`);
+  return files.filter((file) => readFileSync(join(REPO_ROOT, file)).includes(0));
+}
+
+export const SWEEPS = [
+  {name: 'no file outside docs/todos and docs/done names a spec', run: specReferences, fix: 'put the reasoning in the file that needs it; a spec gets deleted and the reference rots'},
+  {name: 'no tracked file outside docs/ names the old repository', run: oldRepoReferences, fix: 'point it at MionKit/mion'},
+  {name: 'no tracked source carries a literal NUL byte', run: nulBytes, fix: 'strip the NUL; git treats the file as binary and a rebase cannot merge it'},
+];
+
+export function main() {
+  const failed = [];
+  for (const sweep of SWEEPS) {
+    const offenders = sweep.run();
+    if (offenders.length === 0) continue;
+    failed.push(sweep.name);
+    note(`${sweep.name} — ${offenders.length} offender(s), ${sweep.fix}:`);
+    for (const file of offenders) console.error(`  ${file}`);
+  }
+  if (failed.length > 0) die(`check-tree: ${failed.length} sweep(s) failed`);
+  success(`check-tree: all ${SWEEPS.length} whole-tree sweeps clean`);
+}
+
+if (import.meta.main) {
+  try {
+    main();
+  } catch (err) {
+    reportCliError(err);
+  }
+}

--- a/scripts/ci/lanes.mjs
+++ b/scripts/ci/lanes.mjs
@@ -1,0 +1,187 @@
+// lanes.mjs — which CI lanes a commit needs, and whether that exact content
+// already went green.
+//
+// THE PROBLEM this solves: every workflow used to decide by DIFF. ci.yml diffed
+// the whole pull request against main (dorny/paths-filter's default on a
+// `pull_request` event), so one touched file under packages/ pinned `pkg=true`
+// for the life of the branch and a later docs-only commit re-ran ~33 runner
+// minutes. pr-heavy.yml and drizzle-e2e.yml had no path gate at all: a label put
+// their lanes on every commit forever.
+//
+// THE ANSWER is content, not diff. Each lane declares the paths that feed it; a
+// lane's hash is the git object ids of exactly those paths in the tree being
+// tested. A lane that passes saves a cache marker under its hash, so a later run
+// whose hash matches KNOWS that content already passed and skips. On a pull
+// request the tree is the MERGE ref, so the hash covers main too: main moving
+// changes it and the lane re-runs, which a "diff since the last green sha" rule
+// would have missed.
+//
+// It is fail-safe in every direction: a cache miss runs the lane, an unclassified
+// path runs every lane, and only a job that actually succeeded ever writes a
+// marker.
+//
+// Usage (via `pnpm miondevx core lanes`, or `node scripts/ci/lanes.mjs …`):
+//   lanes                             print the lane table with each lane's hash
+//   lanes --decide <lane…>            decide those lanes, print the JSON verdict
+//   lanes --green-keys <file>         the marker keys already recorded green
+//   lanes --github                    also write `lanes=<json>` to $GITHUB_OUTPUT
+//                                     and a table to $GITHUB_STEP_SUMMARY
+//   lanes --ref <ref>                 hash that tree instead of HEAD
+import {createHash} from 'node:crypto';
+import {appendFileSync, readFileSync} from 'node:fs';
+import {REPO_ROOT} from '../lib/env.mjs';
+import {capture, die, note, reportCliError} from '../lib/proc.mjs';
+
+// Paths that feed NO lane: read by people and agents, never by a build, a test or
+// a container. Adding a path here is the ONE way to buy a lane skip, so it has to
+// stay provable, and it only became provable for these once the three whole-tree
+// hygiene sweeps moved to scripts/ci/check-tree.mjs. Those sweeps DO read every
+// tracked file, so while they lived in the js-lint suite, ignoring .claude/ or a
+// root doc here would have let an offending edit through unchecked. They now run
+// in the always-on gate job instead, ungated by anything.
+export const FEEDS_NOTHING = ['docs/', 'assets/', '.claude/', '.vscode/', '.husky/', '.git-blame-ignore-revs', 'CHANGELOG.md', 'CLAUDE.md', 'README.md', 'SETUP.md', 'LICENSE'];
+
+// Inputs EVERY lane hashes: the Go resolver, the lockfile, the workspace layout,
+// the repo-wide tool config and the toolchain the bootstrap action pins.
+//
+// ts-go-runtypes/ is here rather than on the `go` lane alone because the binary
+// built from it is the engine every other lane runs on: the plugin tests spawn it,
+// and the container lanes mount it. Its third_party/ submodule rides along as a
+// single gitlink entry, so a submodule bump moves every hash, which is right.
+// Repo-wide config is here for the same reason, and changes rarely enough that the
+// over-run costs nothing.
+const WORKSPACE = ['ts-go-runtypes/', 'package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'tsconfig.json', '.npmrc', '.editorconfig', '.prettierrc', '.prettierignore', '.gitignore', '.gitmodules', 'cliff.toml', 'commitlint.config.js', '.github/actions/'];
+
+// The JS half of the repo. `container/` belongs here, not only to the container
+// lanes: check-code-imports reads every <code-import> in the docs content tree and
+// the contract tests walk that tree plus the benchmark competitor maps and the
+// workflow files. The old path filter listed none of them, so a content-only pull
+// request skipped js-lint and the code-import gate never ran on the very commit
+// that could break it.
+const JS = ['packages/', 'scripts/', 'container/', 'vitest.config.ts', 'version.json', 'drizzle-dialects.json', 'drizzle-suites.pin.json', '.env.sample', '.oxlintrc.json', '.oxfmtrc.json', 'eslint.config.js', '.github/workflows/', ...WORKSPACE];
+// What a lane that packs and installs the workspace reads. No container/ (those
+// lanes name their own image dir) and no workflow files.
+const PACKED = ['packages/', 'scripts/', 'version.json', ...WORKSPACE];
+
+// Lane -> the paths whose CONTENT decides it. A lane hashes these and nothing
+// else, so a file outside every entry cannot make it re-run.
+//
+// A lane is owned by exactly ONE piece of work, because that work is what proves
+// it and saves its marker. `go` and `js-fuzz` therefore split the two halves of
+// the go-fuzz job: the Go suite and the JS fuzz sweep run on the same runner but
+// answer to different inputs, and neither may claim the other's marker.
+export const LANES = {
+  // ci.yml
+  // The packages are a Go input in the other direction: the suites mount the REAL
+  // marker and drizzle packages as virtual node_modules (internal/testfixtures/
+  // realmarker.go and realdrizzle.go), so editing their sources changes what the
+  // Go tests compile against.
+  go: {job: 'go tests + fuzz · the Go suite', paths: ['packages/run-types/', 'packages/drizzle-orm', ...WORKSPACE]},
+  'js-fuzz': {job: 'go tests + fuzz · the JS fuzz sweep', paths: JS},
+  js: {job: 'js tests + lint', paths: JS},
+  smoke: {job: 'container smoke', paths: ['container/website/', 'container/benchmarks/', ...PACKED]},
+  // pr-heavy.yml
+  website: {job: 'build the docs site', paths: ['container/website/', ...PACKED]},
+  bench: {job: 'validation benchmarks', paths: ['container/benchmarks/', ...PACKED]},
+  e2e: {job: 'pre-publish e2e', paths: ['container/pre-publish-e2e/', '.github/verdaccio.yaml', ...PACKED]},
+  // drizzle-e2e.yml
+  drizzle: {job: 'drizzle suites against real databases', paths: ['packages/drizzle-orm', 'packages/run-types/', 'packages/devtools/', 'packages/core/', 'packages/bin-compiler/', 'container/drizzle-e2e/', 'scripts/', 'drizzle-dialects.json', 'drizzle-suites.pin.json', ...WORKSPACE]},
+};
+
+// Prefix match, so a trailing slash means a directory and a bare name means that
+// file. A bare name is a prefix on purpose: 'packages/drizzle-orm' picks up the
+// four sibling dialect packages without naming each one.
+const matches = (path, prefixes) => prefixes.some((prefix) => path.startsWith(prefix));
+
+// A tracked path that matches no lane and no FEEDS_NOTHING entry is an unknown
+// risk: it joins EVERY lane's hash, so adding a directory re-runs everything
+// until someone classifies it. Never a free skip.
+export const unclassified = (paths) => paths.filter((path) => !matches(path, FEEDS_NOTHING) && !Object.values(LANES).some((lane) => matches(path, lane.paths)));
+
+// One `git ls-tree` over the whole tree, partitioned per lane. Hashing the OBJECT
+// IDS (not the bytes) keeps it to a single git call on any repo size.
+export function laneHashes(ref = 'HEAD', {cwd = REPO_ROOT} = {}) {
+  const listed = capture('git', ['ls-tree', '-r', ref, '--format=%(objectname) %(path)'], {cwd});
+  if (listed.status !== 0) die(`git ls-tree ${ref} failed: ${listed.stderr.trim() || listed.error?.message}`);
+  const entries = listed.stdout
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const at = line.indexOf(' ');
+      return {objectname: line.slice(0, at), path: line.slice(at + 1)};
+    });
+  const unknown = unclassified(entries.map((entry) => entry.path));
+  const unknownSet = new Set(unknown);
+  const hashes = {};
+  for (const [name, lane] of Object.entries(LANES)) {
+    const digest = createHash('sha256');
+    for (const entry of entries) {
+      if (matches(entry.path, lane.paths) || unknownSet.has(entry.path)) digest.update(`${entry.objectname} ${entry.path}\n`);
+    }
+    hashes[name] = digest.digest('hex').slice(0, 32);
+  }
+  return {hashes, unknown};
+}
+
+// The cache key a lane's job writes once it passes, and the same key this reads
+// back to decide. Nothing is ever stored UNDER it: the key existing IS the claim
+// that this content passed, which is why a marker proven on another branch counts.
+export const greenKey = (lane, hash) => `mion-lane-green-${lane}-${hash}`;
+
+// Decide the asked-for lanes. Every unknown resolves to RUN: an unreadable or
+// empty key list (a fork pull request has no token) skips nothing.
+export function decide(wanted, {hashes, greenKeys = []}) {
+  const green = new Set(greenKeys);
+  const lanes = {};
+  for (const name of wanted) {
+    const hash = hashes[name];
+    if (!hash) die(`no such lane: ${name} (known lanes: ${Object.keys(LANES).join(', ')})`);
+    const run = !green.has(greenKey(name, hash));
+    lanes[name] = {run, hash, reason: run ? 'inputs not proven green yet' : 'these exact inputs already passed'};
+  }
+  return lanes;
+}
+
+const flagValues = (args, flag) => {
+  const at = args.indexOf(flag);
+  if (at === -1) return [];
+  const rest = args.slice(at + 1);
+  const end = rest.findIndex((arg) => arg.startsWith('--'));
+  return end === -1 ? rest : rest.slice(0, end);
+};
+
+export function main(args) {
+  const ref = flagValues(args, '--ref')[0] ?? 'HEAD';
+  const {hashes, unknown} = laneHashes(ref);
+  if (unknown.length > 0) note(`${unknown.length} path(s) match no lane, so every lane hashes them: ${unknown.slice(0, 5).join(', ')}${unknown.length > 5 ? ' …' : ''}`);
+
+  const wanted = flagValues(args, '--decide');
+  if (wanted.length === 0) {
+    note(`lane inputs at ${ref}:`);
+    for (const [name, lane] of Object.entries(LANES)) console.log(`  ${name.padEnd(9)} ${hashes[name]}  ${lane.job}`);
+    return;
+  }
+
+  const keyFile = flagValues(args, '--green-keys')[0];
+  let greenKeys = [];
+  try {
+    if (keyFile) greenKeys = readFileSync(keyFile, 'utf8').split('\n').filter(Boolean);
+  } catch {
+    note(`could not read ${keyFile}, so every lane runs`);
+  }
+  const lanes = decide(wanted, {hashes, greenKeys});
+  for (const [name, lane] of Object.entries(lanes)) note(`${name.padEnd(9)} ${lane.run ? 'RUN ' : 'skip'}  ${lane.reason}`);
+  if (!args.includes('--github')) return console.log(JSON.stringify(lanes, null, 2));
+
+  appendFileSync(process.env.GITHUB_OUTPUT, `lanes=${JSON.stringify(lanes)}\n`);
+  const rows = Object.entries(lanes).map(([name, lane]) => `| ${name} | ${lane.run ? '**run**' : 'skip'} | ${lane.reason} | \`${lane.hash}\` |`);
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, ['### CI lanes', '', '| lane | | why | inputs |', '| --- | --- | --- | --- |', ...rows, ''].join('\n'));
+}
+
+if (import.meta.main) {
+  try {
+    main(process.argv.slice(2));
+  } catch (err) {
+    reportCliError(err);
+  }
+}

--- a/scripts/lib/devx-registry.mjs
+++ b/scripts/lib/devx-registry.mjs
@@ -70,6 +70,18 @@ export const AREAS = {
       },
       {name: 'smoke', summary: 'end-to-end smoke of the resolver + devtools'},
       {
+        name: 'lanes',
+        args: '[lane…]',
+        summary: 'which CI lanes this tree needs: one hash per lane over the paths that feed it',
+        flags: [
+          ['--decide <lane…>', 'decide those lanes and print the verdict as JSON'],
+          ['--green-keys <file>', 'the marker keys already recorded green (CI passes the cache listing)'],
+          ['--github', 'also write the verdict to $GITHUB_OUTPUT and a table to $GITHUB_STEP_SUMMARY'],
+          ['--ref <ref>', 'hash that tree instead of HEAD'],
+        ],
+        ...noBuild,
+      },
+      {
         name: 'test-batches',
         summary: 'the batched whole vitest suite (what test:ci runs)',
         flags: [

--- a/scripts/miondevx.mjs
+++ b/scripts/miondevx.mjs
@@ -301,6 +301,9 @@ function runCore(args) {
   // the read-only CI gate (ci.yml), and the run itself refuses to start on drift.
   // --check / --list are pure file reads: the registry row keeps them build-free.
   if (sub === 'test-batches') return proxy('node', ['scripts/core/test-batches.mjs', ...rest]);
+  // Which CI lanes this tree's content needs, and why. A pure git read, so the
+  // registry row keeps it build-free; CI runs the same script from ./.github/actions/ci-lanes.
+  if (sub === 'lanes') return proxy('node', ['scripts/ci/lanes.mjs', ...rest]);
   // The drizzle proxy manifest gate: regenerates the per-dialect manifests, driven by the
   // hand-owned drizzle-dialects.json at the repo root (the required --config), from
   // drizzle-orm's d.ts via the embedded checker; --check is the read-only CI gate


### PR DESCRIPTION
Replaces the old `dorny/paths-filter` diff-based gate with a content-based system that hashes the exact inputs each CI lane needs, then skips the lane if that hash already passed. This fixes the core problem: one touched file under `packages/` would pin the filter true for the entire branch lifetime, so a later docs-only commit would re-run ~33 runner minutes for nothing.

## Key changes

- **New lane system** (`scripts/ci/lanes.mjs`): Declares which paths feed each lane, hashes only those paths in the tree being tested, and decides whether to run based on cached green markers. Fail-safe in every direction: unknown paths run everything, cache misses run the lane, only successful jobs write markers.

- **Gate action** (`.github/actions/ci-lanes/`): Reads the lane table, computes hashes for the requested lanes, queries the Actions cache for green markers at those hashes, and outputs a JSON verdict. Runs in the always-on `lanes` job so docs-only commits never spin up a heavy runner.

- **Save action** (`.github/actions/save-lane-green/`): Records a lane as green by writing a cache marker under its hash, but only when the job succeeded. Placed as the last step of each lane's job so a failed or cancelled run never claims a marker.

- **Whole-tree sweeps** (`scripts/ci/check-tree.mjs`): Moved three hygiene checks (spec references, old repo URLs, NUL bytes) from the vitest suite into the always-on gate job. They read `docs/`, `.claude/`, and root prose files — exactly the paths every lane deliberately ignores — so a sweep gated on lane inputs would miss the edits it exists to catch.

- **Workflow updates**: All three workflows (`ci.yml`, `pr-heavy.yml`, `drizzle-e2e.yml`) now declare a `lanes` job and gate their heavy jobs on the verdict. The `go` and `js-fuzz` lanes split the two halves of the go-fuzz job so each owns its own marker. Labels on `pr-heavy.yml` and `drizzle-e2e.yml` now work with content gates, not against them: a labelled PR re-runs only when inputs actually changed.

- **Contract tests** (`packages/devtools/test/ci-lane-contracts.test.ts`): Pins the three halves to each other: the lane table, the `if:` conditions that consult it, and the save steps that write markers. Catches silent failures like a lane gated on a marker some other job writes, or saved by a job that was skipped.

## Implementation notes

- On a pull request the checked-out tree is the MERGE ref, so a lane's hash covers the base branch too: main moving changes the hash and the lane re-runs, which a "diff since the last green commit" rule would have missed.
- The gate job runs no bootstrap and no install (just git + node), so a docs-only commit costs a checkout, not an install.
- Markers are content-based, not ref-based: one proven on any branch counts, so a lane another branch already proved at the same hash skips immediately.

https://claude.ai/code/session_01L7VYhqenmXVLinUH6jedoA