### PR TITLE
fix(platform-uws): drain the body of a request that failed on arrival

### DIFF
--- a/docs/done/uws-no-op-body-drain-does-nothing.md
+++ b/docs/done/uws-no-op-body-drain-does-nothing.md
@@ -1,0 +1,141 @@
+---
+type: fix
+spec: guidelines
+status: done
+created: 2026-09-13
+---
+
+# The uws no-op body drain looks like dead weight, and its comment may be wrong
+
+## Intent
+
+`packages/platform-uws/src/uwsHttp.ts` registers a no-op reader before dispatching a not-found
+request, and says why:
+
+```ts
+// A not-found chain has no route to feed: the body is consumed
+// as it arrives and dropped (a no-op reader keeps the connection reusable), never assembled.
+if (!resolved.readsBody) {
+  res.onData(() => {});
+  dispatchBody('', false);
+  return;
+}
+```
+
+A keep-alive probe cannot find any behaviour the line is responsible for. Either it is dead weight
+and should go along with the half of the comment that justifies it, or it is load-bearing for a
+reason the comment does not name and the comment should say the real one. Both outcomes are fine;
+what is not fine is leaving a line whose stated reason nobody can reproduce.
+
+Settle it, then make the code and the comment agree.
+
+## Evidence
+
+A probe over node's own keep-alive agent, which handles the HTTP protocol correctly (a hand-rolled
+raw-socket probe does NOT work here: it fails to get a second response even for a plain 200, so it
+cannot measure reuse at all and will mislead you).
+
+```ts
+// one request over a keep-alive agent, then a second on the same agent; the socket is tagged on
+// the 'socket' event so a REUSED connection shows the same id both times
+const agent = new Agent({keepAlive: true, maxSockets: 1});
+const first = await call(agent, path, body);
+const second = await call(agent, '/api/echo', '{"echo":[7]}');
+const reused = first.socket === second.socket;
+```
+
+Every case, with the line present and with it deleted:
+
+| case | first | second | same socket |
+| --- | --- | --- | --- |
+| control, a normal echo | 200 | 200 | yes |
+| not-found, small body | 404 | 200 | yes |
+| not-found, 300 KB body | 404 | 200 | yes |
+| throwing pathTransform, small body | 500 | 200 | yes |
+| throwing pathTransform, 300 KB body | 500 | 200 | yes |
+
+The throwing `pathTransform` rows matter because that branch has never had the drain, so it is the
+natural control for what its absence costs. It costs nothing measurable.
+
+## Direction
+
+The implementer plans the details. Worth knowing before starting:
+
+- The probe above is the tool. Rebuild it rather than trusting a raw-socket version.
+- 300 KB was the largest body tried. A body big enough to span many socket reads, a slow client that
+  trickles the body, and a client that never finishes sending are the cases not yet covered, and are
+  the most likely place for a real difference to show.
+- uWS frees the response object on abort (`res.onAborted`), so a case where the client disconnects
+  mid-body is worth including.
+- If the line IS load-bearing, the same reasoning probably applies to the `pathTransform` catch a few
+  lines above, which has no drain: that one would then be a real bug, with the probe to prove it.
+- If it is NOT, delete the line and the clause that justifies it, and check whether
+  `packages/platform-uws/src/security.spec.ts` still says anything untrue about draining.
+
+## Done when
+
+The line is either gone or kept with a comment naming a reason a test can demonstrate, and that test
+exists.
+
+## Outcome — the line is load-bearing (shipped 2026-09-13)
+
+Settled: the drain stays, the comment was wrong about why, and the `pathTransform` catch was missing
+the same drain.
+
+### Why the keep-alive probe found nothing
+
+uWS drops the body either way. The drain is not what discards it. In `HttpContext.h` the whole
+body-data block is guarded by `if (httpResponseData->inStream)`, and the only thing inside that
+block that matters here is the socket timeout: uWS refreshes a socket's idle timeout (10s) **only**
+from inside a body-data callback, and runs that callback only when a data handler is registered.
+
+So a body short enough to arrive inside one idle timeout behaves identically with and without the
+line, which is every case the original probe measured. A body that takes **longer than the idle
+timeout** to finish arriving is the case that differs: with no reader the socket is closed
+mid-upload, even though the response already went out.
+
+### The measurements that settled it
+
+The probe from the Evidence section, extended with a raw socket that paces the body (`fetch` and
+node's `Agent` cannot trickle). 6 MB announced, sent at 320 KB/s (~19s), same server both runs:
+
+| case | drain registered | bytes accepted | server closed the socket |
+| --- | --- | --- | --- |
+| unknown path (404) | yes | 6,000,000 / 6,000,000 | no |
+| unknown path (404) | line deleted | 3,866,624 / 6,000,000 | yes, at 11.9s |
+| known route (200/413) | by `collectBody` | 6,000,000 / 6,000,000 | no |
+| client announces a body, sends nothing | either way | 0 | yes, at ~12s (unchanged) |
+
+The known-route row is the control: `collectBody` registers its own `onDataV2`, so that path already
+had the refresh. The never-sends row shows the drain does not keep a dead client alive.
+
+The prediction in Direction held. The `resolveRequest` catch had the same shape and no drain, so a
+throwing `pathTransform` hit the bug for real: 500 answered, then the socket killed at 12.0s with
+3,866,624 of 6,000,000 bytes accepted. With the drain added there: 6,000,000 accepted, never closed.
+
+A client that disconnects mid-body is unaffected, the server keeps serving.
+
+### What shipped
+
+`packages/platform-uws/src/uwsHttp.ts`
+
+- One `drainRequestBody(res)` helper carrying the real reason, replacing the inline `res.onData(() =>
+  {})` and the "keeps the connection reusable" clause.
+- The same call added to the `resolveRequest` catch, which never had it.
+- The block comment describing `uwsRequestHandler` moved onto that function; it had drifted up above
+  `toRpcError`.
+
+`packages/platform-uws/src/bodyDrain.spec.ts` (new)
+
+- A raw socket announces a 3 MB `Content-Length` and trickles 20 KB every 100ms (200 KB/s, ~15s,
+  past the 10s idle timeout), once for an unknown path and once for a throwing `pathTransform`, both
+  concurrently so they share the wall clock. It asserts every announced byte was accepted and the
+  server never hung up. Without the drain it fails at ~2.4 MB of 3 MB.
+- Its own file rather than an addition to `security.spec.ts`: the router needs a throwing
+  `pathTransform`, and a router can only be created once per module.
+
+`security.spec.ts` needed no correction. Its "a large body on the same kept-alive connection is
+drained, never assembled" is accurate.
+
+No docs changed: nothing on the website mentions body draining, keep-alive or timeouts, and a uWS
+idle-timeout detail is not a knob a consumer sets.

--- a/packages/platform-uws/src/bodyDrain.spec.ts
+++ b/packages/platform-uws/src/bodyDrain.spec.ts
@@ -1,0 +1,105 @@
+/* ########
+ * 2026 mion
+ * Author: Ma-jerez
+ * License: MIT
+ * The software is provided "as is", without warranty of any kind.
+ * ######## */
+
+// A request that failed on arrival is answered before its body has finished coming in, and uWS
+// refreshes the socket's idle timeout only while a body-data callback is registered. Without the
+// drain the adapter registers, an upload slower than that timeout is cut off mid-flight: measured
+// at ~3.9 MB of 6 MB before the socket died at 12s. `fetch` cannot pace a body this slowly, so
+// these ride a raw socket. Its own file: the router carries a throwing pathTransform, and a router
+// is created once per module.
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {createMionRouter, resetRouter} from '@mionjs/router';
+import type {CallContext} from '@mionjs/router';
+import {StatusCodes} from '@mionjs/core';
+import {resetUwsHttpOpts, setUwsHttpOpts, startUwsServer, type UwsServer} from './uwsHttp.ts';
+import {connect} from 'net';
+
+const port = 8293;
+const uploadBytes = 3_000_000;
+const chunkBytes = 20_000;
+const chunkEveryMs = 100; // 200 KB/s: ~15s of upload, past uWS' 10s idle timeout
+
+const mion = createMionRouter({
+  contextDataFactory: () => ({user: null}),
+  basePath: 'api/',
+  pathTransform: (request, path: string): string => {
+    if (path.includes('boom')) throw new Error('pathTransform exploded');
+    return path;
+  },
+});
+
+type SimpleUser = {name: string; surname: string};
+const echo = mion.route((ctx: CallContext, user: SimpleUser): SimpleUser => user);
+
+/** Trickles a body the server has already answered, and reports whether the server hung up on it. */
+function trickleUpload(path: string) {
+  return new Promise<{statusCode: number | null; sentBytes: number; serverHungUp: boolean}>((resolve, reject) => {
+    const socket = connect(port, '127.0.0.1');
+    const chunk = Buffer.alloc(chunkBytes, 0x78);
+    let sentBytes = 0;
+    let statusCode: number | null = null;
+    let ticker: NodeJS.Timeout;
+    socket.on('connect', () => {
+      socket.write(`POST ${path} HTTP/1.1\r\nHost: x\r\nContent-Length: ${uploadBytes}\r\n\r\n`);
+      ticker = setInterval(() => {
+        if (socket.destroyed || sentBytes >= uploadBytes) return;
+        socket.write(chunk.subarray(0, Math.min(chunkBytes, uploadBytes - sentBytes)));
+        sentBytes = Math.min(sentBytes + chunkBytes, uploadBytes);
+        if (sentBytes < uploadBytes) return;
+        // every byte accepted: settle after a short grace rather than waiting for a close that
+        // should never come
+        clearInterval(ticker);
+        setTimeout(() => {
+          const serverHungUp = socket.destroyed;
+          socket.destroy();
+          resolve({statusCode, sentBytes, serverHungUp});
+        }, 200);
+      }, chunkEveryMs);
+    });
+    socket.on('data', (data) => {
+      const status = /HTTP\/1\.1 (\d+)/.exec(data.toString('latin1'));
+      if (status && statusCode === null) statusCode = Number(status[1]);
+    });
+    socket.on('close', () => {
+      clearInterval(ticker);
+      if (sentBytes < uploadBytes) resolve({statusCode, sentBytes, serverHungUp: true});
+    });
+    socket.on('error', (error) => {
+      clearInterval(ticker);
+      if (sentBytes < uploadBytes) resolve({statusCode, sentBytes, serverHungUp: true});
+      else reject(error);
+    });
+  });
+}
+
+describe('uws adapter: a request answered before its body arrived still drains it', () => {
+  let server: UwsServer;
+
+  beforeAll(async () => {
+    resetUwsHttpOpts();
+    resetRouter();
+    mion.initRoutes({echo});
+    setUwsHttpOpts({port});
+    server = await startUwsServer();
+  });
+
+  afterAll(() => server.close());
+
+  it('accepts the whole slow upload for an unknown path and for a throwing pathTransform', async () => {
+    // both uploads share the same ~15s of wall clock
+    const [notFound, transformThrew] = await Promise.all([trickleUpload('/api/nope'), trickleUpload('/api/boom')]);
+
+    expect(notFound.statusCode).toBe(StatusCodes.NOT_FOUND);
+    expect(notFound.sentBytes).toBe(uploadBytes);
+    expect(notFound.serverHungUp).toBe(false);
+
+    expect(transformThrew.statusCode).toBe(StatusCodes.SERVER_ERROR);
+    expect(transformThrew.sentBytes).toBe(uploadBytes);
+    expect(transformThrew.serverHungUp).toBe(false);
+  }, 40_000);
+});

--- a/packages/platform-uws/src/uwsHttp.ts
+++ b/packages/platform-uws/src/uwsHttp.ts
@@ -124,10 +124,14 @@ export async function startUwsServer(options?: Partial<UwsHttpOptions>): Promise
 
 // ############# PRIVATE METHODS #############
 
-// exported for tests and for mounting on a hand-built uWS app; NOT a middleware handler (see
-// setUwsHttpOpts). uWS contract: `req` is only valid synchronously inside this call, so everything
-// the async dispatch needs is snapshotted before the first await; `res` stays valid until the
-// response ends or onAborted fires.
+// uWS refreshes a socket's idle timeout only from inside a body-data callback, and runs that
+// callback only when a data handler is registered. A request answered before its body finished
+// arriving still has that body coming: with no reader the socket is closed mid-upload once the idle
+// timeout elapses, so register a reader that drops every chunk.
+function drainRequestBody(res: HttpResponse) {
+  res.onData(() => {});
+}
+
 function toRpcError(e: unknown): RpcError<string> {
   return e instanceof RpcError
     ? e
@@ -138,6 +142,10 @@ function toRpcError(e: unknown): RpcError<string> {
       });
 }
 
+// exported for tests and for mounting on a hand-built uWS app; NOT a middleware handler (see
+// setUwsHttpOpts). uWS contract: `req` is only valid synchronously inside this call, so everything
+// the async dispatch needs is snapshotted before the first await; `res` stays valid until the
+// response ends or onAborted fires.
 export function uwsRequestHandler(res: HttpResponse, req: HttpRequest): void {
   const state = {replied: false, aborted: false};
   // Everything read from `req` happens HERE, synchronously.
@@ -165,6 +173,7 @@ export function uwsRequestHandler(res: HttpResponse, req: HttpRequest): void {
   try {
     resolved = resolveRequest(path, urlQuery, rawRequest);
   } catch (e) {
+    drainRequestBody(res);
     state.replied = true;
     fatalFail(res, state, respHeaders, toRpcError(e));
     return;
@@ -205,9 +214,9 @@ export function uwsRequestHandler(res: HttpResponse, req: HttpRequest): void {
   // maxSize, which is exactly the maxBodySize contract. The size is the route's own resolved limit
   // (the adapter's option for a route whose types could not say).
   // A not-found chain (an unknown path or batch id) has no route to feed: the body is consumed
-  // as it arrives and dropped (a no-op reader keeps the connection reusable), never assembled.
+  // as it arrives and dropped, never assembled.
   if (!resolved.readsBody) {
-    res.onData(() => {});
+    drainRequestBody(res);
     dispatchBody('', false);
     return;
   }


### PR DESCRIPTION
Settles the `docs/todos/uws-no-op-body-drain-does-nothing.md` question: is the no-op reader in `uwsHttp.ts` dead weight?

It is not. And the branch next to it was missing the same reader, which was a real bug.

## Why the earlier probe found nothing

uWS drops the body either way, so the reader is not what discards it. The reader matters for one thing: uWS refreshes a socket's idle timeout (10s) **only** from inside its body-data callback, and runs that callback only when a data handler is registered (`HttpContext.h` guards the whole block with `if (httpResponseData->inStream)`).

So a body short enough to arrive inside one idle timeout behaves identically with and without the line, which is every case the original probe measured. A body that takes **longer** than the idle timeout to finish arriving is the case that differs: with no reader the socket is closed mid-upload, even though the response already went out.

## Measurements

Raw socket (`fetch` and node's `Agent` cannot pace a body this slowly), 6 MB announced, sent at 320 KB/s (~19s), same server both runs:

| case | reader registered | bytes accepted | server hung up |
| --- | --- | --- | --- |
| unknown path (404) | yes | 6,000,000 / 6,000,000 | no |
| unknown path (404) | line deleted | 3,866,624 / 6,000,000 | yes, at 11.9s |
| known route (200/413) | by `collectBody` | 6,000,000 / 6,000,000 | no |
| client announces a body, sends nothing | either way | 0 | yes, at ~12s (unchanged) |

The known-route row is the control: `collectBody` registers its own `onDataV2`, so that path already had the refresh. The never-sends row shows the reader does not keep a dead client alive.

The todo predicted the `resolveRequest` catch a few lines above would have the same problem, and it did: a throwing `pathTransform` answered 500, then the socket died at 12.0s with 3,866,624 of 6,000,000 bytes accepted. With the reader added there, all 6,000,000 land and the socket stays open.

## Changes

`packages/platform-uws/src/uwsHttp.ts`

- One `drainRequestBody(res)` helper carrying the real reason, replacing the inline `res.onData(() => {})` and its "keeps the connection reusable" clause.
- The same call added to the `resolveRequest` catch, which never had it.
- The block comment describing `uwsRequestHandler` moved back onto that function; it had drifted above `toRpcError`.

`packages/platform-uws/src/bodyDrain.spec.ts` (new)

- A raw socket announces a 3 MB `Content-Length` and trickles 20 KB every 100ms (200 KB/s, ~15s, past the 10s idle timeout), once for an unknown path and once for a throwing `pathTransform`, both concurrently so they share the wall clock. Asserts every announced byte was accepted and the server never hung up. Without the fix it fails at ~2.4 MB of 3 MB.
- Its own file rather than an addition to `security.spec.ts`: the router needs a throwing `pathTransform`, and a router can only be created once per module.

`security.spec.ts` needed no correction, its "a large body on the same kept-alive connection is drained, never assembled" is accurate.

The spec moved to `docs/done/` with the findings and measurements written into it.

## Notes

No docs changed: nothing on the website mentions body draining, keep-alive or timeouts, and a uWS idle-timeout detail is not a knob a consumer sets.

No heavy CI label applies. No package exports, website, benchmark or drizzle files change.

This is meant to merge **before** #276, which changes how an already-failed request is dispatched in the same handler but does not touch these lines.

## Gate

- `pnpm run test:ci`: 482 test files, all 23 projects, green.
- `pnpm run lint` and `pnpm run format`: clean.
- No Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQC3T85w7qfaVvykJS2vCM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQC3T85w7qfaVvykJS2vCM)_